### PR TITLE
Fittestbits/demo fixes2 - three small bug fixes

### DIFF
--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -183,8 +183,8 @@ the TAB-LAYOUT implementation and specialized by its subclasses."))
     ;; add new pages:
     (dolist (page add)
       (setf (tab-page-tab-layout page) parent)
-      (setf (sheet-enabled-p (tab-page-pane page)) nil)
-      (sheet-adopt-child parent (tab-page-pane page)))
+      (sheet-adopt-child parent (tab-page-pane page))
+      (setf (sheet-enabled-p (tab-page-pane page)) nil))
     ;; ensure that at least one page is enabled
     (when (null (tab-layout-enabled-page parent))
       (setf (tab-layout-enabled-page parent) (car (tab-layout-pages parent))))))

--- a/Extensions/render/backend/fonts.lisp
+++ b/Extensions/render/backend/fonts.lisp
@@ -1,7 +1,7 @@
 (in-package :mcclim-render-internals)
 
 ;;;
-;;; Font utilities. 
+;;; Font utilities.
 ;;;
 
 (defstruct (glyph-info (:constructor glyph-info (id width height left right top dx dy paths opacity-image)))
@@ -24,7 +24,7 @@
     (let ((right (+ left width))
 	  (opacity-image (font-generate-opacity-image paths width height left top)))
       (glyph-info 0 dx dy left right top dx dy paths opacity-image))))
-    
+
 (defun font-glyph-info (font character)
   (with-slots (char->glyph-info) font
     (ensure-gethash character char->glyph-info
@@ -73,7 +73,7 @@
 
 (declaim (inline gcache-get))
 
-(defun gcache-get (cache key-number)  
+(defun gcache-get (cache key-number)
   (declare (optimize (speed 3))
            (type (simple-array t (512))))
   (let ((hash (logand (the fixnum key-number) #xFF)))   ; hello.
@@ -111,7 +111,7 @@
                                         &key (start 0) (end (length string)) translate)
   ;; -> (width ascent descent left right
   ;; font-ascent font-descent direction
-  ;; first-not-done)  
+  ;; first-not-done)
   (declare ;;(optimize (speed 3))
            (ignore translate))
   (let ((width
@@ -124,15 +124,16 @@
                           as char = (aref string i)
                           as code = (char-code char)
                           sum (or (gcache-get width-cache code)
-                                  (gcache-set width-cache code (font-glyph-width font char)))
+                                  (gcache-set width-cache code (max (font-glyph-right font char)
+                                                                    (font-glyph-width font char))))
                             #+NIL (clim-clx::font-glyph-width font char))))
            (if (numberp (slot-value font 'fixed-width))
                (* (slot-value font 'fixed-width) (- end start))
-               (typecase string 
-                 (simple-string 
+               (typecase string
+                 (simple-string
                   (locally (declare (type simple-string string))
                     (compute)))
-                 (string 
+                 (string
                   (locally (declare (type string string))
                     (compute)))
                  (t (compute)))))))
@@ -257,4 +258,3 @@
                       ;; * (min 0 left), (max width right)
                       ;; * font-ascent / ascent
                       (values left (- font-ascent) right font-descent)))))))))
-

--- a/Extensions/render/backend/port.lisp
+++ b/Extensions/render/backend/port.lisp
@@ -81,7 +81,7 @@
       (font-families     (make-hash-table :test #'equal))
       (font-faces        (make-hash-table :test #'equal))
       (font-cache        (make-hash-table :test #'equal))
-      (text-style-cache  (make-hash-table :test #'eql)))
+      (text-style-cache  (make-hash-table :test #'equal)))
   (defun make-truetype-font (port filename size)
     (climi::with-lock-held (*zpb-font-lock*)
       (let* ((loader (ensure-gethash filename font-loader-cache


### PR DESCRIPTION
Bugs found running demodemo: add new page to tab-layout caused error; truetype font cache failed and caused error; and, text width calculation didn't match text drawing code.

More details in commit log messages.