### PR TITLE
A few minor fixes

### DIFF
--- a/Apps/Debugger/clim-debugger.lisp
+++ b/Apps/Debugger/clim-debugger.lisp
@@ -30,8 +30,8 @@
 ;;; - Frames could be navigable with arrow keys as well. How to do that?
 ;;;
 
-(defpackage "CLIM-DEBUGGER"
-  (:use  "CL-USER" "CLIM" "CLIM-LISP")
+(defpackage #:clim-debugger
+  (:use #:clim #:clim-lisp #:clim-extensions)
   (:export #:debugger #:with-debugger #:install-debugger))
 
 (in-package :clim-debugger)

--- a/Apps/Inspector/inspector.lisp
+++ b/Apps/Inspector/inspector.lisp
@@ -573,13 +573,13 @@ use implementation-specific functions to be more informative."
 	(princ "Nicknames:" pane)
       (inspect-vertical-list (package-nicknames object) pane))
     (inspector-table-row (pane)
-	(princ "Used by:")
+	(princ "Used by:" pane)
       (inspect-vertical-list (package-used-by-list object) pane))
     (inspector-table-row (pane)
-	(princ "Uses:")
+	(princ "Uses:" pane)
       (inspect-vertical-list (package-use-list object) pane))
     (inspector-table-row (pane)
-	(princ "Exports:")
+	(princ "Exports:" pane)
       (inspect-vertical-list (package-exported-symbols object) pane))))
 
 (defmethod inspect-object ((object vector) pane)
@@ -598,12 +598,12 @@ use implementation-specific functions to be more informative."
 (defmethod inspect-object-briefly ((object string) pane)
   (with-output-as-presentation
       (pane object (presentation-type-of object))
-    (prin1 object)))
+    (prin1 object pane)))
 
 (defmethod inspect-object-briefly ((object number) pane)
   (with-output-as-presentation
       (pane object (presentation-type-of object))
-    (prin1 object)))
+    (prin1 object pane)))
 
 (defun inspect-complex (object pane)
   "Inspect a complex number. Since complex numbers should be inspected
@@ -694,7 +694,7 @@ an error if the given time is not a decodable universal time."
   (with-output-as-presentation
       (pane object (presentation-type-of object))
     (with-text-family (pane :fix)
-      (prin1 object))))
+      (prin1 object pane))))
 
 (defmethod inspect-object ((object symbol) pane)
   (inspector-table (object pane)

--- a/Examples/method-browser.lisp
+++ b/Examples/method-browser.lisp
@@ -77,24 +77,26 @@ specialized on, removing duplicates"
 ;; FIXME: returns nil if there is both an EQL specializer and a
 ;; class specializer for which no prototype instance is available.
 (defun compute-applicable-methods-from-specializers (gf specializers)
-  (if (every #'classp specializers)
+  (multiple-value-bind (applicable-methods validp)
       (c2mop:compute-applicable-methods-using-classes gf specializers)
-      (let ((instances
-             (mapcar (lambda (s)
-                       (cond ((classp s)
-                              ;; Implementation-dependent whether prototypes for
-                              ;; built-in classes (like integer, t) are available.
-                              (multiple-value-bind (prot err)
-                                  (ignore-errors (c2mop:class-prototype s))
-                                (if err 'no-prototype prot)))
-                             ((typep s 'c2mop:eql-specializer)
-                              (c2mop:eql-specializer-object s))
-                             (t
-                              (error "Can't compute effective methods, specializer ~A is not understood."
-                                     s))))
-                     specializers)))
-        (unless (member 'no-prototype instances)
-          (compute-applicable-methods gf instances)))))
+    (if validp
+        applicable-methods
+        (let ((instances
+               (mapcar (lambda (s)
+                         (cond ((classp s)
+                                ;; Implementation-dependent whether prototypes for
+                                ;; built-in classes (like integer, t) are available.
+                                (multiple-value-bind (prot err)
+                                    (ignore-errors (c2mop:class-prototype s))
+                                  (if err 'no-prototype prot)))
+                               ((typep s 'c2mop:eql-specializer)
+                                (c2mop:eql-specializer-object s))
+                               (t
+                                (error "Can't compute effective methods, specializer ~A is not understood."
+                                       s))))
+                       specializers)))
+          (unless (member 'no-prototype instances)
+            (compute-applicable-methods gf instances))))))
 
 ;; FIXME: Support EQL specializers.
 ;; This is hard to do ideally, and I'm not really trying.

--- a/Examples/method-browser.lisp
+++ b/Examples/method-browser.lisp
@@ -324,7 +324,7 @@ available for that argument."
     (let* ((gf (gf frame))
            (methods (compute-applicable-methods-from-specializers gf (arg-types frame)))
            (combination (c2mop:generic-function-method-combination gf))
-           (effective-methods (c2mop:compute-effective-method gf combination methods))
+           (effective-methods (ignore-errors (c2mop:compute-effective-method gf combination methods)))
            (serial-methods (walk-em-form effective-methods)))
       ;; Print the header
       (fresh-line)

--- a/Extensions/render/image-fast-ops.lisp
+++ b/Extensions/render/image-fast-ops.lisp
@@ -89,8 +89,8 @@
      (let ((,src-fn (pixeled-rgba-fn ,design)))
        (declare (type pixeled-design-fn ,src-fn)
                 (ignorable ,src-fn))
-       (loop for ,j-var from ,y to max-y do
-            (loop for ,i-var from ,x to max-x do
+       (loop for ,j-var fixnum from ,y to max-y do
+            (loop for ,i-var fixnum from ,x to max-x do
                  ,@code)))))
 
 (defmacro def-fast-fill-image-without-stencil (image-class set-code channels)
@@ -143,8 +143,8 @@
              (let ((max-y (+ y height -1))
                    (max-x (+ x width -1)))
                (declare (type fixnum max-x max-y))
-               (loop for j from y to max-y do
-                    (loop for i from x to max-x do
+               (loop for j fixnum from y to max-y do
+                    (loop for i fixnum from x to max-x do
                          (dst-fn i j red green blue a)))))))
        (make-rectangle* x y (+ x width) (+ y height)))))
 

--- a/Extensions/render/image-ops.lisp
+++ b/Extensions/render/image-ops.lisp
@@ -36,20 +36,20 @@
            (max-x (+ ,x ,width -1)))
        (declare (type fixnum max-x max-y))
        (flet ((copy-ff ()
-                (loop for ,j-var from y to max-y do
-                     (loop for ,i-var from x to max-x do
+                (loop for ,j-var fixnum from y to max-y do
+                     (loop for ,i-var fixnum from x to max-x do
                           ,@code)))
               (copy-bf ()
-                  (loop for ,j-var from y to max-y do
-                       (loop for ,i-var from max-x downto x do
+                  (loop for ,j-var fixnum from y to max-y do
+                       (loop for ,i-var fixnum from max-x downto x do
                             ,@code)))
               (copy-fb ()
-                  (loop for ,j-var from max-y downto y do
-                       (loop for ,i-var from x to max-x do
+                  (loop for ,j-var fixnum from max-y downto y do
+                       (loop for ,i-var fixnum from x to max-x do
                             ,@code)))
                 (copy-bb ()
-                  (loop for ,j-var from max-y downto y do
-                       (loop for ,i-var from max-x downto x do
+                  (loop for ,j-var fixnum from max-y downto y do
+                       (loop for ,i-var fixnum from max-x downto x do
                             ,@code))))
          (when (and (> ,width 0) (> ,height 0))
            (if (eq ,src-img ,dst-img)


### PR DESCRIPTION
The inspector was printing some inspected values to *standard-output* instead of the pane.
The method-browser demo has been made more robust.
Additional type declarations have been added to the opticl image function to improve performance.