### PR TITLE
Remove the inconsistency between :FIX and :FIXED

### DIFF
--- a/Backends/CLX/fonts.lisp
+++ b/Backends/CLX/fonts.lisp
@@ -99,9 +99,6 @@
                      size   (or size :normal)
                      size   (round (getf clim-clx::*clx-text-sizes* size size)))
 
-               (when (eq family :fixed)
-                 (setf family :fix))
-
                (when (zerop size)
                  (setf size (getf clim-clx::*clx-text-sizes* :normal)))
 

--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -1076,7 +1076,7 @@ time an indexed pattern is drawn.")
   (text-style-character-width text-style medium #\m))
 
 (defmethod text-style-fixed-width-p (text-style (medium clx-medium))
-  (eql (text-style-family text-style) :fixed))
+  (eql (text-style-family text-style) :fix))
 
 (eval-when (:compile-toplevel :execute)
   ;; ASCII / CHAR-CODE compatibility checking

--- a/Core/clim-basic/medium.lisp
+++ b/Core/clim-basic/medium.lisp
@@ -90,7 +90,7 @@
 (defun family-key (family)
   (ecase family
     ((nil) 0)
-    ((:fix :fixed) 1)
+    ((:fix) 1)
     ((:serif) 2)
     ((:sans-serif) 3)))
 

--- a/Examples/text-size-test.lisp
+++ b/Examples/text-size-test.lisp
@@ -29,7 +29,7 @@
    (text (make-pane 'text-editor :height 200 :value "ytmM"))
    (family
     (with-radio-box ()
-      (make-pane 'toggle-button :label "Fixed" :id :fixed)
+      (make-pane 'toggle-button :label "Fixed" :id :fix)
       (radio-box-current-selection
        (make-pane 'toggle-button :label "Serif" :id :serif))
       (make-pane 'toggle-button :label "Sans Serif" :id :sans-serif)))

--- a/Extensions/fonts/xrender-fonts.lisp
+++ b/Extensions/fonts/xrender-fonts.lisp
@@ -430,9 +430,6 @@ The following files should exist:~&~{  ~A~^~%~}"
                  size   (or size :normal)
                  size   (getf clim-clx::*clx-text-sizes* size size))
 
-           (when (eq family :fixed)
-             (setf family :fix))
-
            (find-and-make-truetype-font family face size))))
 
     (or (text-style-mapping port text-style)

--- a/Extensions/render/backend/port.lisp
+++ b/Extensions/render/backend/port.lisp
@@ -57,8 +57,6 @@
                  size   (or size :normal)
 		 size (getf *text-sizes* size size))
 
-           (when (eq family :fixed)
-             (setf family :fix))
            (find-and-make-truetype-font family face size))))
     (or (text-style-mapping port text-style)
         (setf (climi::text-style-mapping port text-style)


### PR DESCRIPTION
According to the spec, the keyword :FIX should be used to indicate a
fixed-width font. In various places in the code, the additional
keyword :FIXED was also allowed, and spacial cases were implemented to
transform that to :FIX.

However, this was not consistent, and specifically the implementation
of TEXT-STYLE-FIXED-WIDTH-P returned true only for the case where the
font was set to :FIXED.

This fix removes any reference to :FIXED, in order to make the API
consistent. One of the examples in clim-examples was also changed to
use :FIX instead of :FIXED.