### PR TITLE
fixes for #490 and #484

### DIFF
--- a/Core/clim-basic/repaint.lisp
+++ b/Core/clim-basic/repaint.lisp
@@ -201,17 +201,10 @@ want to do the same.")
                                                                                   (sheet-region sheet)))))))
     (let* ((parent (sheet-mirrored-ancestor sheet))
            (native-sheet-region (effective-repaint-region parent sheet region)))
-      (with-sheet-medium (medium parent)
-	(with-drawing-options (medium :clipping-region native-sheet-region
-				      :ink (medium-background medium)
-                                      #+jd-test(pane-background sheet)
-                                      #+jd-test(alexandria:random-elt
-                                                (list +darkmagenta+
-                                                      +darkblue+
-                                                      +darkgreen+
-                                                      +darkorange+
-                                                      +darkolivegreen+))
-				      :transformation +identity-transformation+)
-	  (with-bounding-rectangle* (left top right bottom)
-              native-sheet-region
-	    (medium-draw-rectangle* medium left top right bottom t)))))))
+	  (with-sheet-medium (medium parent)
+	    (with-drawing-options (medium :clipping-region native-sheet-region
+					  :ink (pane-background sheet)
+					  :transformation +identity-transformation+)
+	      (with-bounding-rectangle* (left top right bottom)
+		  native-sheet-region
+		(medium-draw-rectangle* medium left top right bottom t)))))))

--- a/Libraries/Drei/input-editor.lisp
+++ b/Libraries/Drei/input-editor.lisp
@@ -639,8 +639,9 @@ if stuff is inserted after the insertion pointer."
     (setf (activation-gesture stream) gesture)
     (rescan-if-necessary stream)
     (return-from stream-process-gesture gesture))
-  (let ((*original-stream* (encapsulating-stream-stream stream)))
-    (unread-gesture gesture :stream (encapsulating-stream-stream stream)))
+  (when (proper-gesture-p gesture)
+    (let ((*original-stream* (encapsulating-stream-stream stream)))
+      (unread-gesture gesture :stream (encapsulating-stream-stream stream))))
   (read-gestures-and-act stream gesture type))
 
 (defmethod reset-scan-pointer ((stream drei-input-editing-mixin)

--- a/Libraries/ESA/esa.lisp
+++ b/Libraries/ESA/esa.lisp
@@ -722,11 +722,13 @@ never refer to a command."))
   (process-gestures command-processor))
 
 (defun esa-read-gesture (&key (command-processor *command-processor*)
-                              (stream *standard-input*))
+                         (stream *standard-input*))
   (unless (null (remaining-keys command-processor))
     (return-from esa-read-gesture
       (pop (remaining-keys command-processor))))
-  (read-gesture :stream stream))
+  (loop for gesture = (read-gesture :stream stream)
+	until (proper-gesture-p gesture)
+	finally (return gesture)))
 
 (defun esa-unread-gesture (gesture &key (command-processor *command-processor*)
                            (stream *standard-input*))


### PR DESCRIPTION
* Revert the part of 9412163 , text-selection seems to work correctly without it. Fixes #484 
* Revert c9176a9 , it breaks ESA and copy-paste. Fixes #490 ,Re-opens #378.