### PR TITLE
Update harfbuzz.lisp

### DIFF
--- a/Extensions/harfbuzz/src/harfbuzz.lisp
+++ b/Extensions/harfbuzz/src/harfbuzz.lisp
@@ -1,6 +1,7 @@
 (in-package :mcclim-harfbuzz)
 
 (cffi:define-foreign-library libharfbuzz
+  (:darwin "libharfbuzz.dylib")                                                          
   (:unix "libharfbuzz.so"))
 
 (cffi:use-foreign-library libharfbuzz)


### PR DESCRIPTION
Added OS X foreign library name.

Does it make sense for the foreign library to be defined both in `functions.lisp` and `harfbuzz.lisp`?