### PR TITLE
Support pasting UTF-8 strings

### DIFF
--- a/Backends/CLX/text-selection.lisp
+++ b/Backends/CLX/text-selection.lisp
@@ -110,7 +110,7 @@
                                    :delete-p t
                                    :result-type '(vector (unsigned-byte 8))))
              (type (case (clim-clx::selection-event-target event)
-                     (:string :iso88519-1)
+                     (:string :iso-88519-1)
                      (:utf8_string :utf-8))))
         (when type
           (babel:octets-to-string v :encoding type)))))

--- a/Core/clim-basic/clim-basic.asd
+++ b/Core/clim-basic/clim-basic.asd
@@ -1,6 +1,12 @@
 
 (defsystem #:clim-basic
-  :depends-on (#:clim-lisp #:spatial-trees (:version "flexichain" "1.5.1") #:bordeaux-threads #:trivial-garbage #:trivial-features)
+  :depends-on (#:clim-lisp
+               #:spatial-trees
+               (:version "flexichain" "1.5.1")
+               #:bordeaux-threads
+               #:trivial-garbage
+               #:trivial-features
+               #:babel)
   :components
   ((:file "setf-star")
    (:file "decls" :depends-on ("setf-star"))


### PR DESCRIPTION
When shift-middle-clicking, request a UTF-8 string instead of a plain string from the owner of the selection.