### PR TITLE
Replace font

### DIFF
--- a/Backends/CLX/mcclim-clx.asd
+++ b/Backends/CLX/mcclim-clx.asd
@@ -1,6 +1,7 @@
 
 (defsystem #:mcclim-clx
-  :depends-on (#:mcclim-clx/basic
+  :depends-on (#:mcclim-fonts
+               #:mcclim-clx/basic
 	       #:mcclim-clx/input
 	       #:mcclim-clx/output
                #:mcclim-image/clx

--- a/Backends/CLX/package.lisp
+++ b/Backends/CLX/package.lisp
@@ -72,4 +72,5 @@
                 #:%sheet-mirror-transformation
 		#:standard-port)
   (:export
-   #:port-find-all-font-families))
+   #:port-find-all-font-families
+   #:find-replacement-fonts-from-renderer))

--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -374,7 +374,7 @@
 ;;; Should this method be defined in fonts.lisp?
 (defgeneric find-replacement-fonts-from-renderer (port font-renderer font string)
   (:method (port font-renderer font string)
-    (cons string '(nil nil))))
+    (list (cons string '(nil nil)))))
 
 ;;; This method can't be defined in fonts.lisp, since it relies on
 ;;; CLX-PORT which is only defined when this file is loaded.

--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -370,3 +370,13 @@
 
 (defmethod port-force-output ((port clx-port))
   (xlib:display-force-output (clx-port-display port)))
+
+;;; Should this method be defined in fonts.lisp?
+(defgeneric find-replacement-fonts-from-renderer (port font-renderer font string)
+  (:method (port font-renderer font string)
+    (cons string '(nil nil))))
+
+;;; This method can't be defined in ports.lisp, since it relies on
+;;; CLX-PORT which is only defined when this file is loaded.
+(defmethod mcclim-font:find-replacement-fonts-from-port ((port clim-clx::clx-port) text-style string)
+  (find-replacement-fonts-from-renderer port (clim-clx::clx-port-font-renderer port) text-style string))

--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -376,7 +376,7 @@
   (:method (port font-renderer font string)
     (cons string '(nil nil))))
 
-;;; This method can't be defined in ports.lisp, since it relies on
+;;; This method can't be defined in fonts.lisp, since it relies on
 ;;; CLX-PORT which is only defined when this file is loaded.
 (defmethod mcclim-font:find-replacement-fonts-from-port ((port clim-clx::clx-port) text-style string)
   (find-replacement-fonts-from-renderer port (clim-clx::clx-port-font-renderer port) text-style string))

--- a/Backends/CLX/text-selection.lisp
+++ b/Backends/CLX/text-selection.lisp
@@ -108,12 +108,10 @@
                                   (selection-event-property event)
                                   ;; :type :text
                                   :delete-p t
-                                  :result-type '(vector (unsigned-byte 8))))
-            (type (case (clim-clx::selection-event-target event)
-                    (:string :iso-88519-1)
-                    (:utf8_string :utf-8))))
-        (when type
-          (babel:octets-to-string v :encoding type)))))
+                                  :result-type '(vector (unsigned-byte 8)))))
+        (case (clim-clx::selection-event-target event)
+          (:string (babel:octets-to-string v :encoding :iso-88519-1))
+          (:utf8_string (babel:octets-to-string v :encoding :utf-8))))))
 
 ;; Incredibly crappy broken unportable Latin 1 encoder which should be
 ;; replaced by various implementation-specific versions.

--- a/Backends/CLX/text-selection.lisp
+++ b/Backends/CLX/text-selection.lisp
@@ -104,14 +104,14 @@
       (progn
         (format *trace-output* "~&;; Oops, selection-notify property is null. Trying the cut buffer instead..~%")
         (xlib:cut-buffer (clx-port-display port)))                
-      (let* ((v (xlib:get-property (sheet-xmirror (event-sheet event))
-                                   (selection-event-property event)
-                                   ;; :type :text
-                                   :delete-p t
-                                   :result-type '(vector (unsigned-byte 8))))
-             (type (case (clim-clx::selection-event-target event)
-                     (:string :iso-88519-1)
-                     (:utf8_string :utf-8))))
+      (let ((v (xlib:get-property (sheet-xmirror (event-sheet event))
+                                  (selection-event-property event)
+                                  ;; :type :text
+                                  :delete-p t
+                                  :result-type '(vector (unsigned-byte 8))))
+            (type (case (clim-clx::selection-event-target event)
+                    (:string :iso-88519-1)
+                    (:utf8_string :utf-8))))
         (when type
           (babel:octets-to-string v :encoding type)))))
 

--- a/Backends/CLX/text-selection.lisp
+++ b/Backends/CLX/text-selection.lisp
@@ -110,7 +110,7 @@
                                    :delete-p t
                                    :result-type '(vector (unsigned-byte 8))))
              (type (case (clim-clx::selection-event-target event)
-                     (:string :iso88519-1)
+                     (:string :iso-88519-1)
                      (:utf8_string :utf-8))))
         (when type
           (babel:octets-to-string v :encoding type)))))

--- a/Core/clim-basic/clim-basic.asd
+++ b/Core/clim-basic/clim-basic.asd
@@ -1,6 +1,12 @@
 
 (defsystem #:clim-basic
-  :depends-on (#:clim-lisp #:spatial-trees (:version "flexichain" "1.5.1") #:bordeaux-threads #:trivial-garbage #:trivial-features)
+  :depends-on (#:clim-lisp
+               #:spatial-trees
+               (:version "flexichain" "1.5.1")
+               #:bordeaux-threads
+               #:trivial-garbage
+               #:trivial-features
+               #:babel)
   :components
   ((:file "setf-star")
    (:file "decls" :depends-on ("setf-star"))

--- a/Extensions/fontconfig/src/fontconfig.lisp
+++ b/Extensions/fontconfig/src/fontconfig.lisp
@@ -319,7 +319,7 @@
 
 (deftype unicode-codepoint () '(integer 0 #.(* (expt 2 16) 17)))
 
-(defun charset-contains-p (charset char)
+(defun charset-contains-char-p (charset char)
   (let ((code (etypecase char
                 (integer char)
                 (character (char-code char)))))

--- a/Extensions/fontconfig/src/fontconfig.lisp
+++ b/Extensions/fontconfig/src/fontconfig.lisp
@@ -277,5 +277,4 @@
                  (multiple-value-bind (word index)
                      (truncate start 32)
                    (plusp (ldb (byte 1 index) (aref bitmap word)))))
-      until (< code bitmap-end))))
-
+      until (<= code bitmap-end))))

--- a/Extensions/fontconfig/src/functions.lisp
+++ b/Extensions/fontconfig/src/functions.lisp
@@ -130,3 +130,8 @@
 (cffi:defcfun ("FcStrListNext" fc-str-list-next) (:pointer fc-char8)
   (str-list :pointer))
 
+(cffi:defcfun ("FcFreeTypeQuery" fc-freetype-query) :pointer
+  (file :string)
+  (id :int)
+  (blanks :pointer)
+  (count (:pointer :int)))

--- a/Extensions/fontconfig/src/functions.lisp
+++ b/Extensions/fontconfig/src/functions.lisp
@@ -51,6 +51,10 @@
   (pattern :pointer)
   (object :string)
   (value fc-bool))
+(cffi:defcfun ("FcPatternAddCharSet" fc-pattern-add-char-set) fc-bool
+  (pattern :pointer)
+  (object :string)
+  (value :pointer))
 (cffi:defcfun ("FcPatternDestroy" fc-pattern-destroy) :void
   (pattern :pointer))
 (cffi:defcfun ("FcPatternPrint" fc-pattern-print) :void
@@ -89,6 +93,9 @@
 (cffi:defcfun ("FcCharSetCreate" fc-char-set-create) :pointer)
 (cffi:defcfun ("FcCharSetDestroy" fc-char-set-destroy) :void
   (char-set :pointer))
+(cffi:defcfun ("FcCharSetAddChar" fc-char-set-add-char) fc-bool
+  (char-set :pointer)
+  (ch fc-char32))
 (cffi:defcfun ("FcCharSetCount" fc-char-set-count) fc-char32
   (char-set :pointer))
 (cffi:defcfun ("FcCharSetFirstPage" fc-char-set-first-page) fc-char32

--- a/Extensions/fontconfig/src/functions.lisp
+++ b/Extensions/fontconfig/src/functions.lisp
@@ -77,6 +77,10 @@
   (num-sets :int)
   (pattern :pointer)
   (object-set :pointer))
+(cffi:defcfun ("FcFontRenderPrepare" fc-font-render-prepare) :pointer
+  (config :pointer)
+  (pattern :pointer)
+  (fonr :pointer))
 
 (cffi:defcfun ("FcObjectSetCreate" fc-object-set-create) :pointer)
 (cffi:defcfun ("FcObjectSetDestroy" fc-object-set-destroy) :void
@@ -125,3 +129,4 @@
   (str-list :pointer))
 (cffi:defcfun ("FcStrListNext" fc-str-list-next) (:pointer fc-char8)
   (str-list :pointer))
+

--- a/Extensions/fontconfig/src/functions.lisp
+++ b/Extensions/fontconfig/src/functions.lisp
@@ -80,7 +80,7 @@
 (cffi:defcfun ("FcFontRenderPrepare" fc-font-render-prepare) :pointer
   (config :pointer)
   (pattern :pointer)
-  (fonr :pointer))
+  (font :pointer))
 
 (cffi:defcfun ("FcObjectSetCreate" fc-object-set-create) :pointer)
 (cffi:defcfun ("FcObjectSetDestroy" fc-object-set-destroy) :void

--- a/Extensions/fontconfig/src/package.lisp
+++ b/Extensions/fontconfig/src/package.lisp
@@ -10,7 +10,7 @@
            #:list-font-dirs
            #:app-font-add-dir
            #:app-font-add-file
-           #:charset-contains-p
+           #:charset-contains-char-p
            #:font-render-prepare
            #:font-render-prepare-match
            #:query-freetype))

--- a/Extensions/fontconfig/src/package.lisp
+++ b/Extensions/fontconfig/src/package.lisp
@@ -9,4 +9,5 @@
            #:font-list
            #:list-font-dirs
            #:app-font-add-dir
-           #:app-font-add-file))
+           #:app-font-add-file
+           #:charset-contains-p))

--- a/Extensions/fontconfig/src/package.lisp
+++ b/Extensions/fontconfig/src/package.lisp
@@ -10,4 +10,5 @@
            #:list-font-dirs
            #:app-font-add-dir
            #:app-font-add-file
-           #:charset-contains-p))
+           #:charset-contains-p
+           #:font-render-prepare))

--- a/Extensions/fontconfig/src/package.lisp
+++ b/Extensions/fontconfig/src/package.lisp
@@ -11,4 +11,5 @@
            #:app-font-add-dir
            #:app-font-add-file
            #:charset-contains-p
-           #:font-render-prepare))
+           #:font-render-prepare
+           #:font-render-prepare-match))

--- a/Extensions/fontconfig/src/package.lisp
+++ b/Extensions/fontconfig/src/package.lisp
@@ -12,4 +12,5 @@
            #:app-font-add-file
            #:charset-contains-p
            #:font-render-prepare
-           #:font-render-prepare-match))
+           #:font-render-prepare-match
+           #:query-freetype))

--- a/Extensions/fonts/common.lisp
+++ b/Extensions/fonts/common.lisp
@@ -7,7 +7,7 @@
 
 (defgeneric find-replacement-fonts-from-port (port text-style string)
   (:method (port text-style string)
-    (cons string '(nil nil))))
+    (list (cons string '(nil nil)))))
 
 (defun find-replacement-text-styles (stream string &key text-style)
   "Find replacement fonts for characters in STRING if they were drawn on STREAM.

--- a/Extensions/fonts/common.lisp
+++ b/Extensions/fonts/common.lisp
@@ -1,0 +1,14 @@
+(defpackage :mcclim-font
+  (:use :cl)
+  (:export #:find-replacement-text-styles
+           #:find-replacement-fonts-from-port))
+
+(in-package :mcclim-font)
+
+(defgeneric find-replacement-fonts-from-port (port text-style string)
+  (:method (port text-style string)
+    (cons string '(nil nil))))
+
+(defun find-replacement-text-styles (stream string &key text-style)
+  (clim:with-sheet-medium (medium stream)
+    (find-replacement-fonts-from-port (clim:port medium) (or text-style (clim:medium-text-style stream)) string)))

--- a/Extensions/fonts/common.lisp
+++ b/Extensions/fonts/common.lisp
@@ -10,5 +10,29 @@
     (cons string '(nil nil))))
 
 (defun find-replacement-text-styles (stream string &key text-style)
+  "Find replacement fonts for characters in STRING if they were drawn on STREAM.
+Use TEXT-STYLE if non-NIL, or the current text style of the stream if
+NIL. This function returns a list of individual parts of the original
+string together with the appropriate text style to use. The returned
+valus is of the form:
+
+    (STRING FAMILY FACE)
+
+If FAMILY and FACE are NIL, this indicates that the base text style
+contains all the characters of the given string.
+
+Example: Assume that the text GREEK is written in greek, and the
+default font does not contain any greek characters, and this function
+is called as follows:
+
+  (find-replacement-text-styles \"abcGREEKdef\")
+
+The return value would then be:
+  ((\"abc\" nil nil)
+   (\"GREEK\" \"Greek Font Family\" \"Greek Font Style\")
+   (\"def\" nil nil))
+
+The second and third values of each element are appropriate for
+arguments to CLIM:MAKE-TEXT-STYLE."
   (clim:with-sheet-medium (medium stream)
     (find-replacement-fonts-from-port (clim:port medium) (or text-style (clim:medium-text-style stream)) string)))

--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -359,8 +359,8 @@ or NIL if the current transformation is the identity transformation."
                  with rx = 0
                  with ry = 0
                  for current-index in index-list
-                 do (let ((x-pos (+ x rx #+nil(glyph-entry-x-offset current-index)))
-                          (y-pos (+ y ry #+nil(glyph-entry-y-offset current-index))))
+                 do (let ((x-pos (+ x rx #+(or) (glyph-entry-x-offset current-index)))
+                          (y-pos (+ y ry #+(or) (glyph-entry-y-offset current-index))))
                       (setf (aref vec 0) (glyph-entry-codepoint current-index))
                       (multiple-value-bind (transformed-x transformed-y)
                           (clim:transform-position transformation x-pos y-pos)
@@ -407,7 +407,7 @@ or NIL if the current transformation is the identity transformation."
                       ;; then we should compute the similar value for the right side as
                       ;; well and it's not clear as to how to find that value.
                       0
-                      #+nil (- (glyph-attributes-x-origin (gethash (glyph-entry-codepoint (first index-list)) cached-glyphs)))
+                      #+(or) (- (glyph-attributes-x-origin (gethash (glyph-entry-codepoint (first index-list)) cached-glyphs)))
                       width
                       (freetype2:face-ascender-pixels face)
                       (freetype2:face-descender-pixels face)

--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -619,7 +619,7 @@ or NIL if the current transformation is the identity transformation."
             (t
              '(nil nil))))))
 
-(defun text-style-contains-p (port text-style ch)
+(defun text-style-contains-char-p (port text-style ch)
   (let* ((font (clim-clx::text-style-to-x-font port text-style))
          (charset (clim-freetype::freetype-font-face/charset (clim-freetype::freetype-font/face font))))
     (mcclim-fontconfig:charset-contains-char-p charset ch)))
@@ -631,7 +631,7 @@ or NIL if the current transformation is the identity transformation."
     for fallback in (text-style-fallback-fonts text-style)
     for fallback-family = (first fallback)
     for fallback-style = (second fallback)
-    when (text-style-contains-p port (clim:make-text-style fallback-family fallback-style 10) ch)
+    when (text-style-contains-char-p port (clim:make-text-style fallback-family fallback-style 10) ch)
       return fallback
     finally (return (find-best-font ch))))
 

--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -359,8 +359,8 @@ or NIL if the current transformation is the identity transformation."
                  with rx = 0
                  with ry = 0
                  for current-index in index-list
-                 do (let ((x-pos (+ x rx (glyph-entry-x-offset current-index)))
-                          (y-pos (+ y ry (glyph-entry-y-offset current-index))))
+                 do (let ((x-pos (+ x rx #+nil(glyph-entry-x-offset current-index)))
+                          (y-pos (+ y ry #+nil(glyph-entry-y-offset current-index))))
                       (setf (aref vec 0) (glyph-entry-codepoint current-index))
                       (multiple-value-bind (transformed-x transformed-y)
                           (clim:transform-position transformation x-pos y-pos)

--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -622,7 +622,7 @@ or NIL if the current transformation is the identity transformation."
 (defun text-style-contains-p (port text-style ch)
   (let* ((font (clim-clx::text-style-to-x-font port text-style))
          (charset (clim-freetype::freetype-font-face/charset (clim-freetype::freetype-font/face font))))
-    (mcclim-fontconfig:charset-contains-p charset ch)))
+    (mcclim-fontconfig:charset-contains-char-p charset ch)))
 
 (defvar *replacement-font-cache* (make-hash-table :test 'equal))
 
@@ -659,7 +659,7 @@ or NIL if the current transformation is the identity transformation."
                (write-char ch current-string)))
       (loop
         for ch across string
-        do (collect-result ch (if (mcclim-fontconfig:charset-contains-p default-charset ch)
+        do (collect-result ch (if (mcclim-fontconfig:charset-contains-char-p default-charset ch)
                                   '(nil nil)
                                   (find-best-font-for-fallback port text-style ch))))
       (push-string)

--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -612,13 +612,11 @@ or NIL if the current transformation is the identity transformation."
 
 (defun find-best-font (ch)
   (let* ((match (mcclim-fontconfig:match-font `((:charset . (:charset ,ch))) '(:family :style) :kind :match-font)))
-    (log:trace "Match for ~s: ~s" ch match)
     (let ((family (cdr (assoc :family match)))
           (style (cdr (assoc :style match))))
       (cond ((and family style)
              (list family style))
             (t
-             (log:warn "No font found for ~s" ch)
              '(nil nil))))))
 
 (defun text-style-contains-p (port text-style ch)
@@ -631,7 +629,6 @@ or NIL if the current transformation is the identity transformation."
     for fallback in (text-style-fallback-fonts text-style)
     for fallback-family = (first fallback)
     for fallback-style = (second fallback)
-    do (log:info "Checking fallback font: ~s" fallback)
     when (text-style-contains-p port (clim:make-text-style fallback-family fallback-style 10) ch)
       return fallback
     finally (return (find-best-font ch))))

--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -10,7 +10,7 @@
 
 (defparameter *freetype-font-scale* 26.6)
 
-(defvar *enable-autohint* nil)
+(defvar *enable-autohint* t)
 
 (defvar *lock* (bordeaux-threads:make-recursive-lock))
 

--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -448,7 +448,8 @@ or NIL if the current transformation is the identity transformation."
   (let ((result (mcclim-fontconfig:match-font (append *main-filter*
                                                       (make-family-pattern family)
                                                       (make-face-pattern face))
-                                              '(:family :style :file :charset))))
+                                              '(:family :style :file :charset)
+                                              :kind :match-font)))
     (list (cdr (assoc :family result))
           (cdr (assoc :style result))
           (cdr (assoc :file result))

--- a/Extensions/fonts/mcclim-fonts.asd
+++ b/Extensions/fonts/mcclim-fonts.asd
@@ -1,5 +1,6 @@
 #| dummy system to make Quicklisp happy |#
-(defsystem #:mcclim-fonts)
+(defsystem #:mcclim-fonts
+  :components ((:file "common")))
 
 (defsystem #:mcclim-fonts/truetype
     :depends-on (#:clim-basic #:zpb-ttf #:cl-vectors #:cl-paths-ttf #:cl-aa #:alexandria)
@@ -13,9 +14,9 @@
   (uiop:symbol-call :mcclim-truetype :autoconfigure-fonts))
 
 (defsystem #:mcclim-fonts/clx-truetype
-    :depends-on (#:mcclim-fonts/truetype #:mcclim-clx)
-    :components ((:file "xrender-fonts")))
+  :depends-on (#:mcclim-fonts/truetype #:mcclim-clx)
+  :components ((:file "xrender-fonts")))
 
 (defsystem #:mcclim-fonts/clx-freetype
-  :depends-on (#:mcclim-clx #:cl-freetype2 #:mcclim-fontconfig #:mcclim-harfbuzz)
+  :depends-on (#:mcclim-fonts #:mcclim-clx #:cl-freetype2 #:mcclim-fontconfig #:mcclim-harfbuzz)
   :components ((:file "freetype")))

--- a/Libraries/Drei/drei-mcclim.asd
+++ b/Libraries/Drei/drei-mcclim.asd
@@ -3,7 +3,8 @@
   :description "Drei Replaces EINE's Inheritor – McCLIM editor substrate"
   :depends-on ((:version "flexichain" "1.5.1")
                #:esa-mcclim #:clim-core #-clim-without-swank #:swank
-               #:automaton #:persistent)
+               #:automaton #:persistent
+               #:mcclim-fonts)
   :components
   ((:file "packages")
    (:file "buffer" :depends-on ("packages"))

--- a/Libraries/Drei/drei-redisplay.lisp
+++ b/Libraries/Drei/drei-redisplay.lisp
@@ -44,9 +44,7 @@
       for new-text-style = (if family (clim:make-text-style family style size) text-style)
       do (progn
            (funcall fn string curr-x new-text-style)
-           (multiple-value-bind (width)
-               (clim:text-size stream string :text-style new-text-style)
-             (incf curr-x width)))
+           (incf curr-x (clim:text-size stream string :text-style new-text-style)))
       finally (return curr-x))))
 
 (defun font-replacement-draw-text* (stream string x y

--- a/Libraries/Drei/drei-redisplay.lisp
+++ b/Libraries/Drei/drei-redisplay.lisp
@@ -45,7 +45,7 @@
       do (progn
            (funcall fn string curr-x new-text-style)
            (multiple-value-bind (width)
-               (clim:text-size stream string :text-style text-style)
+               (clim:text-size stream string :text-style new-text-style)
              (incf curr-x width)))
       finally (return curr-x))))
 
@@ -57,40 +57,10 @@
                             (lambda (string curr-x new-text-style)
                               (clim:draw-text* stream string (+ x curr-x) y :text-style new-text-style :ink ink :align-y align-y))))
 
-(defun xfont-replacement-draw-text* (stream string x y
-                                    &key
-                                      (start 0) (end (length string))
-                                      text-style ink (align-y :baseline))
-  (let* ((blocks (mcclim-font:find-replacement-text-styles stream (subseq string start end) :text-style text-style))
-         (text-style (or text-style (clim:medium-text-style stream)))
-         (size (clim:text-style-size text-style)))
-    (loop
-      with curr-x = x
-      for (string family style) in blocks
-      for new-text-style = (if family (clim:make-text-style family style size) text-style)
-      do (progn
-           (clim:draw-text* stream string curr-x y :text-style new-text-style :ink ink :align-y align-y)
-           (multiple-value-bind (width)
-               (clim:text-size stream string :text-style text-style)
-            (incf curr-x width))))))
-
 (defun font-replacement-text-size (stream string &key (start 0) (end (length string)) text-style)
   (iterate-font-replacement stream string start end text-style (lambda (string curr-x new-text-style)
                                                                  (declare (ignore string curr-x new-text-style))
                                                                  nil)))
-
-(defun xfont-replacement-text-size (stream string &key (start 0) (end (length string)) text-style)
-  (let* ((blocks (mcclim-font:find-replacement-text-styles stream (subseq string start end) :text-style text-style))
-         (text-style (or text-style (clim:medium-text-style stream)))
-         (size (clim:text-style-size text-style)))
-    (loop
-      with curr-width = 0
-      for (string family style) in blocks
-      for new-text-style = (if family (clim:make-text-style family style size) text-style)
-      do (multiple-value-bind (width)
-             (clim:text-size stream string :text-style text-style)
-           (incf curr-width width))
-      finally (return curr-width))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;


### PR DESCRIPTION
Implement support for font replacement.

Apart from changes to the fontconfig library that were needed to provide the ability find fonts that contains certain characters, the main user-visible change is a new function: `FIND-REPLACEMENT-TEXT-STYLES` which splits a string into sections with different text styles that should be used in order to make sure all characters are displayed.

Drei has been modified to take advantage of this function so that it is able to handle text of any language (with the exception of right-to-left text, this requires further changes).