### PR TITLE
#500: Don't directly access TRANSFORMATION slots

### DIFF
--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -1019,7 +1019,7 @@
     (let* ((base-angle (untransform-angle tr angle))
            (x (cos base-angle))
            (y (sin base-angle)))
-      (with-slots (mxx mxy myx myy tx ty) tr
+      (multiple-value-bind (mxx mxy myx myy tx ty) (get-transformation tr)
         (values (+ (* mxx x) (* mxy y) tx)
                 (+ (* myx x) (* myy y) ty))))))
 


### PR DESCRIPTION
Not all subclasses of TRANSFORMATION offer the MXX, MXY, etc. slots.
Use the GET-TRANSFORMATION function to obtain these values instead in
%ELLIPSE-SIMPLIFIED-REPRESENTATION/RADIUS.