### PR TITLE
Freetype: Don't crash when coordinate swizzling is active

### DIFF
--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -364,10 +364,12 @@ or NIL if the current transformation is the identity transformation."
                       (setf (aref vec 0) (glyph-entry-codepoint current-index))
                       (multiple-value-bind (transformed-x transformed-y)
                           (clim:transform-position transformation x-pos y-pos)
-                        (xlib:render-composite-glyphs dest glyphset source
-                                                      (truncate (+ transformed-x 0.5))
-                                                      (truncate (+ transformed-y 0.5))
-                                                      vec))
+                        (unless (or (> transformed-x #xffff)
+                                    (> transformed-y #xffff))
+                          (xlib:render-composite-glyphs dest glyphset source
+                                                        (truncate (+ transformed-x 0.5))
+                                                        (truncate (+ transformed-y 0.5))
+                                                        vec)))
                       (incf rx (/ (glyph-entry-x-advance current-index) 64))
                       (incf ry (/ (glyph-entry-y-advance current-index) 64)))))
           (when transform-matrix


### PR DESCRIPTION
Sometimes there may be requests to draw text just outside the text
area. If coordinate swizzling is active, this area will be just above
position #xFFFF. Such strings should not be visible, but if an attempt
is made to actually copy these characters to the window, xlib will
throw an exception because the coordinate is out of range.

This fix ensures that no characters are drawn outside the valid range.