### PR TITLE
Freetype: The fix for the swizzle issue used incorrect values

### DIFF
--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -364,8 +364,8 @@ or NIL if the current transformation is the identity transformation."
                       (setf (aref vec 0) (glyph-entry-codepoint current-index))
                       (multiple-value-bind (transformed-x transformed-y)
                           (clim:transform-position transformation x-pos y-pos)
-                        (unless (or (> transformed-x #xffff)
-                                    (> transformed-y #xffff))
+                        (unless (or (> transformed-x #x7fff)
+                                    (> transformed-y #x7fff))
                           (xlib:render-composite-glyphs dest glyphset source
                                                         (truncate (+ transformed-x 0.5))
                                                         (truncate (+ transformed-y 0.5))


### PR DESCRIPTION
The actual limit is a signed short, which means the limit is #x7fff,
not #xffff. The problem in the previous fix was unnoticed because of a
typo (while testing, the decimal value 32767 was used, but it was
changed to hex for clarity before commit. The final test to ensure
that it still worked failed to highlight the issue since the actual
problem wasn't reproduced correctly).