### PR TITLE
standard-extended-input-stream: usability fixes

### DIFF
--- a/Core/clim-basic/ports.lisp
+++ b/Core/clim-basic/ports.lisp
@@ -83,6 +83,12 @@
   (when (null *application-frame*)
     (error "~S called with null ~S" 
            '(setf port-keyboard-input-focus) '*application-frame*))
+  ;; XXX: pane frame is not defined for all streams (for instance not for
+  ;; CLIM:STANDARD-EXTENDED-INPUT-STREAM), so this sanity check would lead to
+  ;; error on that.
+  ;; XXX: also should we allow reading objects from foreign application frames?
+  ;; This was the case on Genera and is requested by users from time to time...
+  #+ (or)
   (unless (eq *application-frame* (pane-frame focus))
     (error "frame mismatch in ~S" '(setf port-keyboard-input-focus)))
   (setf (port-frame-keyboard-input-focus port *application-frame*) focus))

--- a/Core/clim-basic/stream-input.lisp
+++ b/Core/clim-basic/stream-input.lisp
@@ -185,9 +185,14 @@ keys read."))
   ((pointer)
    (cursor :initarg :text-cursor)
    (last-gesture :accessor last-gesture :initform nil
-    :documentation "Holds the last gesture returned by
-  stream-read-gesture (not peek-p), untransformed, so it can easily be
-  unread.")))
+    :documentation "Holds the last gesture returned by stream-read-gesture
+(not peek-p), untransformed, so it can easily be unread.")))
+
+(defmethod stream-set-input-focus ((stream standard-extended-input-stream))
+  (let ((port (or (port stream)
+                  (port *application-frame*))))
+    (prog1 (port-keyboard-input-focus port)
+      (setf (port-keyboard-input-focus port) stream))))
 
 (defmacro with-input-focus ((stream) &body body)
   (when (eq stream t)

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -2595,11 +2595,6 @@ SCROLLER-PANE appear on the ergonomic left hand side, or leave set to
   (scroll-extent pane x y)
   (values x y))
 
-(defmethod stream-set-input-focus ((stream clim-stream-pane))
-  (with-slots (port) stream
-    (prog1 (port-keyboard-input-focus port)
-      (setf (port-keyboard-input-focus port) stream))))
-
 ;;; output any buffered stuff before input
 
 (defmethod stream-read-gesture :before ((stream clim-stream-pane)


### PR DESCRIPTION
- Omission/bug in McCLIM. Function CLIM:STREAM-SET-INPUT-FOCUS is part of The
Extended Input Stream Protocol hence method must be implemented for
CLIM:STANDARD-EXTENDED-INPUT-STREAM. Since CLIM:CLIM-STREAM-PANE inherits from
the former then we have no need to define this method for the latter (remove
method specialization).

- Don't check if focus belongs to the current *application-frame* in
(SETF CLIM:PORT-KEYBOARD-INPUT-FOCUS). This loosing of the requirement should
allow sharing some extended-input-streams between frames. Without this hcnage it
would be impossible to (SETF CLIM:PORT-KEYBOARD-INPUT-FOCUS) on
CLIM:STANDARD-EXTENDED-INPUT-STREAM rendering class unfittable to use as it is.