### PR TITLE
Fix repaint order in incremental-redisplay

### DIFF
--- a/Core/clim-core/incremental-redisplay.lisp
+++ b/Core/clim-core/incremental-redisplay.lisp
@@ -837,7 +837,7 @@ in an equalp hash table"))
          ;; moves
          nil
          ;; draws
-         come
+         (reverse come)
          ;; erase overlapping
          (append gone-overlap come-overlap)
          ;; move overlapping


### PR DESCRIPTION
Incremental-redisplay works by calling compute-difference-set which
collects a list of drawing operations which are to be performed. It
does this by pushing the output records to a list. This results in the
order of the output records being reversed, which causes them to be
drawn in the wrong order. This behaviour can be seen when adding
two graphics operations to an updating-output form which draws on top
of each other. After redisplay, the output records will have been
drawn in reverse order.

This fix simply calls REVERSE on the list before returning it.