### PR TITLE
Transform fix

### DIFF
--- a/Examples/image-transform-demo.lisp
+++ b/Examples/image-transform-demo.lisp
@@ -116,9 +116,7 @@
                   (make-skew-transformation x-skew y-skew))))))
       (clim:with-drawing-options (stream :transformation tr)
         (clim:draw-pattern* stream image 0 0)
-        (clim:draw-rectangle* stream 0 0 (clim:pattern-width image) (clim:pattern-height image) :filled nil :ink clim:+blue+)
-        (clim:with-text-size (stream 60)
-          (clim:draw-text* stream "Foo abcdefgh" 100 100))))))
+        (clim:draw-rectangle* stream 0 0 (clim:pattern-width image) (clim:pattern-height image) :filled nil :ink clim:+blue+)))))
 
 (defun image-transform-demo ()
   (let ((frame (clim:make-application-frame 'image-transform-demo)))

--- a/Examples/image-transform-demo.lisp
+++ b/Examples/image-transform-demo.lisp
@@ -116,7 +116,13 @@
                   (make-skew-transformation x-skew y-skew))))))
       (clim:with-drawing-options (stream :transformation tr)
         (clim:draw-pattern* stream image 0 0)
-        (clim:draw-rectangle* stream 0 0 (clim:pattern-width image) (clim:pattern-height image) :filled nil :ink clim:+blue+)))))
+        (clim:draw-rectangle* stream 0 0 (clim:pattern-width image) (clim:pattern-height image) :filled nil :ink clim:+blue+)
+        ;; We don't display text here if using the Truetype font
+        ;; renderer, since other font renderers doesn't support text
+        ;; transform.
+        #+mcclim-ffi-freetype
+        (clim:with-text-size (stream 60)
+          (clim:draw-text* stream "Foo abcdefgh" 100 100))))))
 
 (defun image-transform-demo ()
   (let ((frame (clim:make-application-frame 'image-transform-demo)))

--- a/Examples/image-transform-demo.lisp
+++ b/Examples/image-transform-demo.lisp
@@ -92,7 +92,7 @@
     (clim:redisplay-frame-pane frame (clim:find-pane-named frame 'image-demo))))
 
 (defun make-skew-transformation (x-skew y-skew)
-  (clim:make-transformation (1+ (* (tan x-skew) (tan y-skew))) (tan x-skew)
+  (clim:make-transformation 1 (tan x-skew)
                             (tan y-skew) 1
                             0 0))
 
@@ -116,7 +116,9 @@
                   (make-skew-transformation x-skew y-skew))))))
       (clim:with-drawing-options (stream :transformation tr)
         (clim:draw-pattern* stream image 0 0)
-        (clim:draw-rectangle* stream 0 0 (clim:pattern-width image) (clim:pattern-height image) :filled nil :ink clim:+blue+)))))
+        (clim:draw-rectangle* stream 0 0 (clim:pattern-width image) (clim:pattern-height image) :filled nil :ink clim:+blue+)
+        (clim:with-text-size (stream 60)
+          (clim:draw-text* stream "Foo abcdefgh" 100 100))))))
 
 (defun image-transform-demo ()
   (let ((frame (clim:make-application-frame 'image-transform-demo)))

--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -313,14 +313,14 @@ rendering, otherwise the identity matrix will be used instead."
 or NIL if the current transformation is the identity transformation."
   (if (eq transformation 'clim:+identity-transformation+)
       nil
-      (multiple-value-bind (rxx ryx rxy ryy)
+      (multiple-value-bind (rxx rxy ryx ryy)
           (climi::get-transformation transformation)
         (if (and (= rxx 1)
-                 (= ryx 0)
                  (= rxy 0)
+                 (= ryx 0)
                  (= ryy 1))
             nil
-            (make-array '(2 2) :initial-contents (list (list rxx rxy) (list ryx ryy)))))))
+            (make-array '(2 2) :initial-contents (list (list rxx (- rxy)) (list (- ryx) ryy)))))))
 
 ;;; We only cache glyphsets that does not have a transformation
 ;;; applied. The assumption is that applying transformation on text is


### PR DESCRIPTION
This pull request contains three fixes:

**Fix 1**

When applying the CLIM transformation matrix when loading characters using Freetype, the rotation direction is wrong. The previous solution was to transpose the matrix. This works for rotation, but ends up applying skew transformations along the wrong axis.

This fix solves the problem in the correct way by negating the xy and yx values.

**Fix 2**

The skew transformation matrix in the image-transform demo was computed as the product of the x-skew and y-skew vectors. This fix uses a single x and y skew matrix.

**Fix 3**

Some text was added to the image-transform demo in order to be able to verify that text transform works.