### PR TITLE
Fix the :CONTENTS initialiser for SHEET-MULTIPLE-CHILD-MIXIN

### DIFF
--- a/Core/clim-basic/sheets.lisp
+++ b/Core/clim-basic/sheets.lisp
@@ -619,7 +619,11 @@
 ;;; sheet multiple child mixin
 
 (defclass sheet-multiple-child-mixin ()
-  ((children :initform nil :initarg :children :accessor sheet-children)))
+  ((children :initform nil :accessor sheet-children)))
+
+(defmethod initialize-instance :after ((sheet sheet-multiple-child-mixin) &key contents)
+  (dolist (child contents)
+    (sheet-adopt-child sheet child)))
 
 (defmethod sheet-adopt-child ((sheet sheet-multiple-child-mixin)
 			      (child sheet-parent-mixin))


### PR DESCRIPTION
Previously, the CHILDREN slot has an initarg called :CHILDREN. This
initarg was not usable since none of the logic implemented by
SHEET-ADOPT-CHILD was performed.

This fix changes this so that SHEET-ADOPT-CHILD is called once for
each child. It also renames the keyword argument to :CONTENTS in order
to be consistent with other panes.