### PR TITLE
Don't implement :CONTENTS initarg on SHEET-MULTIPLE-CHILD-MIXIN

### DIFF
--- a/Core/clim-basic/sheets.lisp
+++ b/Core/clim-basic/sheets.lisp
@@ -621,10 +621,6 @@
 (defclass sheet-multiple-child-mixin ()
   ((children :initform nil :accessor sheet-children)))
 
-(defmethod initialize-instance :after ((sheet sheet-multiple-child-mixin) &key contents)
-  (dolist (child contents)
-    (sheet-adopt-child sheet child)))
-
 (defmethod sheet-adopt-child ((sheet sheet-multiple-child-mixin)
 			      (child sheet-parent-mixin))
   (push child (sheet-children sheet)))

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -1766,6 +1766,10 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
 
 (defclass bboard-pane (composite-pane) ())
 
+(defmethod initialize-instance :after ((sheet bboard-pane) &key contents)
+  (dolist (child contents)
+    (sheet-adopt-child sheet child)))
+
 (defmethod compose-space ((bboard bboard-pane) &key width height)
   (declare (ignore width height))
   (make-space-requirement :width 300 :height 300))


### PR DESCRIPTION
The previous fix 204d80c6815cf7448d43f9d5d8fb05dac37bf8ca added a
:CONTENTS initarg to SHEET-MULTIPLE-CHILD-MIXIN. This was problematic
as it conflicted with other implementations of the same argument.

This fix moves this code to the BBOARD-PANE specifically. If it's
needed for other classes, they should be implemented for each one
individually.