### PR TITLE
filtered button-release for pointer-wheel events

### DIFF
--- a/Backends/CLX/input.lisp
+++ b/Backends/CLX/input.lisp
@@ -143,8 +143,10 @@
 	((:button-press :button-release)
 	 (let ((modifier-state (clim-xcommon:x-event-state-modifiers *clx-port* state))
                (button (decode-x-button-code code)))
-           (if (member button '(#.+pointer-wheel-up+ #.+pointer-wheel-down+
-                                #.+pointer-wheel-left+ #.+pointer-wheel-right+))
+           (if (and
+                (member button '(#.+pointer-wheel-up+ #.+pointer-wheel-down+
+                                 #.+pointer-wheel-left+ #.+pointer-wheel-right+))
+                (eq event-key :button-press))
                (make-instance 'climi::pointer-scroll-event
                               :pointer 0
                               :button button :x x :y y

--- a/Backends/CLX/input.lisp
+++ b/Backends/CLX/input.lisp
@@ -143,10 +143,11 @@
 	((:button-press :button-release)
 	 (let ((modifier-state (clim-xcommon:x-event-state-modifiers *clx-port* state))
                (button (decode-x-button-code code)))
-           (if (and
-                (member button '(#.+pointer-wheel-up+ #.+pointer-wheel-down+
-                                 #.+pointer-wheel-left+ #.+pointer-wheel-right+))
-                (eq event-key :button-press))
+           (if (and (eq event-key :button-press)
+                    (member button '(#.+pointer-wheel-up+
+                                     #.+pointer-wheel-down+
+                                     #.+pointer-wheel-left+
+                                     #.+pointer-wheel-right+)))
                (make-instance 'climi::pointer-scroll-event
                               :pointer 0
                               :button button :x x :y y


### PR DESCRIPTION
X generates a button-press and a button-release event on each scroll-wheel change. The code assumes that only one scroll-wheel event should get generated on scroll wheel movement and only generates the event on button-press.