### PR TITLE
Remove old code that was part of the optimised scroll

### DIFF
--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -1412,136 +1412,16 @@ time an indexed pattern is drawn.")
       (setf (getf (xlib:drawable-plist drawable) 'cached-picture)
             (create-picture-from-drawable drawable))))
 
-(defun make-xrender-colour (fg)
-  (list (ash (ldb (byte 8 16) fg) 8)
-        (ash (ldb (byte 8 8) fg) 8)
-        (ash (ldb (byte 8 0) fg) 8)
-        #xFFFF))
-
-(defun create-pen (drawable gc)
-  (let* ((fg (xlib::gcontext-foreground gc))
-         (cached-pen (getf (xlib:gcontext-plist gc) 'cached-pen)))
-    (cond ((and cached-pen (equal (second cached-pen) fg))
-           (first cached-pen))
-          (t
-           (when cached-pen
-             (xlib:render-free-picture (first cached-pen)))
-           (let* ((pixmap (xlib:create-pixmap :drawable (xlib:drawable-root drawable)
-                                              :width 1
-                                              :height 1
-                                              :depth 32))
-                  (picture (xlib:render-create-picture pixmap
-                                                       :format (find-rgba-format (xlib::drawable-display drawable))
-                                                       :repeat :on))
-                  (colour (list (ash (ldb (byte 8 16) fg) 8)
-                                (ash (ldb (byte 8 8) fg) 8)
-                                (ash (ldb (byte 8 0) fg) 8)
-                                #xFFFF)))
-             (xlib:render-fill-rectangle picture :src colour 0 0 1 1)
-             (xlib:free-pixmap pixmap)
-             (setf (getf (xlib:gcontext-plist gc) 'cached-pen) (list picture fg))
-             picture)))))
-
-(defun create-move-sheet-temp-buffer-picture (drawable)
-  (or (getf (xlib:window-plist drawable) 'temp-buffer-picture)
-      (setf (getf (xlib:window-plist drawable) 'temp-buffer-picture)
-            (let ((pixmap (xlib:create-pixmap :width (xlib:drawable-width drawable)
-                                              :height (xlib:drawable-height drawable)
-                                              :depth (xlib:drawable-depth drawable)
-                                              :drawable drawable)))
-              (create-picture-from-drawable pixmap)))))
-
-(declaim (inline simple-round))
-(defun simple-round (n)
-  (if (minusp n)
-      (truncate (- n 0.5))
-      (truncate (+ n 0.5))))
-
-(defun render-scroll-sheet (sheet x y dx dy update-fn)
-  (let ((parent (pane-viewport sheet)))
-    (if (null parent)
-        ;; No parent
-        (funcall update-fn)
-        ;; ELSE: Check if we can use optimised scrolling
-        (multiple-value-bind (width height)
-            (bounding-rectangle-size (sheet-region parent))
-          (if (not (or (and (zerop dx) (< (abs dy) height))
-                       (and (zerop dy) (< (abs dx) width))))
-              ;; If scrolling isn't strictly vertical or horizontal, just do a full update
-              (funcall update-fn)
-              ;; ELSE: We can refresh only part of the content, after copying the overlapping area
-              ;; It is assumed that the position of a sheet is always 0,0
-              (progn
-                (multiple-value-bind (x y)
-                    (bounding-rectangle-position (sheet-region parent))
-                  (assert (and (zerop x) (zerop y))))
-                ;; Copy the overlapping area
-                (with-sheet-medium (medium sheet)
-                  (with-clx-graphics () medium
-                    (let* ((src (create-dest-picture mirror))
-                           (temp-buffer (create-move-sheet-temp-buffer-picture mirror)))
-                      (multiple-value-bind (src-x src-y dest-x dest-y area-width area-height updated-rectangle)
-                          (cond ((and (zerop dx) (minusp dy))
-                                 (values 0 (- dy) 0 0 width (+ height dy)
-                                         (make-rectangle* (- x) (- (+ height dy) y) (- width x) (- height y))))
-                                ((and (zerop dx) (plusp dy))
-                                 (values 0 0 0 dy width (- height dy)
-                                         (make-rectangle* (- x) (- y) (- width x) (- dy y))))
-                                ((and (minusp dx) (zerop dy))
-                                 (values (- dx) 0 0 0 (+ width dx) height
-                                         (make-rectangle* (- (+ width dx) x) (- y) (- width x) (- height x))))
-                                ((and (plusp dx) (zerop dy))
-                                 (values 0 0 dx 0 (- width dx) height
-                                         (make-rectangle* (- x) (- y) (- dx x) (- height y))))
-                                (t
-                                 (error "Unexpected movement coordinates: ~s,~s" dx dy)))
-                        (let ((width-integer (truncate (+ area-width 0.5)))
-                              (height-integer (truncate (+ area-height 0.5))))
-                          (setf (xlib:picture-clip-mask src) :none)
-                          (xlib:render-composite :over src nil temp-buffer
-                                                 src-x src-y ;src pos
-                                                 0 0         ;mask pos
-                                                 0 0         ;dest pos
-                                                 width-integer height-integer ;size
-                                                 )
-                          (xlib:render-composite :over temp-buffer nil src
-                                                 0 0
-                                                 0 0
-                                                 dest-x dest-y
-                                                 width-integer height-integer))
-                        (let ((climi::*inhibit-dispatch-repaint* t))
-                          (funcall update-fn))
-                        (repaint-sheet sheet updated-rectangle)))))))))))
-
 (defmethod move-sheet ((sheet clx-pane-mixin) x y)
   (let ((transform (sheet-transformation sheet)))
     (multiple-value-bind (old-x old-y)
         (transform-position transform 0 0)
-      ;;
       (let ((dx (- x old-x))
             (dy (- y old-y)))
-        ;;
-        (flet ((update-transform ()
-                 (setf (sheet-transformation sheet)
-                       (compose-translation-with-transformation
-                        transform (- x old-x) (- y old-y)))))
-          ;; The scroll optimisation has been disabled since there are
-          ;; issues when the window is partially obstructed. The
-          ;; solution is to draw to a backing pixmap instead, but this
-          ;; would be part of the larger work to implement double
-          ;; buffering for drawing.
-          #+(or)
-          (cond ((and (zerop dx) (zerop dy))
-                 ;; No movement, skip update
-                 nil)
-                ((and (zerop (nth-value 1 (truncate dx)))
-                      (zerop (nth-value 1 (truncate dy))))
-                 ;; Coordinates are aligned, we can use optimised scrolling
-                 (render-scroll-sheet sheet x y (truncate dx) (truncate dy) #'update-transform))
-                (t
-                 (update-transform)))
-          (unless (and (zerop dx) (zerop dy))
-            (update-transform)))))))
+        (unless (and (zerop dx) (zerop dy))
+          (setf (sheet-transformation sheet)
+                (compose-translation-with-transformation
+                 transform (- x old-x) (- y old-y))))))))
 
 (defmethod resize-sheet :before ((sheet clx-pane-mixin) width height)
   (with-sheet-medium (medium sheet)

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -2666,21 +2666,12 @@ SCROLLER-PANE appear on the ergonomic left hand side, or leave set to
   (when (stream-drawing-p stream)
     (change-stream-space-requirements stream :height new-height)
     (unless (eq :allow (stream-end-of-page-action stream))
-      ;; At this point, we might be in the middle of drawing and
-      ;; recording an output record. We can't call SCROLL-EXTENT
-      ;; directly here since it might want to repaint a portion of the
-      ;; pane that has been revealed. However, since the output
-      ;; records won't be added to the stream until later, the repaint
-      ;; will not draw the correct thing.
-      ;;
-      ;; The solution is to queue an event that will trigger the scoll
-      ;; later, at which point the output records are properly setup.
       (scroll-extent stream
-                   0
-                   (max 0 (- new-height
-                             (bounding-rectangle-height
-                              (or (pane-viewport stream)
-                                  stream))))))))
+                     0
+                     (max 0 (- new-height
+                               (bounding-rectangle-height
+                                (or (pane-viewport stream)
+                                    stream))))))))
 
 ;;; INTERACTOR PANES
 

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -2662,21 +2662,6 @@ SCROLLER-PANE appear on the ergonomic left hand side, or leave set to
     ((type t) (stream clim-stream-pane))
   (funcall-presentation-generic-function presentation-type-history type))
 
-(defclass scroll-extent-event (standard-event)
-  ((stream :initarg :stream
-           :reader scroll-extent-event/stream)
-   (new-height :initarg :new-height
-               :reader scroll-extent-event/new-height)))
-
-(defmethod handle-event ((sheet clim-stream-pane) (event scroll-extent-event))
-  (let ((stream (scroll-extent-event/stream event)))
-    (scroll-extent stream
-                   0
-                   (max 0 (- (scroll-extent-event/new-height event)
-                             (bounding-rectangle-height
-                              (or (pane-viewport stream)
-                                  stream)))))))
-
 (defmethod %note-stream-end-of-page ((stream clim-stream-pane) action new-height)
   (when (stream-drawing-p stream)
     (change-stream-space-requirements stream :height new-height)
@@ -2690,11 +2675,12 @@ SCROLLER-PANE appear on the ergonomic left hand side, or leave set to
       ;;
       ;; The solution is to queue an event that will trigger the scoll
       ;; later, at which point the output records are properly setup.
-      (queue-event stream
-                   (make-instance 'scroll-extent-event
-                                  :sheet stream
-                                  :stream stream
-                                  :new-height new-height)))))
+      (scroll-extent stream
+                   0
+                   (max 0 (- new-height
+                             (bounding-rectangle-height
+                              (or (pane-viewport stream)
+                                  stream))))))))
 
 ;;; INTERACTOR PANES
 


### PR DESCRIPTION
The optimised scroll implementation implemented scrolling by copying
the content of the window instead of repaining it. This worked
sometimes, but was problematic when a window was partially visible.

As it turns out, the proper way to do this is to always draw the
window content to a backing pixmap so that the previous content is
always available. If this is done, not much of the old code will be
useful anyway, so to clean things up this commit removes all of the
unused code.