### PR TITLE
Small changes

### DIFF
--- a/Core/clim-basic/recording.lisp
+++ b/Core/clim-basic/recording.lisp
@@ -2099,16 +2099,6 @@ according to the flags RECORD and DRAW."
 
 
 ;;; Additional methods
-(defmethod scroll-vertical :around ((stream output-recording-stream) dy)
-  (declare (ignore dy))
-  (with-output-recording-options (stream :record nil)
-    (call-next-method)))
-
-(defmethod scroll-horizontal :around ((stream output-recording-stream) dx)
-  (declare (ignore dx))
-  (with-output-recording-options (stream :record nil)
-    (call-next-method)))
-
 (defmethod handle-repaint :around ((stream output-recording-stream) region)
   (with-output-recording-options (stream :record nil)
     (call-next-method)))

--- a/Core/clim-basic/stream-output.lisp
+++ b/Core/clim-basic/stream-output.lisp
@@ -233,19 +233,6 @@
           (call-next-method))
         (call-next-method))))
 
-(defgeneric scroll-vertical (stream dy))
-
-(defmethod scroll-vertical ((stream standard-extended-output-stream) dy)
-  (multiple-value-bind (tx ty)
-      (bounding-rectangle-position (sheet-region stream))
-    (scroll-extent stream tx (+ ty dy))))
-
-(defgeneric scroll-horizontal (stream dx))
-
-(defmethod scroll-horizontal ((stream standard-extended-output-stream) dx)
-  (multiple-value-bind (tx ty) (bounding-rectangle-position (sheet-region stream))
-    (scroll-extent stream (+ tx dx) ty)))
-
 (defmacro with-cursor-off (stream &body body)
   `(letf (((cursor-visibility (stream-text-cursor ,stream)) nil))
      ,@body))
@@ -296,7 +283,9 @@
                  (setq split (max (find-split (- margin cx))
                                   (1+ start))))
                 (:scroll
-                 (scroll-horizontal stream width))
+                 (multiple-value-bind (tx ty)
+                     (bounding-rectangle-position (sheet-region stream))
+                   (scroll-extent stream (+ tx width) ty)))
                 (:allow)))
             (unless (= start split)
               (stream-write-output stream string nil start split)

--- a/Core/clim-basic/transforms.lisp
+++ b/Core/clim-basic/transforms.lisp
@@ -424,28 +424,28 @@ real numbers, and default to 0."
                value)))
 
 (defun compose-translation-with-transformation (transformation dx dy)
-  (compose-transformations transformation
-			   (make-translation-transformation dx dy)))
+  (compose-transformations (make-translation-transformation dx dy)
+                           transformation))
 
 (defun compose-scaling-with-transformation (transformation sx sy &optional origin)
-  (compose-transformations transformation
-			   (make-scaling-transformation sx sy origin)))
+  (compose-transformations (make-scaling-transformation sx sy origin)
+                           transformation))
 
 (defun compose-rotation-with-transformation (transformation angle &optional origin)
-  (compose-transformations transformation
-			   (make-rotation-transformation angle origin)))
+  (compose-transformations (make-rotation-transformation angle origin)
+                           transformation))
 
 (defun compose-transformation-with-translation (transformation dx dy)
-  (compose-transformations (make-translation-transformation dx dy)
-			   transformation))
+  (compose-transformations transformation
+                           (make-translation-transformation dx dy)))
 
 (defun compose-transformation-with-scaling (transformation sx sy &optional origin)
-  (compose-transformations (make-scaling-transformation sx sy origin)
-			   transformation))
+  (compose-transformations transformation
+                           (make-scaling-transformation sx sy origin)))
 
 (defun compose-transformation-with-rotation (transformation angle &optional origin)
-  (compose-transformations (make-rotation-transformation angle origin)
-			   transformation))
+  (compose-transformations transformation
+                           (make-rotation-transformation angle origin)))
 
 (defmacro with-translation ((medium dx dy) &body body)
   `(with-drawing-options (,medium

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -1900,6 +1900,7 @@ SCROLLER-PANE appear on the ergonomic left hand side, or leave set to
                ;; --GB 2005-11-29
                :initform t
                :initarg :scroll-bar
+               :initarg :scroll-bars
                :accessor scroller-pane-scroll-bar)
    (viewport   :initform nil)
    (vscrollbar :initform nil)
@@ -2470,6 +2471,7 @@ SCROLLER-PANE appear on the ergonomic left hand side, or leave set to
   ((redisplay-needed :initarg :display-time) 
    (scroll-bars :type scroll-bar-spec ; (member t :vertical :horizontal nil)
 		:initform nil
+                :initarg :scroll-bar
 		:initarg :scroll-bars
 		:accessor pane-scroll-bars)
   
@@ -2774,10 +2776,11 @@ current background message was set."))
 
 (defun make-clim-stream-pane (&rest options
                               &key (type 'clim-stream-pane)
-                                (scroll-bars :vertical)
+                                (scroll-bar :vertical)
+                                (scroll-bars scroll-bar)
                                 (borders t)
                                 &allow-other-keys)
-  (with-keywords-removed (options (:type :scroll-bars :borders))
+  (with-keywords-removed (options (:type :scroll-bar :scroll-bars :borders))
     ;; The user space requirement options belong to the scroller ..
     (let* ((space-keys '(:width :height :max-width :max-height
 			 :min-width :min-height))


### PR DESCRIPTION
These changes were extracted from my current medium work and are unrelated to it (still needed and being improvement).

- compose-x-with-y transformation functions had arguments reversed
- small cleanup for scroll methods and initargs (no distracting unused code)
- specialization for mediums to be able draw on non-stream sheet inside with-room-for-graphics

I hope to make a follow-up pull request wrt invoke-with-room-for-graphics, but this will be bigger task and I don't want to get distracted from what I'm doing now.