### PR TITLE
scigraph: use draw-string instead of draw-vertical-text

### DIFF
--- a/Apps/Scigraph/dwim/draw.lisp
+++ b/Apps/Scigraph/dwim/draw.lisp
@@ -150,9 +150,10 @@ advised of the possiblity of such damages.
 	 ;; Ideally, we would want to draw on a bitmap here and rotate the bitmap.
 	 ;; In CLIM, however, you can't do that.  And in Dynamic Windows, that is
 	 ;; an extremely expensive operation.  So forget it.
-	 (draw-vertical-text string stream u v
-			     :rotation rotation
-			     :alu alu :style character-style))))
+         (climi::with-rotation (stream rotation (clim:make-point u v))
+           (draw-string string u v :alu alu :stream stream
+		        :attachment-y attachment-y
+		        :character-style character-style)))))
 
 (defun draw-polygon (points &key (stream *standard-output*) (alu %alu) (filled nil)
 		     &allow-other-keys)

--- a/Apps/Scigraph/scigraph/annotated-graph.lisp
+++ b/Apps/Scigraph/scigraph/annotated-graph.lisp
@@ -394,14 +394,14 @@ older classes in favor of cleaned up newer ones.  Someday, ...
 	(let* ((annotation (make-border-annotation
 			     self STREAM y-label :left
 			     ull vll
-			     'y-label (/ pi 2) nil))
+			     'y-label #.(/ pi -2) nil))
 	       (height nil))
 	  (setf (style annotation) (y-label-text-style self stream))
 	  (setq height (* (length y-label) (stream-line-height stream)))
 	  (set-uv-position annotation
 			   (- ull (* (stream-character-width stream)
 				     (+ y-digits 2)))
-			   (+ (values (truncate (+ vll vur) 2))
+			   (- (values (truncate (+ vll vur) 2))
 			      (values (truncate height 2))))
 	  (setq y-annotation annotation))))))
 


### PR DESCRIPTION
 * this allows for properly rotated text

 * adjust text angle and position for proper vertical
   positioning/orientation.