### PR TITLE
specialize region-* methods on (drei-area region) and vice versa

### DIFF
--- a/Libraries/Drei/drei-clim.lisp
+++ b/Libraries/Drei/drei-clim.lisp
@@ -503,22 +503,22 @@ record."))
 (defmethod rectangle-edges* ((rectangle drei-area))
   (bounding-rectangle* rectangle))
 
-(defmethod region-union ((region1 drei-area) region2)
+(defmethod region-union ((region1 drei-area) (region2 region))
   (region-union (bounding-rectangle region1) region2))
 
-(defmethod region-union (region1 (region2 drei-area))
+(defmethod region-union ((region1 region) (region2 drei-area))
   (region-union region1 (bounding-rectangle region2)))
 
-(defmethod region-intersection ((region1 drei-area) region2)
+(defmethod region-intersection ((region1 drei-area) (region2 region))
   (region-intersection (bounding-rectangle region1) region2))
 
-(defmethod region-intersection (region1 (region2 drei-area))
+(defmethod region-intersection ((region1 region) (region2 drei-area))
   (region-intersection region1 (bounding-rectangle region2)))
 
-(defmethod region-difference ((region1 drei-area) region2)
+(defmethod region-difference ((region1 drei-area) (region2 region))
   (region-difference (bounding-rectangle region1) region2))
 
-(defmethod region-difference (region1 (region2 drei-area))
+(defmethod region-difference ((region1 region) (region2 drei-area))
   (region-difference region1 (bounding-rectangle region2)))
 
 (defmethod transform-region (transformation (region drei-area))


### PR DESCRIPTION
 * not just (drei-area *). This ensures that our region-union,
   region-intersection, and region-difference methods, which extract
   the bounding-rectangle of the drei area before re-calling the
   region-* method, get called instead of methods that specialize
   on (region region).