### PR TITLE
Fix breakage from "medium-transformation-fixes" merge

### DIFF
--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -319,6 +319,9 @@ translated, so they begin at different position than [0,0])."))
         gc))))
 
 
+;; Variable is used to deallocate lingering resources after the operation.
+(defvar ^cleanup)
+
 ;;; XXX: both PM and MM pixmaps should be freed with (xlib:free-pixmap pixmap)
 ;;; when not used. We do not do that right now.
 (defun compute-rgb-mask (drawable image)
@@ -424,8 +427,6 @@ translated, so they begin at different position than [0,0])."))
                                                        :normalize :y-banding)))
           nconcing (multiple-value-list (region->clipping-values region))))))
 
-;; Variable is used to deallocate lingering resources after the operation.
-(defvar ^cleanup)
 (defmacro with-clx-graphics ((&optional (mirror 'mirror)
                                         (line-style 'line-style)
                                         (ink 'ink)

--- a/Core/clim-basic/clim-basic.asd
+++ b/Core/clim-basic/clim-basic.asd
@@ -1,4 +1,3 @@
-
 (defsystem #:clim-basic
   :depends-on (#:clim-lisp
                #:spatial-trees
@@ -13,10 +12,10 @@
    (:file "protocol-classes" :depends-on ("decls"))
    (:file "multiprocessing" :depends-on ("decls")) ; legacy mp backends are in Lisp-Dep/mp-*.lisp
    (:file "utils" :depends-on ("decls" "multiprocessing"))
-   (:file "design" :depends-on ("decls" "protocol-classes" "utils"))
    (:file "X11-colors" :depends-on ("decls" "protocol-classes" "multiprocessing" "design" "regions"))
    (:file "coordinates" :depends-on ("decls" "protocol-classes" "multiprocessing"))
    (:file "transforms" :depends-on ("decls" "protocol-classes" "multiprocessing" "coordinates" "utils"))
+   (:file "design" :depends-on ("decls" "protocol-classes" "utils" "transforms"))
    (:file "dead-keys" :depends-on ("decls"))
    (:file "regions" :depends-on ("decls" "protocol-classes" "multiprocessing" "coordinates" "utils" "transforms" "setf-star" "design"))
    (:file "pattern" :depends-on ("decls" "protocol-classes" "utils" "design"))

--- a/Core/clim-basic/pattern.lisp
+++ b/Core/clim-basic/pattern.lisp
@@ -187,7 +187,7 @@ pattern, stencil, image etc)."))
         element)))
 
 (defclass stencil (%array-pattern)
-  ((array :type (simple-array (single-float 0.0 1.0) 2)))
+  ((array :type (simple-array (single-float 0.0f0 1.0f0) 2)))
   (:documentation "Stencil pattern provides opacity mask."))
 
 (defun make-stencil (array)


### PR DESCRIPTION
I had to fix these things in order to load McCLIM without warnings or errors.

One is due to unusual `*read-default-float-format*`, but that used to not be a problem.