### PR TITLE
provide :initform for rgb-image-pixmap

### DIFF
--- a/Backends/RasterImage/rgb-port.lisp
+++ b/Backends/RasterImage/rgb-port.lisp
@@ -21,7 +21,7 @@
 ;;;
 
 (defclass rgb-image-pixmap (image-pixmap-mixin basic-pane)
-  ())
+  ((region :initform (make-bounding-rectangle 0 0 100 100))))
 
 
 (defmethod port-allocate-pixmap ((port rgb-image-port) sheet width height)

--- a/Backends/RasterImage/rgb-port.lisp
+++ b/Backends/RasterImage/rgb-port.lisp
@@ -21,7 +21,7 @@
 ;;;
 
 (defclass rgb-image-pixmap (image-pixmap-mixin basic-pane)
-  ((region :initform (make-bounding-rectangle 0 0 100 100))))
+  ((region :initform +nowhere+)))
 
 
 (defmethod port-allocate-pixmap ((port rgb-image-port) sheet width height)


### PR DESCRIPTION
 * without this the various multiple-inheritance of rgb-image-pixmap
   results in an initform of :nil whereas the slot is designed to be a
   region, not (or null region).

 * The error only shows up (I think) when running with safety 3, but
   seems like a legitimate error.