### PR TITLE
Examples/puzzle.lisp: no longer uses non exported symbols

### DIFF
--- a/Apps/Scigraph/dwim/present.lisp
+++ b/Apps/Scigraph/dwim/present.lisp
@@ -60,16 +60,9 @@ advised of the possiblity of such damages.
 
 (defun bounding-rectangle* (presentation)
   "Get the bounding edges of the presentation."
-  (let ((stream *standard-output*))
-    ;; Seem to need to know the stream under the presentation.
-    ;; Take a wild guess.
-    (multiple-value-bind (xoff yoff)
-        (climi::convert-from-relative-to-absolute-coordinates
-         stream
-         (clim::output-record-parent presentation))
-      (clim:with-bounding-rectangle*
-          (left top right bottom) presentation
-        (values (+ left xoff) (+ top yoff) (+ right xoff) (+ bottom yoff))))))
+  (clim:with-bounding-rectangle*
+      (left top right bottom) presentation
+    (values left top right bottom)))
 
 (defun redisplay (record stream)
   (clim:redisplay record stream :check-overlapping nil))

--- a/Core/clim-core/incremental-redisplay.lisp
+++ b/Core/clim-core/incremental-redisplay.lisp
@@ -1054,13 +1054,6 @@ in an equalp hash table"))
    record
    t))
 
-(defun convert-from-relative-to-absolute-coordinates (stream record)
-  (declare (ignore stream record))
-  "This compatibility function returns offsets that are suitable for
-  drawing records that are the children of `record'. In McCLIM this is
-  a noop because output records are kept in stream coordinates."
-  (values 0 0))
-
 
 ;;; Support for explicitly changing output records
 

--- a/Examples/puzzle.lisp
+++ b/Examples/puzzle.lisp
@@ -44,15 +44,10 @@
   :inherit-from '(integer 1 15))
 
 (define-presentation-method highlight-presentation ((type puzzle-cell) record stream state)
-  state
-  (multiple-value-bind (xoff yoff)
-      (climi::convert-from-relative-to-absolute-coordinates
-       stream (output-record-parent record))
-    (with-bounding-rectangle* (left top right bottom) record
-      (draw-rectangle* stream
-		       (+ left xoff) (+ top yoff)
-		       (+ right xoff) (+ bottom yoff)
-		       :ink +flipping-ink+))))
+  (with-bounding-rectangle* (left top right bottom) record
+    (draw-rectangle* stream
+		     left top right bottom
+		     :ink +flipping-ink+)))
 
 (defun encode-puzzle-cell (row column)
   (+ (* row 4) column))
@@ -79,7 +74,7 @@
 				       :cache-value value)
 		(formatting-cell (stream :align-x :right)
 		  (unless (zerop value)
-		    (with-output-as-presentation 
+		    (with-output-as-presentation
 			(stream cell-id 'puzzle-cell)
 		      (format stream "~2D" value))))))))))))
 


### PR DESCRIPTION
I got rid of climi::convert-from-relative-to-absolute-coordinates