### PR TITLE
Fixes for render and pattern changes

### DIFF
--- a/Examples/patterns.lisp
+++ b/Examples/patterns.lisp
@@ -85,6 +85,8 @@ R: restart demo
 Q: quit application frame
 Space: redisplay application")
 
+(defvar *draw* :pattern)
+
 (defclass my-basic-pane (clim:basic-pane clime:always-repaint-background-mixin) ())
 
 (define-application-frame pattern-design-test ()
@@ -319,7 +321,6 @@ right-trimmed for spaces."
   (with-translation (pane 5 5)
     (test-example pane)))
 
-(defvar *draw* :pattern)
 (defmethod display ((frame pattern-design-test) pane &aux (draw *draw*))
   (do ((i 5 (+ i 16))
        (j 5 (+ j 16))

--- a/Examples/patterns.lisp
+++ b/Examples/patterns.lisp
@@ -16,7 +16,7 @@
 
   (let* ((array (make-array '(50 50) :initial-element 1 :element-type 'bit))
          (array2 (make-array '(20 20) :initial-element 1 :element-type 'fixnum))
-         (array3 (make-array '(50 50) :initial-element 0.0 :element-type 'single-float))
+         (array3 (make-array '(50 50) :initial-element 0.0f0 :element-type 'single-float))
          (2-designs  (list +dark-blue+ +dark-red+))
          (2-designs* (list +dark-salmon+ +dark-slate-grey+))
          (4-designs  (list +orange+ +dark-green+ +red+ +blue+))
@@ -35,7 +35,7 @@
     ;; set array3 for gradient stencil
     (dotimes (i 50)
       (dotimes (j 50)
-        (setf (aref array3 i j) (/ (+ i j) 100.0))))
+        (setf (aref array3 i j) (/ (+ i j) 100.0f0))))
 
     (defparameter *patterns*
       (list

--- a/Extensions/render/image.lisp
+++ b/Extensions/render/image.lisp
@@ -27,6 +27,8 @@
 
 ;;; Unsafe versions of COPY-IMAGE. Caller must ensure that all arguments are
 ;;; valid and arrays are of proper type.
+(declaim (inline %copy-image %copy-image*))
+
 (defun %copy-image (src-array dst-array x1s y1s x1d y1d x2 y2)
   (declare (type fixnum x1s y1s x1d y1d x2 y2)
            (type (simple-array (unsigned-byte 32) 2) src-array dst-array)
@@ -44,8 +46,6 @@
                (src-i dest-i x1s x1d x2) :backward t)
     (setf (aref dst-array dest-j dest-i)
           (aref src-array src-j src-i))))
-
-(declaim (inline %copy-image %copy-image*))
 
 ;;; XXX: We should unify it with COPY-AREA and MEDIUM-COPY-AREA. That means that
 ;;; raster images should be mediums on their own rights (aren't they?).
@@ -74,6 +74,8 @@
         #1#))
   (make-rectangle* (1- dx) (1- dy) (+ dx width) (+ dy height)))
 
+(declaim (inline %blend-image %blend-image*))
+
 (defun %blend-image (src-array dst-array x1s y1s x1d y1d x2 y2)
   (declare (type fixnum x1s y1s x1d y1d x2 y2)
            (type (simple-array (unsigned-byte 32) 2) src-array dst-array)
@@ -97,8 +99,6 @@
         (setf (aref dst-array dest-j dest-i)
               (octet-blend-function* r.fg g.fg b.fg a.fg
                                      r.bg g.bg b.bg a.bg))))))
-
-(declaim (inline %blend-image %blend-image*))
 
 (defun blend-image (src-image sx sy width height dst-image dx dy
                     &aux

--- a/Extensions/render/utilities.lisp
+++ b/Extensions/render/utilities.lisp
@@ -31,6 +31,8 @@ top-left. Useful when we iterate over the same array and mutate its state."
            (,a (ldb (byte 8 00) ,elt)))
        ,@body)))
 
+(declaim (inline %rgba->vals %vals->rgba))
+
 (defun %vals->rgba (r g b &optional (a #xff))
   (declare (type octet r g b a)
            (optimize (speed 3) (safety 0)))
@@ -44,7 +46,7 @@ top-left. Useful when we iterate over the same array and mutate its state."
           (ldb (byte 8 08) rgba)
           (ldb (byte 8 00) rgba)))
 
-(declaim (inline %rgba->vals %vals->rgba))
+(declaim (inline %check-coords %blend-octets %octet-mult))
 
 ;;; Returns T for valid arguments, NIL for malformed width/height and signals an
 ;;; error if coordinates go out of arrays bounds.
@@ -86,9 +88,7 @@ top-left. Useful when we iterate over the same array and mutate its state."
                       (byte 8 0)
                       0)))))
 
-(declaim (ftype (function (octet octet) octet) octet-mult))
+(declaim (ftype (function (octet octet) octet) %octet-mult))
 (defun %octet-mult (a b)
   (let ((temp (+ (* a b) #x80)))
     (logand #xFF (ash (+ (ash temp -8) temp) -8))))
-
-(declaim (inline %check-coords %blend-octets %octet-mult))


### PR DESCRIPTION
* The `inline` declamations in `Extensions/render/*.lisp` work better when textually preceding the functions they refer to.
* An `ftype` declamation for `%octet-mult` referred to `octet-mult` instead.
* The new `Examples/patterns.lisp` demo used float literals without exponent markers in conjunction with specialized arrays. This leads to errors with non-standard `*read-default-float-format*` values.
* The same demo referred to the `*draw*` variable before its definition.