### PR TITLE
Define getenv for clasp

### DIFF
--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -15,7 +15,8 @@
   #+openmcl (ccl::getenv string)
   #+lispworks (lw:environment-variable string)
   #+ecl (ext:getenv string)
-  #-(or ecl excl cmu scl clisp sbcl openmcl lispworks)
+  #+clasp (ext:getenv string)
+  #-(or ecl excl cmu scl clisp sbcl openmcl lispworks clasp)
   (error "GET-ENVIRONMENT-VARIABLE not implemented"))
 
 ;;; It would be nice to define this macro in terms of letf, but that


### PR DESCRIPTION
There are other errors loading mcclim in clasp, but these are errors in clasp, so I don't want to workaround in mcclim