### PR TITLE
Print object enhancements 5

### DIFF
--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -159,6 +159,17 @@
 (defclass standard-polygon (polygon)
   ((points :initarg :points)))
 
+(defmethod slots-for-pprint-object append ((object standard-polyline))
+  '(points closed))
+
+(defmethod print-object ((self standard-polyline) sink)
+  (cond
+    ((and *print-readably* (not *read-eval*))
+     (error "cannot readably print standard-polyline when not *read-eval*."))
+    ((and *print-pretty* *print-readably*)
+     (simple-pprint-object sink self))
+    (t (print-unreadable-object (self sink :identity nil :type t)))))
+
 ;;; -- 2.5.3.1 Constructors for CLIM Polygons and Polylines  -----------------
 
 (defun coord-seq->point-seq (sequence)

--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -551,12 +551,13 @@
    (tr          :initarg :tr)))         
 
 (defmethod print-object ((ell elliptical-thing) stream)
-  (with-slots (start-angle end-angle tr) ell
-    (format stream "#<~A [~A ~A] ~A>"
-            (type-of ell)
-            (and start-angle (* (/ 180 pi) start-angle))
-            (and end-angle (* (/ 180 pi) end-angle))
-            tr)))
+  (print-unreadable-object (ell stream :type t :identity t)
+    (with-slots (start-angle end-angle tr) ell
+      (format stream "~A [~A ~A] ~A"
+              (type-of ell)
+              (and start-angle (* (/ 180 pi) start-angle))
+              (and end-angle (* (/ 180 pi) end-angle))
+              tr))))
 
 (defclass standard-ellipse (elliptical-thing ellipse) ())
 (defclass standard-elliptical-arc (elliptical-thing elliptical-arc) ())

--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -113,9 +113,18 @@
     :x (coerce x 'coordinate)
     :y (coerce y 'coordinate)))
 
+(defmethod slots-for-pprint-object append ((object standard-point))
+  '(x y))
+
 (defmethod print-object ((self standard-point) sink)
-  (with-slots (x y) self
-    (format sink "#<~S ~S ~S>" 'standard-point x y)))
+  (cond
+    ((and *print-readably* (not *read-eval*))
+     (error "cannot readably print standard-point when not *read-eval*."))
+    ((and *print-pretty* *print-readably*)
+     (simple-pprint-object sink self))
+    (t (print-unreadable-object (self sink :identity nil :type t)
+         (with-slots (x y) self
+           (format sink "~S ~S" x y))))))
 
 ;;; Point protocol: point-position
 
@@ -334,9 +343,18 @@
     (multiple-value-bind (x2 y2) (line-end-point* self)
       (line-contains-point-p* x1 y1 x2 y2 x y))))
 
+(defmethod slots-for-pprint-object append ((object standard-line))
+  '(x1 y1 x2 y2))
+
 (defmethod print-object ((self standard-line) sink)
-  (with-slots (x1 y1 x2 y2) self
-    (format sink "#<~S ~D ~D ~D ~D>" (type-of self) x1 y1 x2 y2)))
+  (cond
+    ((and *print-readably* (not *read-eval*))
+     (error "cannot readably print standard-line when not *read-eval*."))
+    ((and *print-pretty* *print-readably*)
+     (simple-pprint-object sink self))
+    (t (print-unreadable-object (self sink :identity nil :type t)
+         (with-slots (x1 y1 x2 y2) self
+           (format sink "~D ~D ~D ~D" x1 y1 x2 y2))))))
 
 ;;; -- 2.5.5 Rectangles in CLIM ----------------------------------------------
 
@@ -550,14 +568,23 @@
    ;; object.
    (tr          :initarg :tr)))         
 
+(defmethod slots-for-pprint-object append ((object elliptical-thing))
+  '(start-angle end-angle tr))
+
 (defmethod print-object ((ell elliptical-thing) stream)
-  (print-unreadable-object (ell stream :type t :identity t)
-    (with-slots (start-angle end-angle tr) ell
-      (format stream "~A [~A ~A] ~A"
-              (type-of ell)
-              (and start-angle (* (/ 180 pi) start-angle))
-              (and end-angle (* (/ 180 pi) end-angle))
-              tr))))
+  (cond
+    ((and *print-readably* (not *read-eval*))
+     (error "cannot readably print elliptical-thing when not *read-eval*."))
+    ((and *print-pretty* *print-readably*)
+     (simple-pprint-object stream ell))
+    (t
+     (print-unreadable-object (ell stream :type t :identity t)
+       (with-slots (start-angle end-angle tr) ell
+         (format stream "~A [~A ~A] ~A"
+                 (type-of ell)
+                 (and start-angle (* (/ 180 pi) start-angle))
+                 (and end-angle (* (/ 180 pi) end-angle))
+                 tr))))))
 
 (defclass standard-ellipse (elliptical-thing ellipse) ())
 (defclass standard-elliptical-arc (elliptical-thing elliptical-arc) ())
@@ -799,9 +826,18 @@
                   ((and sip eip)
                    ;; region difference may not work here due to float rounding
                    (let ((guess-line (make-line p1 si)))
-                     (if (not (region-intersects-region-p guess-line end-ray))
-                         (region-union guess-line (make-line p2 ei))
-                         (region-union (make-line p1 ei) (make-line p2 si)))))
+                     (let ((intersection-line
+                            (if (not (region-intersects-region-p guess-line end-ray))
+                                (region-union guess-line (make-line p2 ei))
+                                (region-union (make-line p1 ei) (make-line p2 si)))))
+                       (if (linep intersection-line)
+                           intersection-line
+                           (progn
+                             #+nil
+                             (error "Trying to intersect line ~S with
+                         ellipse ~S returned ~S which is not a line."
+                                    line ellipse intersection-line)
+                             intersection-line)))))
                   ;; line intersect only one angle ray
                   (t (make-line (if p1p p1 p2)
                                 (if sip si ei))))))))))))

--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -168,7 +168,8 @@
      (error "cannot readably print standard-polyline when not *read-eval*."))
     ((and *print-pretty* *print-readably*)
      (simple-pprint-object sink self))
-    (t (print-unreadable-object (self sink :identity nil :type t)))))
+    (t
+     (print-unreadable-object (self sink :identity t :type t)))))
 
 ;;; -- 2.5.3.1 Constructors for CLIM Polygons and Polylines  -----------------
 

--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -2895,7 +2895,7 @@ transformation and angle are needed."
 ;;;
 
 (defmethod print-object ((self standard-rectangle) stream)
-  (print-unreadable-object (self stream :type t :identity t)
+  (print-unreadable-object (self stream :type t :identity nil)
     (with-standard-rectangle (x1 y1 x2 y2)
       self
       (format stream "X ~S:~S Y ~S:~S" x1 x2 y1 y2))))

--- a/Core/clim-basic/transforms.lisp
+++ b/Core/clim-basic/transforms.lisp
@@ -85,6 +85,19 @@ transformation protocol."))
   (:documentation
    "A transformation class which is neither the identity nor a translation."))
 
+(defmethod slots-for-pprint-object append ((object standard-hairy-transformation))
+  '(mxx mxy myx myy tx ty))
+
+(defmethod print-object ((self standard-hairy-transformation) sink)
+  (cond
+    ((and *print-readably* (not *read-eval*))
+     (error "cannot readably print standard-hairy-transformation when not *read-eval*."))
+    ((and *print-pretty* *print-readably*)
+     (simple-pprint-object sink self))
+    (t (print-unreadable-object (self sink :identity nil :type t)
+         (apply #'format sink "~S ~S ~S ~S ~S ~S"
+                (multiple-value-list (get-transformation self)))))))
+
 (defmethod print-object ((self standard-transformation) sink)
   (print-unreadable-object (self sink :identity nil :type t)
     (apply #'format sink "~S ~S ~S ~S ~S ~S"

--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -594,5 +594,7 @@ STREAM in the direction DIRECTION."
              (write-char #\: stream)
              (princ slot-name stream)
              (write-char #\Space stream)
+             (unless (atom slot-value)
+               (princ "'" stream))
              (write slot-value :stream stream))))))
 

--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -560,3 +560,39 @@ STREAM in the direction DIRECTION."
               (slot-value original slot))))
     copy))
 
+;;
+;; pretty printing
+;;
+;; This is a simplified version of the approach used by David
+;; Lichteblau for pretty-printing objects in cxml-stp/node.lip
+
+(defgeneric slots-for-pprint-object (node)
+  (:documentation "A generic function that returns the slot names of
+  objects to be pretty-printed by simple-pprint-object. Providers of
+  print-object methods that intend to use simple-pprint-object should
+  provide their own methods that return the appropriate slot-names.")
+  (:method-combination append)
+  (:method append ((object t)) nil))
+
+(defun simple-pprint-object (stream object)
+  (let ((slots (mapcan (lambda (slot)
+			 (let ((value (slot-value object slot)))
+			   (list (list slot value))))
+		       (slots-for-pprint-object object))))
+    (with-slots (start-angle end-angle tr)
+        object
+      (pprint-logical-block (stream (list object) :prefix "#.(" :suffix ")")
+        (write (intern "MAKE-INSTANCE" *package*) :stream stream)
+        (write-char #\Space stream)
+        (write-char #\' stream)
+        (write (class-name (class-of object)) :stream stream)
+        ;; now print :slot-name slot-value for each slot
+        (loop for (slot-name slot-value) in slots
+           do
+             (write-char #\Space stream)
+             (pprint-newline :fill stream)
+             (write-char #\: stream)
+             (princ slot-name stream)
+             (write-char #\Space stream)
+             (write slot-value :stream stream))))))
+


### PR DESCRIPTION
These commits allow for printing some CLIM objects readably when *print-readably* is t.