### PR TITLE
Add Dejavu font path for OpenSUSE

### DIFF
--- a/Extensions/fonts/fontconfig.lisp
+++ b/Extensions/fonts/fontconfig.lisp
@@ -24,7 +24,7 @@
   (find-if #'probe-file
            '(#p"/usr/share/fonts/truetype/ttf-dejavu/"
              #p"/usr/share/fonts/truetype/dejavu/"
-	     #p"/usr/share/fonts/truetype/"
+             #p"/usr/share/fonts/truetype/"
              #p"/usr/share/fonts/TTF/"
              #p"/usr/share/fonts/"
              #p"/usr/local/share/fonts/dejavu/"

--- a/Extensions/fonts/fontconfig.lisp
+++ b/Extensions/fonts/fontconfig.lisp
@@ -24,6 +24,7 @@
   (find-if #'probe-file
            '(#p"/usr/share/fonts/truetype/ttf-dejavu/"
              #p"/usr/share/fonts/truetype/dejavu/"
+	     #p"/usr/share/fonts/truetype/"
              #p"/usr/share/fonts/TTF/"
              #p"/usr/share/fonts/"
              #p"/usr/local/share/fonts/dejavu/"


### PR DESCRIPTION
While loading McCLIM under OpenSUSE, it prompted an error "McCLIM was unable to configure it self automatically using fontconfig." I found the DejaVu fonts are in a directory that isn't be listed in *truetype-font-path*, so a add the directory to it, then problem solved.