### PR TITLE
Scigraph: bug fix

### DIFF
--- a/Apps/Scigraph/scigraph/frame.lisp
+++ b/Apps/Scigraph/scigraph/frame.lisp
@@ -72,9 +72,7 @@ class.  So you should do the following (in the ws package, 'natch):
    (display :application
 	    :display-function 'redisplay-graphs
 	    :display-time t
-	    :text-style 
-	    (parse-text-style '(:fix :roman :normal))
-	    ;; :initial-cursor-visibility nil
+	    :text-style (parse-text-style '(:fix :roman :normal))
 	    :scroll-bars t))
   (:pointer-documentation t)
   (:layouts

--- a/Apps/Scigraph/scigraph/frame.lisp
+++ b/Apps/Scigraph/scigraph/frame.lisp
@@ -74,7 +74,7 @@ class.  So you should do the following (in the ws package, 'natch):
 	    :display-time t
 	    :text-style 
 	    (parse-text-style '(:fix :roman :normal))
-	    :initial-cursor-visibility nil
+	    ;; :initial-cursor-visibility nil
 	    :scroll-bars t))
   (:pointer-documentation t)
   (:layouts


### PR DESCRIPTION
Simple bug fix for Scigraph. 

Invalid initialization argument:
  :INITIAL-CURSOR-VISIBILITY

:initial-cursor-visibility initarg is not accepted in application-pane  initialization and it is not in the specification.

Before commit 
9434255f * bad protocol-classes: remove runtime overhead, restore initarg checking

this didn't produce an error, now it does.