### PR TITLE
remove :borders arg from make-pane call in ESA

### DIFF
--- a/Libraries/ESA/esa.lisp
+++ b/Libraries/ESA/esa.lisp
@@ -82,8 +82,7 @@ will probably have the same value as `*application-frame*'.")
   ((master-pane :initarg :master-pane :reader master-pane))
   (:default-initargs
       :background +gray85+
-      :scroll-bars nil
-      :borders nil))
+      :scroll-bars nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; 


### PR DESCRIPTION
 * The :borders argument that used to be here triggers an error when
   one tries to create an esa::info-pane (as Gsharp does). I don't
   know if this ever worked (presumably it must have) but in the
   current McCLIM, :borders is not an initarg to info-pane, or its
   superclass application-pane. Removing the :borders arg from the
   :default-initargs allows Gsharp to run. Without doing so, we get an
   error.