### PR TITLE
ESA pane subclass :default-initargs fixes

### DIFF
--- a/Libraries/ESA/esa.lisp
+++ b/Libraries/ESA/esa.lisp
@@ -81,9 +81,7 @@ will probably have the same value as `*application-frame*'.")
 (defclass info-pane (application-pane)
   ((master-pane :initarg :master-pane :reader master-pane))
   (:default-initargs
-      :background +gray85+
-      :scroll-bars nil
-      :borders nil))
+   :background +gray85+))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; 
@@ -109,7 +107,6 @@ message is supposed to be displayed in the minibuffer.")
                  :documentation "The universal time at which the
 current message was set."))
   (:default-initargs
-   :scroll-bars nil
    :display-function 'display-minibuffer
    :display-time :command-loop
    :incremental-redisplay t))


### PR DESCRIPTION
 * remove :borders arg and :scroll-bars from ESA application-pane
   subclass :default-initargs. The spec and our current code don't
   explicitly allow for this. Whether they should allow this or not is
   another issue and there is a separate Issue open to address this
   <https://github.com/McCLIM/McCLIM/issues/628>. In the meantime, fix
   the default :initargs so ESA panes work with current McCLIM.