### PR TITLE
Box adjuster improvements

### DIFF
--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -1015,7 +1015,7 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
     :initarg       :fillp
     :initform      nil
     :reader        box-client-fillp
-    :documentation "Whether this child can stretch infinitly.")
+    :documentation "Whether this child can stretch infinitely.")
    (fixed-size
     :initarg       :fixed-size
     :initform      nil

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -1014,17 +1014,17 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
   ((fillp
     :initarg       :fillp
     :initform      nil
-    :reader        box-client-fillp
+    :accessor      box-client-fillp
     :documentation "Whether this child can stretch infinitely.")
    (fixed-size
     :initarg       :fixed-size
     :initform      nil
-    :reader        box-client-fixed-size
+    :accessor      box-client-fixed-size
     :documentation "Possible fixed size of a child.")
    (proportion
     :initarg       :proportion
     :initform      nil
-    :reader        box-client-proportion
+    :accessor      box-client-proportion
     :documentation "Proportion child should get of excess space.")
    (pane
     :initarg       :pane


### PR DESCRIPTION
This re-implementation uses a different approach: instead of tweaking the space requirements of the left and right client, the box client strategies (fixed size, proportional size, fill) are adjusted in a way that reserves the general strategy (e.g. a client using fill above a client using proportional) but changes the parameters.

Furthermore, instead of tracking an offset from the start point of the drag, the pointer position in the coordinate system of the left child is tracked. This is necessary for the implementation strategy described above.