### PR TITLE
README.md improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-<h1 align="center"> <br> 
-<a href="https://common-lisp.net/project/mcclim/">
-<img src="https://common-lisp.net/project/mcclim/img/mcclim.png"
-alt="McCLIM">
-</a> 
-<br> McCLIM 0.9.8-dev post-"Imbolc"
-<br> </h1>
+# ![logo](https://common-lisp.net/project/mcclim/img/mcclim.png)
+
+## [McCLIM](https://common-lisp.net/project/mcclim/) Version 0.9.8-dev post-"Imbolc"
 
 McCLIM, an implementation of the "[Common Lisp Interface Manager CLIM
 II Specification](http://bauhh.dyndns.org:8000/clim-spec/index.html)",
@@ -12,21 +8,21 @@ is a portable and high-level user interface management system toolkit
 for Common Lisp. It has a powerful presentation model which allows us
 to directly link the visual representation of an object to its
 semantics. It has several high-level programming capabilities that
-enable us to develop a user interface conveniently; including formatted
-output, graphics, windowing and commands that are invoked by typing
-text, keyboard shortcuts or clicking a mouse button.
+enable us to develop a user interface conveniently; including
+formatted output, graphics, windowing and commands that are invoked by
+typing text, keyboard shortcuts or clicking a mouse button.
 
 McCLIM works with Allegro CL, Clozure CL, CLISP, CMUCL, Embeddable CL,
 the Scieneer CL Common-lisp, SBCL and the LispWorks implementations.
 Right now the only backend supported by McCLIM is CLX, which ties it
-to the Xserver on the host system. Any platform capable of running 
+to the Xserver on the host system. Any platform capable of running
 Xserver may run McCLIM applications.
 
 ### Installing McCLIM
 McCLIM is available on
 [`Quicklisp`](https://www.quicklisp.org/beta/). Make sure you have
 installed a supported Common Lisp implementation and `Quicklisp` is
-configured correctly. Then, McCLIM can be installed by entering the 
+configured correctly. Then, McCLIM can be installed by entering the
 following in your REPL:
 
 ```lisp
@@ -42,8 +38,8 @@ and run the example browser application:
 ```
 
 ### An Example
-1) Quickload McCLIM by running `(ql:quickload "mcclim")`.
-2) Put the following code in a file `example.lisp`.
+1. Quickload McCLIM by running `(ql:quickload "mcclim")`.
+2. Put the following code in a file `example.lisp`.
 ```lisp
 (in-package :common-lisp-user)
 
@@ -71,7 +67,7 @@ and run the example browser application:
 (defun app-main ()
   (run-frame-top-level (make-application-frame 'superapp)))
 ```
-3) Load the file and run:
+3. Load the file and run:
 ```lisp
 (app:app-main)
 ```
@@ -86,13 +82,13 @@ resources are listed on [CLiki](http://www.cliki.net/CLIM) and McCLIM
 
 ### Subdirectory Overview
  - **Apps** - sample applications. This includes:
-   1) Apps/Debugger - Peter Mechleborg's debugger (similar to Slime's).
-   2) Apps/Functional-Geometry - Frank Buss and Rainer Joswig's functional
+   1. Apps/Debugger - Peter Mechleborg's debugger (similar to Slime's).
+   2. Apps/Functional-Geometry - Frank Buss and Rainer Joswig's functional
 	   geometry package for drawing "Escher" tiles.
-   3) Apps/Inspector - Robert Strandh's inspector (similar to
+   3. Apps/Inspector - Robert Strandh's inspector (similar to
    slime's).
-   4) Apps/Listener - Andy Hefner's Lisp Listener.
-   5) Scigraph - BBN's graphing package.
+   4. Apps/Listener - Andy Hefner's Lisp Listener.
+   5. Scigraph - BBN's graphing package.
  - **Documentation** - Contains available documentation such as
    Documentation for Libraries `Drei` and `ESA`, A Guided Tour of
    CLIM, Specification in LATEX source and Manual in LATEX and texinfo


### PR DESCRIPTION
 * Replaced the inline HTML with actual markdown. We lose the
   centering, but gain the ability to have Markdown parsers actually
   successfully parse the README.md file, which is particularly nice
   for eval'ing the lisp code directly out of README.md.

 * fix some long line/line ending spaces

 * Use markdown numbered lists (1., 2., , etc...) instead of 1), 2), etc...