### PR TITLE
Make PARSE-SPACE handle all real numbers

### DIFF
--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -462,7 +462,7 @@ STREAM in the direction DIRECTION."
   ;; extended-output stream is also a sheet and has a graft. 
   ;; --GB 2002-08-14
   (etypecase specification
-    (integer specification)
+    (real specification)
     ((or string character) (multiple-value-bind (width height)
                                (text-size stream (string specification))
                              (ecase direction


### PR DESCRIPTION
Previously PARSE-SPACE will raise an error if the specification was a
non-integer number. This was the case even if the number is a floating
point number with a zero fractional part. The error is raised by a
call to ETYPECASE which checks for an integer.

This can happen if one sets a font size to fractional size and
attempts to display a FORMATTING-TABLE. The implementation of
FORMATTING-TABLE reads the STREAM-VERTICAL-SPACING, which is now a
floating-point number and passes it to PARSE-SPACE.

This fix changes the check from INTEGER to REAL so that any kind of
number is supported.