### PR TITLE
cleanup: don't muffle style-warnings

### DIFF
--- a/Core/clim-basic/stream-output.lisp
+++ b/Core/clim-basic/stream-output.lisp
@@ -397,22 +397,20 @@ STREAM-STRING-WIDTH will be called."))
     (declare (ignore y))
     (zerop x)))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro with-room-for-graphics ((&optional (stream t)
-                                               &rest arguments
-                                               &key (first-quadrant t)
-                                               height
-                                               (move-cursor t)
-                                               (record-type ''standard-sequence-output-record))
-                                     &body body)
-    (declare (ignore first-quadrant height move-cursor record-type))
-    (let ((cont (gensym "CONT."))
-          (stream (stream-designator-symbol stream '*standard-output*)))
-      `(labels ((,cont (,stream)
-                  ,@body))
-         (declare (dynamic-extent #',cont))
-         (invoke-with-room-for-graphics #',cont ,stream ,@arguments)))))
+(defmacro with-room-for-graphics ((&optional (stream t)
+                                             &rest arguments
+                                             &key (first-quadrant t)
+                                             height
+                                             (move-cursor t)
+                                             (record-type ''standard-sequence-output-record))
+                                  &body body)
+  (declare (ignore first-quadrant height move-cursor record-type))
+  (let ((cont (gensym "CONT."))
+        (stream (stream-designator-symbol stream '*standard-output*)))
+    `(labels ((,cont (,stream)
+                ,@body))
+       (declare (dynamic-extent #',cont))
+       (invoke-with-room-for-graphics #',cont ,stream ,@arguments))))
 
 (defmacro with-end-of-line-action ((stream action) &body body)
   (when (eq stream t)

--- a/Core/clim-core/bordered-output.lisp
+++ b/Core/clim-core/bordered-output.lisp
@@ -102,19 +102,17 @@
     (with-bounding-rectangle* (left top right bottom) ,record
       ,@body)))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro surrounding-output-with-border
-      ((&optional stream &rest drawing-options &key (shape :rectangle)
-                  (move-cursor t)
-                  &allow-other-keys)
-        &body body)
-    (declare (ignore shape move-cursor))
-    (setf stream (stream-designator-symbol stream '*standard-output*))
-    (gen-invoke-trampoline 'invoke-surrounding-output-with-border
-                           (list stream)
-                           drawing-options
-                           body)))
+(defmacro surrounding-output-with-border
+    ((&optional stream &rest drawing-options &key (shape :rectangle)
+                (move-cursor t)
+                &allow-other-keys)
+     &body body)
+  (declare (ignore shape move-cursor))
+  (setf stream (stream-designator-symbol stream '*standard-output*))
+  (gen-invoke-trampoline 'invoke-surrounding-output-with-border
+                         (list stream)
+                         drawing-options
+                         body))
 
 (defmethod recompute-extent-for-changed-child
     ((record bordered-output-record) child x1 y1 x2 y2)

--- a/Core/clim-core/incremental-redisplay.lisp
+++ b/Core/clim-core/incremental-redisplay.lisp
@@ -1087,39 +1087,33 @@ in an equalp hash table"))
 	(propagate-to-updating-output
 	 parent child mode old-bounding-rectangle)))))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defgeneric note-output-record-child-changed
-      (record child mode old-position old-bounding-rectangle stream
-       &optional erases moves draws erase-overlapping move-overlapping
-       &key check-overlapping)))
+(defgeneric note-output-record-child-changed
+    (record child mode old-position old-bounding-rectangle stream
+     &optional erases moves draws erase-overlapping move-overlapping
+     &key check-overlapping))
 
 ;;; The default - do nothing
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmethod note-output-record-child-changed
-      (record child mode old-position old-bounding-rectangle stream
-       &optional erases moves draws erase-overlapping move-overlapping
-       &key check-overlapping)
-    (declare (ignore record child mode old-position old-bounding-rectangle stream
-                     erases moves draws erase-overlapping move-overlapping
-                     check-overlapping))
-    nil))
+(defmethod note-output-record-child-changed
+    (record child mode old-position old-bounding-rectangle stream
+     &optional erases moves draws erase-overlapping move-overlapping
+     &key check-overlapping)
+  (declare (ignore record child mode old-position old-bounding-rectangle stream
+                   erases moves draws erase-overlapping move-overlapping
+                   check-overlapping))
+  nil)
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmethod note-output-record-child-changed
-      (record (child displayed-output-record) (mode (eql :move))
-       old-position old-bounding-rectangle
-       (stream updating-output-stream-mixin)
-       &optional erases moves draws erase-overlapping move-overlapping
-       &key (check-overlapping t))
-    (declare (ignore old-position erases moves draws erase-overlapping
-                     move-overlapping
-                     check-overlapping))
-    (when (stream-redisplaying-p stream)
-      (propagate-to-updating-output record child  mode old-bounding-rectangle))))
+(defmethod note-output-record-child-changed
+    (record (child displayed-output-record) (mode (eql :move))
+     old-position old-bounding-rectangle
+     (stream updating-output-stream-mixin)
+     &optional erases moves draws erase-overlapping move-overlapping
+     &key (check-overlapping t))
+  (declare (ignore old-position erases moves draws erase-overlapping
+                   move-overlapping
+                   check-overlapping))
+  (when (stream-redisplaying-p stream)
+    (propagate-to-updating-output record child  mode old-bounding-rectangle)))
 
 (defmethod* (setf output-record-position) :around
     (nx ny (record displayed-output-record))

--- a/Core/clim-core/input-editing.lisp
+++ b/Core/clim-core/input-editing.lisp
@@ -187,26 +187,24 @@ gesture, otherwise returns false."
 	do (return t)
 	finally (return nil)))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro with-input-editor-typeout ((&optional (stream t) &rest args
-                                                  &key erase)
-                                        &body body)
-    "Clear space above the input-editing stream `stream' and
+(defmacro with-input-editor-typeout ((&optional (stream t) &rest args
+                                                &key erase)
+                                     &body body)
+  "Clear space above the input-editing stream `stream' and
 evaluate `body', capturing output done to `stream'. Place will be
 obtained above the input-editing area and the output put
 there. Nothing will be displayed until `body' finishes. `Stream'
 is not evaluated and must be a symbol. If T (the default),
 `*standard-input*' will be used. `Stream' will be bound to an
 `extended-output-stream' while `body' is being evaluated."
-    (declare (ignore erase))
-    (check-type stream symbol)
-    (let ((stream (if (eq stream t) '*standard-output* stream)))
-      `(invoke-with-input-editor-typeout
-        ,stream
-        #'(lambda (,stream)
-            ,@body)
-        ,@args))))
+  (declare (ignore erase))
+  (check-type stream symbol)
+  (let ((stream (if (eq stream t) '*standard-output* stream)))
+    `(invoke-with-input-editor-typeout
+      ,stream
+      #'(lambda (,stream)
+          ,@body)
+      ,@args)))
 
 (defgeneric invoke-with-input-editor-typeout (stream continuation &key erase)
   (:documentation "Call `continuation' with a single argument, a
@@ -279,14 +277,12 @@ defaulting to T for `*standard-output*'."
   (with-input-editor-typeout (stream :erase t)
     (declare (ignore stream))))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro with-input-editing ((&optional (stream t)
-                                           &rest args
-                                           &key input-sensitizer (initial-contents "")
-                                           (class ''standard-input-editing-stream))
-                                 &body body)
-    "Establishes a context in which the user can edit the input
+(defmacro with-input-editing ((&optional (stream t)
+                                         &rest args
+                                         &key input-sensitizer (initial-contents "")
+                                         (class ''standard-input-editing-stream))
+                              &body body)
+  "Establishes a context in which the user can edit the input
 typed in on the interactive stream `stream'. `Body' is then
 executed in this context, and the values returned by `body' are
 returned as the values of `with-input-editing'. `Body' may have
@@ -312,13 +308,13 @@ is a string, the string will be inserted into the input buffer
 using `replace-input'. If it is a list, the printed
 representation of the object will be inserted into the input
 buffer using `presentation-replace-input'."
-    (setq stream (stream-designator-symbol stream '*standard-input*))
-    (with-keywords-removed (args (:input-sensitizer :initial-contents :class))
-      `(invoke-with-input-editing ,stream
-                                  #'(lambda (,stream) ,@body)
-                                  ,input-sensitizer ,initial-contents
-                                  ,class
-                                  ,@args))))
+  (setq stream (stream-designator-symbol stream '*standard-input*))
+  (with-keywords-removed (args (:input-sensitizer :initial-contents :class))
+    `(invoke-with-input-editing ,stream
+                                #'(lambda (,stream) ,@body)
+                                ,input-sensitizer ,initial-contents
+                                ,class
+                                ,@args)))
 
 (defmacro with-input-position ((stream) &body body)
   (let ((stream-var (gensym "STREAM")))

--- a/Core/clim-core/menu-choose.lisp
+++ b/Core/clim-core/menu-choose.lisp
@@ -172,21 +172,19 @@
 
 ;; Spec macro.
 ;; The menu is not visible.
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro with-menu ((menu &optional associated-window
-                             &key (deexpose t) label scroll-bars)
-                             &body body)
-    (check-type menu symbol)
-    (with-gensyms (with-menu-cont)
-      `(flet ((,with-menu-cont (,menu)
-                ,@body))
-         (declare (dynamic-extent #',with-menu-cont))
-         (invoke-with-menu #',with-menu-cont
-                           ,associated-window ; XXX
-                           ',deexpose         ; XXX!!!
-                           ,label
-                           ,scroll-bars)))))
+(defmacro with-menu ((menu &optional associated-window
+                           &key (deexpose t) label scroll-bars)
+                     &body body)
+  (check-type menu symbol)
+  (with-gensyms (with-menu-cont)
+    `(flet ((,with-menu-cont (,menu)
+              ,@body))
+       (declare (dynamic-extent #',with-menu-cont))
+       (invoke-with-menu #',with-menu-cont
+                         ,associated-window ; XXX
+                         ',deexpose         ; XXX!!!
+                         ,label
+                         ,scroll-bars))))
 
 (defun invoke-with-menu (continuation associated-window deexpose
 			 label scroll-bars)

--- a/Core/clim-core/pointer-tracking.lisp
+++ b/Core/clim-core/pointer-tracking.lisp
@@ -294,17 +294,15 @@
 	     (funcall feedback-event-fn record stream x0 y0 x y event)
 	     (return-from drag-output-record (values x y)))))))))
   
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro dragging-output ((&optional (stream '*standard-output*) &rest args
-                                        &key (repaint t) finish-on-release multiple-window)
-                              &body body)
-    (declare (ignore repaint finish-on-release multiple-window))
-    (setq stream (stream-designator-symbol stream '*standard-output*))
-    (with-gensyms (record)
-      `(let ((,record (with-output-to-output-record (,stream)
-                        ,@body)))
-         (drag-output-record ,stream ,record :erase-final t ,@args)))))
+(defmacro dragging-output ((&optional (stream '*standard-output*) &rest args
+                                      &key (repaint t) finish-on-release multiple-window)
+                           &body body)
+  (declare (ignore repaint finish-on-release multiple-window))
+  (setq stream (stream-designator-symbol stream '*standard-output*))
+  (with-gensyms (record)
+    `(let ((,record (with-output-to-output-record (,stream)
+                      ,@body)))
+       (drag-output-record ,stream ,record :erase-final t ,@args))))
 
 (defun dragging-drawing (stream drawer &key (finish-on-release t)
                          (pointer (port-pointer (port stream)))

--- a/Core/clim-core/presentation-defs.lisp
+++ b/Core/clim-core/presentation-defs.lisp
@@ -380,30 +380,28 @@ otherwise return false."
     (type-key parameters options object type stream view
      &key &allow-other-keys))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defun present (object &optional (type (presentation-type-of object))
-                         &key
-                           (stream *standard-output*)
-                           (view (stream-default-view stream))
-                           modifier
-                           acceptably
-                           (for-context-type type)
-                           single-box
-                           (allow-sensitive-inferiors t)
-                           (sensitive t)
-                           (record-type 'standard-presentation))
-    (let* ((real-type (expand-presentation-type-abbreviation type))
-           (context-type (if (eq for-context-type type)
-                             real-type
-                             (expand-presentation-type-abbreviation
-                              for-context-type))))
-      (stream-present stream object real-type
-                      :view view :modifier modifier :acceptably acceptably
-                      :for-context-type context-type :single-box single-box
-                      :allow-sensitive-inferiors allow-sensitive-inferiors
-                      :sensitive sensitive
-                      :record-type record-type))))
+(defun present (object &optional (type (presentation-type-of object))
+                &key
+                  (stream *standard-output*)
+                  (view (stream-default-view stream))
+                  modifier
+                  acceptably
+                  (for-context-type type)
+                  single-box
+                  (allow-sensitive-inferiors t)
+                  (sensitive t)
+                  (record-type 'standard-presentation))
+  (let* ((real-type (expand-presentation-type-abbreviation type))
+         (context-type (if (eq for-context-type type)
+                           real-type
+                           (expand-presentation-type-abbreviation
+                            for-context-type))))
+    (stream-present stream object real-type
+                    :view view :modifier modifier :acceptably acceptably
+                    :for-context-type context-type :single-box single-box
+                    :allow-sensitive-inferiors allow-sensitive-inferiors
+                    :sensitive sensitive
+                    :record-type record-type)))
 
 (defgeneric stream-present (stream object type
                             &key view modifier acceptably for-context-type
@@ -453,34 +451,32 @@ otherwise return false."
    :acceptably acceptably :for-context-type for-context-type)
   nil)
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defun present-to-string (object &optional (type (presentation-type-of object))
-                                   &key (view +textual-view+)
-                                        acceptably
-                                        (for-context-type type)
-                                        (string nil stringp)
-                                        (index 0 indexp))
-    (let* ((real-type (expand-presentation-type-abbreviation type))
-           (context-type (if (eq for-context-type type)
-                             real-type
-                             (expand-presentation-type-abbreviation
-                              for-context-type))))
-      (when (and stringp indexp)
-        (setf (fill-pointer string) index))
-      (flet ((do-present (s)
-               (stream-present s object real-type
-                               :view view :acceptably acceptably
-                               :for-context-type context-type)))
-        (declare (dynamic-extent #'do-present))
-        (let ((result (if stringp
-                          (with-output-to-string (stream string)
-                            (do-present stream))
-                          (with-output-to-string (stream)
-                            (do-present stream)))))
-          (if stringp
-              (values string (fill-pointer string))
-              result))))))
+(defun present-to-string (object &optional (type (presentation-type-of object))
+                          &key (view +textual-view+)
+                            acceptably
+                            (for-context-type type)
+                            (string nil stringp)
+                            (index 0 indexp))
+  (let* ((real-type (expand-presentation-type-abbreviation type))
+         (context-type (if (eq for-context-type type)
+                           real-type
+                           (expand-presentation-type-abbreviation
+                            for-context-type))))
+    (when (and stringp indexp)
+      (setf (fill-pointer string) index))
+    (flet ((do-present (s)
+             (stream-present s object real-type
+                             :view view :acceptably acceptably
+                             :for-context-type context-type)))
+      (declare (dynamic-extent #'do-present))
+      (let ((result (if stringp
+                        (with-output-to-string (stream string)
+                          (do-present stream))
+                        (with-output-to-string (stream)
+                          (do-present stream)))))
+        (if stringp
+            (values string (fill-pointer string))
+            result)))))
 
 ;;; I believe this obsolete... --moore
 (defmethod presentation-replace-input

--- a/Core/clim-core/table-formatting.lisp
+++ b/Core/clim-core/table-formatting.lisp
@@ -89,25 +89,23 @@
    :min-width (parse-space stream min-width :horizontal)
    :min-height (parse-space stream min-height :vertical)))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro formatting-cell ((&optional (stream t)
-                                        &rest more
-                                        &key align-x align-y
-                                        (min-width 0) (min-height 0)
-                                        (record-type ''standard-cell-output-record))
-                             &body body)
-    (declare (ignorable align-x align-y))
-    (setq stream (stream-designator-symbol stream '*standard-output*))
-    (with-keywords-removed (more (:record-type :min-width :min-height))
-      (with-gensyms (record)
-        ;; Blow off order-of-evaluation issues for the moment...
-        `(with-new-output-record
-             (,stream ,record-type ,record ,@more
-                      :min-width (parse-space ,stream ,min-width :horizontal)
-                      :min-height (parse-space ,stream ,min-height :vertical))
-           (letf (((stream-cursor-position ,stream) (values 0 0)))
-             ,@body))))))
+(defmacro formatting-cell ((&optional (stream t)
+                                      &rest more
+                                      &key align-x align-y
+                                      (min-width 0) (min-height 0)
+                                      (record-type ''standard-cell-output-record))
+                           &body body)
+  (declare (ignorable align-x align-y))
+  (setq stream (stream-designator-symbol stream '*standard-output*))
+  (with-keywords-removed (more (:record-type :min-width :min-height))
+    (with-gensyms (record)
+      ;; Blow off order-of-evaluation issues for the moment...
+      `(with-new-output-record
+           (,stream ,record-type ,record ,@more
+                    :min-width (parse-space ,stream ,min-width :horizontal)
+                    :min-height (parse-space ,stream ,min-height :vertical))
+         (letf (((stream-cursor-position ,stream) (values 0 0)))
+               ,@body)))))
 
 
 ;;; Generic block formatting
@@ -165,17 +163,15 @@ to a table cell within the row."))
                                (row-record standard-row-output-record))
   (map-over-block-cells function row-record))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro formatting-row ((&optional (stream t)
-                                       &rest more
-                                       &key (record-type ''standard-row-output-record))
-                            &body body)
-    (setf stream (stream-designator-symbol stream '*standard-output*))
-    (with-gensyms (record)
-      (with-keywords-removed (more (:record-type))
-        `(with-new-output-record (,stream ,record-type ,record ,@more)
-           ,@body)))))
+(defmacro formatting-row ((&optional (stream t)
+                                     &rest more
+                                     &key (record-type ''standard-row-output-record))
+                          &body body)
+  (setf stream (stream-designator-symbol stream '*standard-output*))
+  (with-gensyms (record)
+    (with-keywords-removed (more (:record-type))
+      `(with-new-output-record (,stream ,record-type ,record ,@more)
+         ,@body))))
 
 (defgeneric invoke-formatting-row (stream cont record-type &rest initargs))
 
@@ -204,18 +200,16 @@ corresponding to a table cell within the column."))
 (defmethod map-over-column-cells (function (column-record standard-column-output-record))
   (map-over-block-cells function column-record))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro formatting-column ((&optional (stream t)
-                                          &rest more
-                                          &key (record-type
-                                                ''standard-column-output-record))
-                               &body body)
-    (setf stream (stream-designator-symbol stream '*standard-output*))
-    (with-gensyms (record)
-      (with-keywords-removed (more (:record-type))
-        `(with-new-output-record (,stream ,record-type ,record ,@more)
-           ,@body)))))
+(defmacro formatting-column ((&optional (stream t)
+                                        &rest more
+                                        &key (record-type
+                                              ''standard-column-output-record))
+                             &body body)
+  (setf stream (stream-designator-symbol stream '*standard-output*))
+  (with-gensyms (record)
+    (with-keywords-removed (more (:record-type))
+      `(with-new-output-record (,stream ,record-type ,record ,@more)
+         ,@body))))
 
 (defgeneric invoke-formatting-column (stream cont record-type &rest initargs))
 
@@ -273,25 +267,23 @@ skips intervening non-table output record structures."))
                 (replay-output-record record stream region x-offset y-offset))
             (nreverse other-records)))))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro formatting-table ((&optional (stream t)
-                                         &rest args
-                                         &key x-spacing y-spacing
-                                         multiple-columns
-                                         multiple-columns-x-spacing
-                                         equalize-column-widths (move-cursor t)
-                                         (record-type ''standard-table-output-record)
-                                         &allow-other-keys)
-                              &body body)
-    (declare (ignore x-spacing y-spacing multiple-columns
-                     multiple-columns-x-spacing
-                     equalize-column-widths move-cursor record-type))
-    (gen-invoke-trampoline 'invoke-formatting-table
-                           (list (stream-designator-symbol stream
-                                                           '*standard-output*))
-                           args
-                           body)))
+(defmacro formatting-table ((&optional (stream t)
+                                       &rest args
+                                       &key x-spacing y-spacing
+                                       multiple-columns
+                                       multiple-columns-x-spacing
+                                       equalize-column-widths (move-cursor t)
+                                       (record-type ''standard-table-output-record)
+                                       &allow-other-keys)
+                            &body body)
+  (declare (ignore x-spacing y-spacing multiple-columns
+                   multiple-columns-x-spacing
+                   equalize-column-widths move-cursor record-type))
+  (gen-invoke-trampoline 'invoke-formatting-table
+                         (list (stream-designator-symbol stream
+                                                         '*standard-output*))
+                         args
+                         body))
 
 (defun invoke-formatting-table
     (stream continuation
@@ -466,26 +458,24 @@ skips intervening non-table output record structures."))
                       items))
              args))))
 
-(locally
-    (declare #+sbcl (sb-ext:muffle-conditions style-warning))
-  (defmacro formatting-item-list ((&optional (stream t)
-                                             &rest args
-                                             &key x-spacing y-spacing n-columns n-rows
-                                             stream-width stream-height
-                                             max-width max-height
-                                             initial-spacing (row-wise t) (move-cursor t)
-                                             record-type &allow-other-keys)
-                                  &body body)
-    (declare (ignore x-spacing y-spacing n-columns n-rows
-                     stream-width stream-height
-                     max-width max-height
-                     initial-spacing row-wise move-cursor
-                     record-type))
-    (setf stream (stream-designator-symbol stream '*standard-output*))
-    (gen-invoke-trampoline 'invoke-format-item-list
-                           (list stream)
-                           args
-                           body)))
+(defmacro formatting-item-list ((&optional (stream t)
+                                           &rest args
+                                           &key x-spacing y-spacing n-columns n-rows
+                                           stream-width stream-height
+                                           max-width max-height
+                                           initial-spacing (row-wise t) (move-cursor t)
+                                           record-type &allow-other-keys)
+                                &body body)
+  (declare (ignore x-spacing y-spacing n-columns n-rows
+                   stream-width stream-height
+                   max-width max-height
+                   initial-spacing row-wise move-cursor
+                   record-type))
+  (setf stream (stream-designator-symbol stream '*standard-output*))
+  (gen-invoke-trampoline 'invoke-format-item-list
+                         (list stream)
+                         args
+                         body))
 
 ;;; Helper function
 


### PR DESCRIPTION
While I get the sentiment that &key and &optional are something what will stay
in codebase (because that's how CLIM is specified) so we don't need
style-warnings about that, these local declarations muffle *all* style warnings
what is plain wrong.

These are legitimate style warnings anyway and I see nothing wrong with the fact
it is signalled. Commit doesn't introduce any functional changes, just removes
(locally (declare (sb-ext:muffle-conditions style-warning)) …) declarations.