### PR TITLE
Gadget views

### DIFF
--- a/Core/clim-basic/views.lisp
+++ b/Core/clim-basic/views.lisp
@@ -44,34 +44,6 @@
 (defclass pointer-documentation-view (textual-view)
   ())
 
-;;; Views described in the Franz User manual (CLIM 2.2)...
-
-(defclass toggle-button-view (gadget-view)
-  ())
-
-(defclass push-button-view (gadget-view)
-  ())
-
-(defclass radio-box-view (gadget-view)
-  ())
-
-(defclass check-box-view (gadget-view)
-  ())
-
-(defclass slider-view (gadget-view)
-  ())
-
-(defclass text-field-view (gadget-dialog-view)
-  ((width :accessor width :initarg :width :initform nil)))
-
-(defclass text-editor-view (gadget-view)
-  ())
-
-(defclass list-pane-view (gadget-view)
-  ((visible-items :accessor visible-items :initarg :visible-items)))
-
-(defclass option-pane-view (gadget-view)
-  ())
 
 (defparameter +textual-view+ (make-instance 'textual-view))
 
@@ -87,21 +59,6 @@
 
 (defparameter +pointer-documentation-view+ (make-instance 'pointer-documentation-view))
 
-(defparameter +toggle-button-view+ (make-instance 'toggle-button-view))
-
-(defparameter +push-button-view+ (make-instance 'push-button-view))
-
-(defparameter +radio-box-view+ (make-instance 'radio-box-view))
-
-(defparameter +slider-view+ (make-instance 'slider-view))
-
-(defparameter +text-field-view+ (make-instance 'text-field-view))
-
-(defparameter +text-editor-view+ (make-instance 'text-editor-view))
-
-(defparameter +list-pane-view+ (make-instance 'list-pane-view))
-
-(defparameter +option-pane-view+ (make-instance 'option-pane-view))
 
 (defmethod stream-default-view (stream)
   (declare (ignore stream))

--- a/Core/clim-core/clim-core.asd
+++ b/Core/clim-core/clim-core.asd
@@ -13,7 +13,7 @@
    (:file "frames" :depends-on ("commands" "presentations" "presentation-defs"
                                 "pointer-tracking" "incremental-redisplay"))
    (:file "dialog-views" :depends-on ("presentations" "incremental-redisplay"
-                                      "bordered-output" "presentation-defs"))
+                                      "bordered-output" "presentation-defs" "gadgets"))
    (:file "presentation-defs" :depends-on ("input-editing" "presentations"))
    (:file "gadgets" :depends-on ("commands" "pointer-tracking" "input-editing" 
                                  "frames" "incremental-redisplay" "panes"))

--- a/Core/clim-core/dialog-views.lisp
+++ b/Core/clim-core/dialog-views.lisp
@@ -251,6 +251,31 @@
 						 present-p
 						 query-identifier)))))
 
+;;;; text-editor-view
+
+(define-presentation-method accept-present-default
+    ((type string) stream (view text-editor-view) default default-supplied-p
+     present-p query-identifier)
+  (unless default-supplied-p
+    (setf default ""))
+  (let ((gadget (make-gadget-pane-from-view view stream
+                                            :value default
+                                            :value-changed-callback
+                                            (%standard-value-changed-callback query-identifier))))
+    (updating-output (stream
+                      :cache-value t    ; don't redisplay
+                      :unique-id query-identifier
+                      :record-type 'accepting-values-record)
+
+                     (with-output-as-presentation (stream query-identifier 'selectable-query
+                                                          :single-box t)
+                       (surrounding-output-with-border (stream :shape :rounded
+                                                               :radius 3 :background clim:+background-ink+
+                                                               :foreground clim:+foreground-ink+
+                                                               :move-cursor t)
+                                                       (with-output-as-gadget (stream)
+                                                         gadget))))))
+
 ;;; A gadget that's not in the spec but which would  be useful.
 (defclass pop-up-menu-view (gadget-dialog-view)
   ()

--- a/Core/clim-core/dialog-views.lisp
+++ b/Core/clim-core/dialog-views.lisp
@@ -205,6 +205,34 @@
                                 :value-changed-callback
                                 (%standard-value-changed-callback query-identifier)))
 
+;;;; slider-view
+
+(define-presentation-method accept-present-default
+    ((type real) stream (view slider-view) default default-supplied-p
+     present-p query-identifier)
+  (make-output-record-from-view view stream query-identifier
+                                :value default
+                                :max-value high ; high: presentation parameter
+                                :min-value low ; low: presentation parameter
+                                :show-value-p t
+                                :value-changed-callback (%standard-value-changed-callback query-identifier)))
+
+(define-presentation-method accept-present-default
+    ((type integer) stream (view slider-view) default default-supplied-p
+     present-p query-identifier)
+  (make-output-record-from-view view stream query-identifier
+                                :value default
+                                :max-value high ; presentation parameter
+                                :min-value low ; presentation parameter
+                                :show-value-p t
+                                :number-of-quanta (- high low)
+                                :value-changed-callback
+                                (lambda (pane item)
+                                  (declare (ignore pane))
+                                  (let ((value (round item)))
+                                    (throw-object-ptype `(com-change-query ,query-identifier ,value)
+                                                        '(command :command-table accept-values))))))
+
 ;;; A gadget that's not in the spec but which would  be useful.
 (defclass pop-up-menu-view (gadget-dialog-view)
   ()

--- a/Core/clim-core/dialog-views.lisp
+++ b/Core/clim-core/dialog-views.lisp
@@ -115,6 +115,68 @@
                                 :value-changed-callback
                                 (%standard-value-changed-callback query-identifier)))
 
+;;; radio-box-view
+
+(define-presentation-method accept-present-default
+    ((type completion) stream (view radio-box-view) default default-supplied-p
+     present-p query-identifier)
+  (let ((buttons (loop for choice in sequence collect
+                      (make-pane 'toggle-button
+                                 :indicator-type :one-of
+                                 :id (funcall value-key choice)
+                                 :label (funcall name-key choice)))))
+    (make-output-record-from-view view stream query-identifier
+                                  :choices buttons
+                                  :current-selection (find default buttons :test test :key #'gadget-id)
+                                  :value-changed-callback
+                                  (lambda (pane item)
+                                    (let ((value (gadget-id item)))
+                                      (throw-object-ptype `(com-change-query ,query-identifier ,value)
+                                                          '(command :command-table accept-values)))))))
+
+;;; check-box-view
+
+(define-presentation-method accept-present-default
+    ((type subset-completion) stream (view check-box-view) default default-supplied-p
+     present-p query-identifier)
+  (let ((buttons (loop for choice in sequence collect
+                      (make-pane 'toggle-button
+                                 :indicator-type :some-of
+                                 :id (funcall value-key choice)
+                                 :label (funcall name-key choice)))))
+    (make-output-record-from-view view stream query-identifier
+                                  :choices buttons
+                                  :current-selection
+                                  (remove-if-not (lambda (x) (find (gadget-id x) default :test test)) buttons)
+                                  :value-changed-callback
+                                  (lambda (pane item)
+                                    (let ((value (map 'list #'gadget-id item)))
+                                      (throw-object-ptype `(com-change-query ,query-identifier ,value)
+                                                          '(command :command-table accept-values)))))))
+
+;;; option-pane-view
+
+(define-presentation-method accept-present-default
+    ((type completion) stream (view option-pane-view) default default-supplied-p
+     present-p query-identifier)
+  (flet ((generate-callback (query-identifier)
+           (lambda (pane item)
+             (declare (ignore pane))
+             (when *accepting-values-stream*
+               (when-let ((query (find query-identifier
+                                       (queries *accepting-values-stream*)
+                                       :key #'query-identifier :test #'equal)))
+                 (setf (value query) item)
+                 (setf (changedp query) t))))))
+    (make-output-record-from-view view stream query-identifier
+                                  :mode :exclusive
+                                  :test test
+                                  :value default
+                                  :name-key name-key
+                                  :value-key value-key
+                                  :items sequence
+                                  :value-changed-callback (generate-callback query-identifier))))
+
 ;;; A gadget that's not in the spec but which would  be useful.
 (defclass pop-up-menu-view (gadget-dialog-view)
   ()

--- a/Core/clim-core/dialog-views.lisp
+++ b/Core/clim-core/dialog-views.lisp
@@ -233,6 +233,24 @@
                                     (throw-object-ptype `(com-change-query ,query-identifier ,value)
                                                         '(command :command-table accept-values))))))
 
+;;;; text-field
+
+(define-default-presentation-method accept-present-default
+    (type stream (view text-field-view) default default-supplied-p
+     present-p query-identifier)
+  (if (width view)
+      (multiple-value-bind (cx cy)
+	  (stream-cursor-position stream)
+	(declare (ignore cy))
+	(letf (((stream-text-margin stream) (+ cx (width view))))
+	  (funcall-presentation-generic-function accept-present-default
+						 type
+						 stream
+						 +textual-dialog-view+
+						 default default-supplied-p
+						 present-p
+						 query-identifier)))))
+
 ;;; A gadget that's not in the spec but which would  be useful.
 (defclass pop-up-menu-view (gadget-dialog-view)
   ()

--- a/Core/clim-core/dialog-views.lisp
+++ b/Core/clim-core/dialog-views.lisp
@@ -177,6 +177,34 @@
                                   :items sequence
                                   :value-changed-callback (generate-callback query-identifier))))
 
+;;; list-pane-view
+
+(define-presentation-method accept-present-default
+    ((type completion) stream (view list-pane-view) default default-supplied-p
+     present-p query-identifier)
+  (make-output-record-from-view view stream query-identifier
+                                :mode :exclusive
+                                :test test
+                                :value default
+                                :name-key name-key
+                                :value-key value-key
+                                :items sequence
+                                :value-changed-callback
+                                (%standard-value-changed-callback query-identifier)))
+
+(define-presentation-method accept-present-default
+    ((type subset-completion) stream (view list-pane-view) default default-supplied-p
+     present-p query-identifier)
+  (make-output-record-from-view view stream query-identifier
+                                :mode :nonexclusive
+                                :test test
+                                :value default
+                                :name-key name-key
+                                :value-key value-key
+                                :items sequence
+                                :value-changed-callback
+                                (%standard-value-changed-callback query-identifier)))
+
 ;;; A gadget that's not in the spec but which would  be useful.
 (defclass pop-up-menu-view (gadget-dialog-view)
   ()

--- a/Core/clim-core/dialog-views.lisp
+++ b/Core/clim-core/dialog-views.lisp
@@ -20,6 +20,65 @@
 
 ;;; Classes for the gadget dialog views. Eventually.
 
+;;; Views described in the Franz User manual (CLIM 2.2). Sec. 8.6.13
+
+(macrolet
+    ((define-gadget-view (name &optional new-slots)
+       (let ((class-name (alexandria:symbolicate name '-view))
+             (variable-name (alexandria:symbolicate '+ name '-view+))
+             (slots (c2mop:class-slots (c2mop:ensure-finalized (find-class name)))))
+         `(progn
+            (defclass ,class-name (gadget-view)
+              ((gadget-name :allocation :class :reader view-gadget-name :initform ',name)
+               (gadget-slots :allocation :class :reader view-gadget-slots
+                             :initform
+                             ',(loop for slot in slots
+                                  when (c2mop:slot-definition-initargs slot)
+                                  collect (list (c2mop:slot-definition-name slot) (car (c2mop:slot-definition-initargs slot)))))
+               ,@new-slots
+               ,@(loop for slot in slots
+                    when (c2mop:slot-definition-initargs slot)
+                    collect
+                      (list (c2mop:slot-definition-name slot)
+                            :initarg (car (c2mop:slot-definition-initargs slot))
+                            :type (c2mop:slot-definition-type slot)))))
+            (defvar ,variable-name (make-instance ',class-name))
+            ',name))))
+
+  (define-gadget-view toggle-button)
+  (define-gadget-view push-button)
+  (define-gadget-view radio-box)
+  (define-gadget-view check-box)
+  (define-gadget-view slider)
+  (define-gadget-view text-field
+      ((width :accessor width :initarg :width :initform nil)))
+  (define-gadget-view text-editor)
+  (define-gadget-view list-pane)
+  (define-gadget-view option-pane))
+
+;;; Use textual-dialog-view as default for Views not implemented
+
+(define-default-presentation-method accept-present-default
+    (type stream (view gadget-view) default default-supplied-p
+          present-p query-identifier)
+  (funcall-presentation-generic-function accept-present-default
+                                         type
+                                         stream
+                                         +textual-dialog-view+
+                                         default default-supplied-p
+                                         present-p
+                                         query-identifier))
+
+(define-default-presentation-method accept
+    (type stream (view gadget-view) &key default default-type)
+  (funcall-presentation-generic-function accept
+                                         type
+                                         stream
+                                         +textual-dialog-view+
+                                         :default default
+                                         :default-type default-type))
+
+
 ;;; A gadget that's not in the spec but which would  be useful.
 (defclass pop-up-menu-view (gadget-dialog-view)
   ()

--- a/Core/clim-core/dialog.lisp
+++ b/Core/clim-core/dialog.lisp
@@ -535,24 +535,6 @@ is called. Used to determine if any editing has been done by user")))
 
 (defparameter *no-default-cache-value* (cons nil nil))
 
-;;; Hack until more views / dialog gadgets are defined.
-
-(define-default-presentation-method accept-present-default
-    (type stream (view text-field-view) default default-supplied-p
-     present-p query-identifier)
-  (if (width view)
-      (multiple-value-bind (cx cy)
-	  (stream-cursor-position stream)
-	(declare (ignore cy))
-	(letf (((stream-text-margin stream) (+ cx (width view))))
-	  (funcall-presentation-generic-function accept-present-default
-						 type
-						 stream
-						 +textual-dialog-view+
-						 default default-supplied-p
-						 present-p
-						 query-identifier)))))
-
 (define-default-presentation-method accept-present-default
     (type stream (view textual-dialog-view) default default-supplied-p
      present-p query-identifier)

--- a/Core/clim-core/dialog.lisp
+++ b/Core/clim-core/dialog.lisp
@@ -838,40 +838,6 @@ is run for the last time"))
     (run-frame-top-level frame)
     (slot-value frame 'return-value)))
 
-;;; The list pane in an accepting-values dialog
-
-(define-presentation-method accept-present-default
-    ((type completion) stream (view list-pane-view)
-     default default-supplied-p present-p query-identifier)
-  (declare (ignore present-p))
-  (unless default-supplied-p
-    (setq default (funcall value-key (elt sequence 0))))
-  (let ((gadget-options
-         (loop
-            for slot in '(foreground background text-style visible-items)
-            for initarg in '(:foreground :background :text-style :visible-items)
-            when (slot-boundp view slot)
-            append (list initarg (slot-value view slot))))
-        (fm (frame-manager *application-frame*))
-        (command-ptype '(command :command-table accept-values)))
-    (flet ((value-changed-callback (pane item)
-	     (declare (ignore pane))
-             (throw-object-ptype `(com-change-query ,query-identifier ,item)
-                                 command-ptype))
-           (dont-redisplay (a b)
-             (declare (ignore a b))
-             t))
-      (updating-output (stream
-                        :cache-value t
-                        :cache-test #'dont-redisplay
-                        :unique-id query-identifier
-                        :record-type 'accepting-values-record)
-        (with-look-and-feel-realization (fm *application-frame*)
-          (with-output-as-gadget (stream)
-            (apply #'make-pane 'list-pane
-                   :items sequence :name-key name-key :value-key value-key
-                   :value-changed-callback #'value-changed-callback
-                   gadget-options)))))))
 
 ;;; An accept-values button sort of behaves like an accepting-values query with
 ;;; no value.

--- a/Core/clim-core/gadgets.lisp
+++ b/Core/clim-core/gadgets.lisp
@@ -713,7 +713,14 @@ and must never be nil.")
 ;;; 30.4.9 The abstract text-editor Gadget
 
 (defclass text-editor (text-field)
-  ()
+  ((ncolumns :reader text-editor-ncolumns
+             :initarg :ncolumns
+             :initform nil
+             :type (or null integer))
+   (nlines :reader text-editor-nlines
+           :initarg :nlines
+           :initform nil
+           :type (or null integer)))
   (:documentation "The value is a string"))
 
 ;;;; ------------------------------------------------------------------------------------------

--- a/Examples/accepting-values-test.lisp
+++ b/Examples/accepting-values-test.lisp
@@ -22,7 +22,7 @@
 						    "yes")))))
       (clim:radio-box-current-selection "no")
       "yes"))
-   (interactor :interactor)
+   (interactor :interactor :min-width 600)
    (doc :pointer-documentation))
   (:layouts
    (defaults
@@ -61,6 +61,8 @@
     (present '(com-accept-popup) 'command :stream pane)
     (fresh-line pane)
     (present '(com-accepting-with-list-pane-view) 'command :stream pane)
+    (fresh-line pane)
+    (present '(com-accepting-with-gadgets) 'command :stream pane)
     (fresh-line pane)))
 
 (define-av-test-command (com-refresh
@@ -147,5 +149,13 @@
     ()
   (with-slots (own-window-p) clim:*application-frame*
     (format t "Result: ~S~%" (multiple-value-list (accepting-with-list-pane-view :ow own-window-p))))
+  (finish-output *standard-output*))
+
+(define-av-test-command (com-accepting-with-gadgets
+			 :name t
+			 :menu nil)
+    ()
+  (with-slots (own-window-p) clim:*application-frame*
+    (format t "Result: ~S~%" (multiple-value-list (accepting-with-gadgets :ow own-window-p))))
   (finish-output *standard-output*))
 

--- a/Examples/accepting-values.lisp
+++ b/Examples/accepting-values.lisp
@@ -274,3 +274,24 @@
     (notify-user *application-frame*
                  (format nil "~a, ~a, and ~a were selected." abbrev prez vp))
     (values abbrev prez vp)))
+
+(defun accepting-with-gadgets (&key (stream *query-io*) (ow t))
+  (clim:accepting-values (stream :resynchronize-every-pass t :own-window ow)
+                         (fresh-line stream)
+
+                         (let (results)
+                           (macrolet ((generate-accept (type prompt view &rest keys)
+                                        `(progn
+                                           (push (accept ,type :prompt ,prompt :view ,view :stream stream ,@keys) results)
+                                           (fresh-line stream))))
+                             (generate-accept 'boolean "Toggle button [boolean]" +toggle-button-view+)
+                             (generate-accept '(member 1 2 3 4) "Radio Box [completion] " +radio-box-view+ :default 3)
+                             (generate-accept '(member "first" "second" "third") "Radio Box vertical [completion] " '(radio-box-view :orientation :vertical))
+                             (generate-accept '(member "Red" "Green" "Blue") "List pane [completion] " +list-pane-view+)
+                             (generate-accept '(member-sequence ("Male" "Female") :test string=) "Option pane [completion] " +option-pane-view+ :default "Male")
+                             (generate-accept '(subset 1 10 100 1000) "Check list [subset]" +check-box-view+ :default '(1 1000))
+                             (generate-accept '(subset :a :b :c :d) "List pane [subset]" +list-pane-view+ :default '(:a))
+                             (generate-accept '(float -1 1) "slider [float]" '(slider-view :orientation :horizontal :decimal-places 2) :default 0)
+                             (generate-accept '(integer 0 10) "slider [integer]" +slider-view+ :default 0)
+                             (generate-accept 'string "text editor [string]" '(text-editor-view :ncolumns 10 :nlines 10)))
+                           (nreverse results))))

--- a/package.lisp
+++ b/package.lisp
@@ -1626,6 +1626,8 @@
    #:+push-button-view+                 ;constant
    #:radio-box-view                     ;class
    #:+radio-box-view+                   ;class
+   #:check-box-view                     ;class
+   #:+check-box-view+                   ;class
    #:read-bitmap-file                   ;function
    #:slider-view                        ;slider-view
    #:+slider-view+                      ;constant


### PR DESCRIPTION
I start to implement the gadget views to be used with accepting-values as described in Franz Manual section 8.6.13 (CLIM 2.2 specification).

For this:

1. Specification conformity: some slots defined in abstract class gadget specification in McCLIM was implemented only in the concrete gadget class. With this PR  this slots are defined inthe abstract class.

2. The gadget views are defined in such a way that they have the same slots of the corresponding abstract gadget class. (This is obtain with a macro that use MOP).

3. For each gadget view is implemeted the method accept-present-default

4. In the Accepting Value Test demo is inserted a test for the gadget views. 
