### PR TITLE
seos: split functions, margins and end-of-*-action changes

### DIFF
--- a/Core/clim-basic/stream-output.lisp
+++ b/Core/clim-basic/stream-output.lisp
@@ -387,10 +387,14 @@
     (setf (cursor-position (stream-text-cursor stream))
           (values (stream-effective-left-margin stream)
                   updated-cy))
-    (maybe-end-of-page-action stream (+ updated-cy vertical-spacing))
-    (finish-output stream)       ; this will close the output record if recorded
-    (setf (slot-value stream 'baseline) 0
-          (%stream-char-height stream) 0)))
+    (finish-output stream)       ; this will close the output record if recorded)
+    (let* ((medium       (sheet-medium stream))
+           (text-style   (medium-text-style medium))
+           (new-baseline (text-style-ascent text-style medium))
+           (new-height   (text-style-height text-style medium)))
+      (maybe-end-of-page-action stream (+ updated-cy new-height))
+      (setf (slot-value stream 'baseline) new-baseline
+            (%stream-char-height stream)  new-height))))
 
 (defgeneric stream-write-output (stream line string-width &optional start end)
   (:documentation

--- a/Core/clim-basic/stream-output.lisp
+++ b/Core/clim-basic/stream-output.lisp
@@ -202,14 +202,17 @@
 ;;; -- jd 2019-01-09
 
 (defgeneric stream-effective-left-margin (stream)
+  (:documentation "Absolute position of the left margin in stream coordinates.")
   (:method ((stream standard-extended-output-stream))
     0))
 
 (defgeneric stream-effective-top-margin (stream)
+  (:documentation "Absolute position of the top margin in stream coordinates.")
   (:method ((stream standard-extended-output-stream))
     0))
 
 (defgeneric stream-effective-right-margin (stream)
+  (:documentation "Absolute position of the right margin in stream coordinates.")
   (:method ((stream standard-extended-output-stream))
     (or (slot-value stream 'margin)
         (let ((sheet (or (pane-viewport stream) stream)))
@@ -219,6 +222,7 @@
               (bounding-rectangle-width sheet))))))
 
 (defgeneric stream-effective-bottom-margin (stream)
+  (:documentation "Absolute position of the bottom margin in stream coordinates.")
   (:method ((stream standard-extended-output-stream))
     (bounding-rectangle-height stream)))
 

--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -567,6 +567,19 @@ STREAM in the direction DIRECTION."
             (setf last-bad current-guess))
      finally (return last-good)))
 
+;; Implementing line breaking as defined in Unicode[1] is left as an excercise
+;; for the reader. [1] https://unicode.org/reports/tr14/ -- jd 2019-01-08
+(defun line-break-opportunities (string start end &optional (break-characters '(#\space)))
+  "Returns a sequence of string indexes where line may be braken."
+  (loop
+     with space-indexes = (make-array 1 :fill-pointer 0 :adjustable t :element-type 'fixnum)
+     for i from start below (1- end)
+     do (when (member (aref string i) break-characters :test #'char=)
+          (vector-push-extend i space-indexes))
+     finally
+       (vector-push-extend (1- end) space-indexes)
+       (return space-indexes)))
+
 ;;; Command name utilities that are useful elsewhere.
 
 (defun command-name-from-symbol (symbol)

--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -548,6 +548,25 @@ STREAM in the direction DIRECTION."
      end
      finally (return (values bindings new-arg-list))))
 
+(defun bisect (start end predicate &optional (predicament :half))
+  (when (funcall predicate end)
+    (return-from bisect end))
+  (when (eql predicament :half)
+    (setf predicament (lambda (last-good last-bad)
+                        (let ((predicament (floor (+ last-good last-bad) 2)))
+                          (and (/= predicament last-good)
+                               (/= predicament last-bad)
+                               predicament)))))
+  (loop
+     with last-good = start
+     with last-bad = end
+     as current-guess = (funcall predicament last-good last-bad)
+     until (null current-guess)
+     do (if (funcall predicate current-guess)
+            (setf last-good current-guess)
+            (setf last-bad current-guess))
+     finally (return last-good)))
+
 ;;; Command name utilities that are useful elsewhere.
 
 (defun command-name-from-symbol (symbol)

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -2621,9 +2621,10 @@ SCROLLER-PANE appear on the ergonomic left hand side, or leave set to
 	(medium-clear-area (sheet-medium pane) left top right bottom)))
     (clear-output-record output-history))
   (window-erase-viewport pane)
-  (let ((cursor (stream-text-cursor pane)))
-    (when cursor
-      (setf (cursor-position cursor) (values 0 0))))
+  (when-let ((cursor (stream-text-cursor pane)))
+    (setf (cursor-position cursor)
+          (values (stream-effective-left-margin pane)
+                  (stream-effective-top-margin pane))))
   (setf (stream-width pane) 0)
   (setf (stream-height pane) 0)
   (scroll-extent pane 0 0)

--- a/Examples/demodemo.lisp
+++ b/Examples/demodemo.lisp
@@ -126,7 +126,7 @@ argument to avoid creating too many functions with similar name."))
                    (make-demo-button "Overlapping patterns" 'patterns-overlap)
                    (make-demo-button "Text transformations" 'text-transformations-test)
                    (make-demo-button "Text multiline positioning" 'text-multiline-positioning)
-                   (make-demo-button "SEOS baseline" 'seos-baseline)))))))))
+                   (make-demo-button "SEOS baseline and wrapping" 'seos-baseline)))))))))
 
 (defun demodemo ()
   (run-frame-top-level (make-application-frame 'demodemo)))

--- a/Examples/seos-baseline.lisp
+++ b/Examples/seos-baseline.lisp
@@ -3,10 +3,14 @@
 
 (define-application-frame seos-baseline ()
   ()
+  (:menu-bar seos-command-table)
   (:pane :application
+         :width 350
+         :height 400
          :display-function #'display
          :end-of-line-action :allow
-         :scroll-bars nil))
+         :end-of-page-action :allow
+         :text-margin 300))
 
 (defun show-line (stream &rest args)
   (loop for (size text) on args by #'cddr do
@@ -17,22 +21,41 @@
 (defmethod display ((frame seos-baseline) pane)
   (declare (ignore frame))
   (show-line pane :normal "Hello " :huge "world!")
-  (show-line pane :normal "Second " :huge "line " :tiny "hello " :normal "world!")
+  (show-line pane
+             :normal "Hello world "
+             :normal "hiho" :large "hiho" :huge "hiho" :tiny "hiho" :normal "hiho"
+             :normal "hiho" :large "hiho" :huge "hiho" :tiny "hiho" :normal "hiho"
+             :normal "hiho" :large "hiho" :huge "hiho" :tiny "hiho" :normal "hiho"
+             :normal "hiho" :large "hiho" :huge "hiho" :tiny "hiho" :normal "hiho")
   (show-line pane :huge "Third " :normal "line " :tiny "hello " :huge "world!")
   (show-line pane :normal "Last " :huge "line " :normal "bam bam")
 
   (terpri pane)
-  (with-room-for-graphics (pane)
-    (draw-line* pane 0 0 530 0))
+  (let ((y (nth-value 1 (stream-cursor-position pane))))
+   (draw-line* pane (climi::stream-effective-left-margin pane)
+               y
+               (climi::stream-effective-right-margin pane)
+               y
+               :ink +blue+ :line-dashes t))
   (terpri pane)
   (format pane "All lines should have text aligned on the same baseline. Likely failures:
 
 1. Parts of the text with different size aligned to the top (not baseline).
+2. Pressing space cause redisplay and schedules repaint after 1s. This may exhibit different outlook of displayed and repainted output.
+3. All lines in this description are long. Use menu to change end of line action. Current action is ~s.
+4. When viewport is smaller than the whole scrolling area ALT scrolls to the very bottom.
+6. There is one line below these points. Stream height may not be recalculated to take it into account because it doesn't have newline character in the end. When wrapped part of the text may not be rendered. Try pressing space.
+7. Said last line may be rendered and recorded, but not scrolled to the end despite :SCROLL contract.
+8. Some lines here are lengthy to test different wrapping scenarios. Page end action :WRAP is not very useful - it is not a bug that text is drawn on top of the previous one. Here comes a lot of letters with random spaces: AAA BBBBBBBBBBBBBBB CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD.
 
-2. Pressing space cause redisplay and schedules repaint after 1s. This may
-exhibit different outlook of displayed and repainted output.
-
-See the introduction in \"15.3 The Text Cursor\"."))
+See the introduction in \"15.3 The Text Cursor\"."
+          (stream-end-of-line-action pane))
+  (draw-rectangle* pane
+                   (climi::stream-effective-left-margin pane)
+                   (climi::stream-effective-top-margin pane)
+                   (climi::stream-effective-right-margin pane)  ; may be nil!
+                   (climi::stream-effective-bottom-margin pane) ; may be nil!
+                   :ink +red+ :line-dashes t :filled nil))
 
 (define-seos-baseline-command (com-redisplay :keystroke #\space) ()
   (schedule-event *standard-output*
@@ -40,3 +63,43 @@ See the introduction in \"15.3 The Text Cursor\"."))
                                  :region +everywhere+
                                  :sheet *standard-output*)
                   1))
+
+(make-command-table 'seos-command-table
+                    :errorp nil
+                    :menu '(("Line" :menu line-ct)
+                            ("Page" :menu page-ct)))
+
+(make-command-table 'line-ct :errorp nil
+                    :menu '(("Allow" :command com-allow-line)
+                            ("Scroll" :command com-scroll-line)
+                            ("Wrap" :command com-wrap-line)
+                            ("Wrap word" :command com-wrap*-line)))
+
+(make-command-table 'page-ct :errorp nil
+                    :menu '(("Allow" :command com-allow-page)
+                            ("Scroll" :command com-scroll-page)
+                            ("Wrap" :command com-wrap-page)))
+
+(define-seos-baseline-command (com-allow-line :keystroke #\1) ()
+  (setf (stream-end-of-line-action *standard-output*) :allow))
+
+(define-seos-baseline-command (com-scroll-line :keystroke #\2) ()
+  (setf (stream-end-of-line-action *standard-output*) :scroll))
+
+(define-seos-baseline-command (com-wrap-line :keystroke #\3) ()
+  (setf (stream-end-of-line-action *standard-output*) :wrap))
+
+(define-seos-baseline-command (com-wrap*-line :keystroke #\4) ()
+  (setf (stream-end-of-line-action *standard-output*) :wrap*))
+
+(define-seos-baseline-command (com-allow-page :keystroke #\q) ()
+  (setf (stream-end-of-page-action *standard-output*) :allow))
+
+(define-seos-baseline-command (com-scroll-page :keystroke #\w) ()
+  (setf (stream-end-of-page-action *standard-output*) :scroll))
+
+(define-seos-baseline-command (com-wrap-page :keystroke #\e) ()
+  (setf (stream-end-of-page-action *standard-output*) :wrap))
+
+;(run-frame-top-level (make-application-frame 'seos-baseline))
+


### PR DESCRIPTION
- stream text split functions (for wrapping) should be faster now thanks to bisection (instead of naive letter-by-letter algorithm)
- end-of-line-action accepts now `:wrap*` for wrapping by word
- end-of-page is now recognized even when text-style changes size on a line
- new internal protocol introduced.

stream-effective-left-margin
stream-effective-right-margin
stream-effective-top-margin
stream-effective-bottom-margin`

Right now all except the right margin resort to window size (0,0,text-margin,window-height), they will have more useful implementation in upcoming PR with margin-mixin. Related parts of code has been adjusted to honor results of these functions.