### PR TITLE
clim-stream-pane: specify default dimensions

### DIFF
--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -2519,8 +2519,8 @@ SCROLLER-PANE appear on the ergonomic left hand side, or leave set to
    (user-min-height :accessor %pane-user-min-height)
    (user-max-height :accessor %pane-user-max-height)
    ;; size required by the stream
-   (stream-width :initform 0 :accessor stream-width)
-   (stream-height :initform 0 :accessor stream-height))
+   (stream-width :initform 100 :accessor stream-width)
+   (stream-height :initform 100 :accessor stream-height))
   (:documentation
    "This class implements a pane that supports the CLIM graphics,
     extended input and output, and output recording protocols."))


### PR DESCRIPTION
X protocol can't handle windows of width/height = 0. It can handle them when
size is 1x1, but this doesn't make much sense as a default. We provide defaults
for 100x100. Note, that stream-width/stream-height are somewhat inconsistent
with default width/height intiargs despite some visible effort to make them as
an extension of said mechanism. Fixes #47.