### PR TITLE
Scigraph dialogs

### DIFF
--- a/Apps/Scigraph/dwim/package.lisp
+++ b/Apps/Scigraph/dwim/package.lisp
@@ -41,7 +41,8 @@ advised of the possiblity of such damages.
                 #:frame-manager
                 #:find-frame-manager
                 #:suggest
-                #:expression)
+                #:expression
+                #:accept)
   (:shadow #:interactive-stream-p
 
            #:menu-choose
@@ -54,7 +55,6 @@ advised of the possiblity of such damages.
            #:bounding-rectangle*
            #:redisplay
            #:redisplayable-format
-           #:accept
            #:accepting-values
            #:accept-values
            #:accept-variable-values
@@ -162,7 +162,6 @@ advised of the possiblity of such damages.
            #:bounding-rectangle*
            #:redisplay
            #:redisplayable-format
-           #:accept
            #:accepting-values
            #:accept-values
            #:accept-variable-values

--- a/Apps/Scigraph/dwim/present.lisp
+++ b/Apps/Scigraph/dwim/present.lisp
@@ -81,26 +81,6 @@ advised of the possiblity of such damages.
 	  (apply #'format stream string a)))
       (apply #'format stream string args)))
 
-(defun accept (presentation-type &key
-				 (view nil view-p)
-				 (stream *standard-output*)
-				 (prompt t)
-				 default query-identifier)
-  (if view-p
-      (clim:accept presentation-type
-                   :view view
-                   :stream stream
-                   :prompt prompt
-                   :default default
-                   :display-default nil
-                   :query-identifier query-identifier)
-      (clim:accept presentation-type
-                   :stream stream
-                   :prompt prompt
-                   :default default
-                   :display-default nil
-                   :query-identifier query-identifier)))
-
 (defun accept-values (descriptions &key (prompt nil)
 					(stream *query-io*)
 					(own-window nil))

--- a/Core/clim-basic/encapsulate.lisp
+++ b/Core/clim-basic/encapsulate.lisp
@@ -464,6 +464,9 @@ if there is one, or STREAM"
 
 ;;; Extended Output Streams
 
+(def-stream-method extended-output-stream-p
+    ((stream standard-encapsulating-stream)))
+
 (def-stream-method stream-text-cursor ((stream standard-encapsulating-stream)))
 
 (def-stream-method (setf stream-text-cursor)

--- a/Core/clim-basic/encapsulate.lisp
+++ b/Core/clim-basic/encapsulate.lisp
@@ -535,7 +535,10 @@ if there is one, or STREAM"
              (declare (ignore old-medium))
              (funcall continuation medium))
          drawing-options))
-                               
+
+(defmethod invoke-with-sheet-medium-bound (continuation (medium null) (stream standard-encapsulating-stream))
+  (invoke-with-sheet-medium-bound continuation medium  (slot-value stream 'stream)))
+
 ;;; Extended Input Streams
 
 (def-stream-method extended-input-stream-p

--- a/Core/clim-basic/encapsulate.lisp
+++ b/Core/clim-basic/encapsulate.lisp
@@ -542,6 +542,12 @@ if there is one, or STREAM"
 (defmethod invoke-with-sheet-medium-bound (continuation (medium null) (stream standard-encapsulating-stream))
   (invoke-with-sheet-medium-bound continuation medium  (slot-value stream 'stream)))
 
+(defmethod do-graphics-with-options ((sheet encapsulating-stream) func &rest options)
+  (with-sheet-medium (medium sheet)
+    (let ((*foreground-ink* (medium-foreground medium))
+          (*background-ink* (medium-background medium)))
+      (apply #'do-graphics-with-options-internal medium sheet func options))))
+
 ;;; Extended Input Streams
 
 (def-stream-method extended-input-stream-p

--- a/Core/clim-basic/encapsulate.lisp
+++ b/Core/clim-basic/encapsulate.lisp
@@ -548,6 +548,10 @@ if there is one, or STREAM"
           (*background-ink* (medium-background medium)))
       (apply #'do-graphics-with-options-internal medium sheet func options))))
 
+(defmethod invoke-with-room-for-graphics (cont (stream encapsulating-stream) 
+                                          &rest options)
+  (apply #'invoke-with-room-for-graphics cont (encapsulating-stream-stream stream) options))
+
 ;;; Extended Input Streams
 
 (def-stream-method extended-input-stream-p

--- a/Core/clim-core/presentation-defs.lisp
+++ b/Core/clim-core/presentation-defs.lisp
@@ -1752,7 +1752,14 @@ protocol retrieving gestures from a provided string."))
   (defconstant +completion-options+
     '((name-key 'default-completion-name-key)
       documentation-key
-      (partial-completers '(#\Space)))))
+      (partial-completers '(#\Space))
+      (printer #'write-token)
+      (highlighter #'highlight-completion-choice))))
+
+;;;; This function is copied from CLIM Franz code
+(defun highlight-completion-choice (continuation object stream)
+  (with-text-face (stream :bold)
+    (funcall continuation object stream)))
 
 (define-presentation-type completion (sequence
                                       &key (test 'eql) (value-key 'identity))
@@ -1826,7 +1833,9 @@ protocol retrieving gestures from a provided string."))
   (make-presentation-type-specifier `(completion ,elements)
                                     :name-key name-key
                                     :documentation-key documentation-key
-                                    :partial-completers partial-completers)
+                                    :partial-completers partial-completers
+                                    :printer printer
+                                    :highlighter highlighter)
   :options #.+completion-options+)
 
 (define-presentation-type-abbreviation member-sequence (sequence
@@ -1835,7 +1844,9 @@ protocol retrieving gestures from a provided string."))
    `(completion ,sequence ,@(and testp `(:test ,test)))
    :name-key name-key
    :documentation-key documentation-key
-   :partial-completers partial-completers)
+   :partial-completers partial-completers
+   :printer printer
+   :highlighter highlighter)
   :options #.+completion-options+)
 
 (defun member-alist-value-key (element)
@@ -1858,10 +1869,14 @@ protocol retrieving gestures from a provided string."))
                 :value-key member-alist-value-key)
    :name-key name-key
    :documentation-key documentation-key
-   :partial-completers partial-completers)
+   :partial-completers partial-completers
+   :printer printer
+   :highlighter highlighter)
   :options ((name-key 'default-completion-name-key)
             (documentation-key 'member-alist-doc-key)
-            (partial-completers '(#\Space))))
+            (partial-completers '(#\Space))
+            (printer #'write-token)
+            (highlighter #'highlight-completion-choice)))
 
 (define-presentation-type subset-completion (sequence
                                              &key (test 'eql)
@@ -1870,7 +1885,9 @@ protocol retrieving gestures from a provided string."))
             documentation-key
             (partial-completers '(#\Space))
             (separator #\,)
-            (echo-space t))
+            (echo-space t)
+            (printer #'write-token)
+            (highlighter #'highlight-completion-choice))
   :inherit-from t)
 
 (define-presentation-method presentation-typep (object
@@ -1933,7 +1950,9 @@ protocol retrieving gestures from a provided string."))
   (make-presentation-type-specifier `(subset-completion ,elements)
                                     :name-key name-key
                                     :documentation-key documentation-key
-                                    :partial-completers partial-completers)
+                                    :partial-completers partial-completers
+                                    :printer printer
+                                    :highlighter highlighter)
   :options #.+completion-options+)
 
 (define-presentation-type-abbreviation subset-sequence (sequence
@@ -1942,7 +1961,9 @@ protocol retrieving gestures from a provided string."))
    `(subset-completion ,sequence ,@(and testp `(:test ,test)))
    :name-key name-key
    :documentation-key documentation-key
-   :partial-completers partial-completers)
+   :partial-completers partial-completers
+   :printer printer
+   :highlighter highlighter)
   :options #.+completion-options+)
 
 (define-presentation-type-abbreviation subset-alist (alist
@@ -1952,10 +1973,14 @@ protocol retrieving gestures from a provided string."))
                        :value-key member-alist-value-key)
    :name-key name-key
    :documentation-key documentation-key
-   :partial-completers partial-completers)
+   :partial-completers partial-completers
+   :printer printer
+   :highlighter highlighter)
   :options ((name-key 'default-completion-name-key)
             (documentation-key 'member-alist-doc-key)
-            (partial-completers '(#\Space))))
+            (partial-completers '(#\Space))
+            (printer #'write-token)
+            (highlighter #'highlight-completion-choice)))
 
 (define-presentation-type sequence (type)
   :options ((separator #\,) (echo-space t))


### PR DESCRIPTION
With this PR the Scigraph dialogs works and now it is possible to change the line type and the symbol of the data with dialogs.

This solve issue #704 

To try it:
1. load scigraph
2. open scigraph demo `(gr:make-demo-frame)` 
3. right click on one of the two data presentation on the legend of the graph and choose from the menu "Change Data Symbols..."

For the moment in the dialog the line types are printed as number and not graphically as expected from Scigraph code. To improve this it will be necessary in the future:
1. Use `:printer` option of completion presentation in `accept-present-default` methods.
2.  Implement the possibiliy to have for gadget labels not only string but also graphics (pixmap for examples) 