### PR TITLE
Scigraph: remove accept from dwim package

### DIFF
--- a/Apps/Scigraph/dwim/package.lisp
+++ b/Apps/Scigraph/dwim/package.lisp
@@ -41,7 +41,8 @@ advised of the possiblity of such damages.
                 #:frame-manager
                 #:find-frame-manager
                 #:suggest
-                #:expression)
+                #:expression
+                #:accept)
   (:shadow #:interactive-stream-p
 
            #:menu-choose
@@ -54,7 +55,6 @@ advised of the possiblity of such damages.
            #:bounding-rectangle*
            #:redisplay
            #:redisplayable-format
-           #:accept
            #:accepting-values
            #:accept-values
            #:accept-variable-values
@@ -162,7 +162,6 @@ advised of the possiblity of such damages.
            #:bounding-rectangle*
            #:redisplay
            #:redisplayable-format
-           #:accept
            #:accepting-values
            #:accept-values
            #:accept-variable-values

--- a/Apps/Scigraph/dwim/present.lisp
+++ b/Apps/Scigraph/dwim/present.lisp
@@ -81,26 +81,6 @@ advised of the possiblity of such damages.
 	  (apply #'format stream string a)))
       (apply #'format stream string args)))
 
-(defun accept (presentation-type &key
-				 (view nil view-p)
-				 (stream *standard-output*)
-				 (prompt t)
-				 default query-identifier)
-  (if view-p
-      (clim:accept presentation-type
-                   :view view
-                   :stream stream
-                   :prompt prompt
-                   :default default
-                   :display-default nil
-                   :query-identifier query-identifier)
-      (clim:accept presentation-type
-                   :stream stream
-                   :prompt prompt
-                   :default default
-                   :display-default nil
-                   :query-identifier query-identifier)))
-
 (defun accept-values (descriptions &key (prompt nil)
 					(stream *query-io*)
 					(own-window nil))


### PR DESCRIPTION
Following the suggetion of @slyrus I split PR #706 in three part. This is the third part about Scigraph accept function.

The ACCEPT version in DWIM package produced a SHEET-IS-NOT-A-CHILD
error when a dialog with gadget was closed.

This is due to how QUERY-IDENTIFIER parameter was passed to the
CLIM:ACCEPT function.

Because the Scigraph version in McCLIM is a CLIM2 only application the
DWIM:ACCEPT compatibility layer is no more necessary.

For this reason this commit remove the function ACCEPT from DWIM
package and now Scigraph use directly the CLIM:ACCEPT function.