### PR TITLE
add dejavu font path in gentoo/funtoo system.

### DIFF
--- a/Extensions/fonts/fontconfig.lisp
+++ b/Extensions/fonts/fontconfig.lisp
@@ -24,6 +24,7 @@
   (find-if #'probe-file
            '(#p"/usr/share/fonts/truetype/ttf-dejavu/"
              #p"/usr/share/fonts/truetype/dejavu/"
+             #p"/usr/share/fonts/dejavu/"
              #p"/usr/share/fonts/truetype/"
              #p"/usr/share/fonts/TTF/"
              #p"/usr/share/fonts/"


### PR DESCRIPTION
In Gentoo/Funtoo linux system, the font path for dejavu is `/usr/share/fonts/dejavu/`.

It will raise a warning if such path doesn't exist.