### PR TITLE
Make PRESENTATION-HISTORY-ADD into a generic function

### DIFF
--- a/Core/clim-core/presentation-defs.lisp
+++ b/Core/clim-core/presentation-defs.lisp
@@ -665,13 +665,14 @@ history will be unchanged."
          (when ,added
            (decf (fill-pointer (presentation-history-array ,history))))))))
 
-(defun presentation-history-add (history object ptype)
-  "Add OBJECT and PTYPE to the HISTORY unless they are already at the head of
- HISTORY"
-  (multiple-value-bind (top-object top-ptype)
-      (presentation-history-top history ptype)
-    (unless (and top-ptype (eql object top-object) (equal ptype top-ptype))
-      (presentation-history-insert history object ptype))))
+(defgeneric presentation-history-add (history object ptype)
+  (:documentation "Add OBJECT and PTYPE to the HISTORY unless they are already at the head of
+ HISTORY")
+  (:method (history object ptype)
+    (multiple-value-bind (top-object top-ptype)
+        (presentation-history-top history ptype)
+      (unless (and top-ptype (eql object top-object) (equal ptype top-ptype))
+        (presentation-history-insert history object ptype)))))
 
 (define-presentation-generic-function %accept accept
     (type-key parameters options type stream view &key))

--- a/Core/clim/input-editing-drei.lisp
+++ b/Core/clim/input-editing-drei.lisp
@@ -183,49 +183,49 @@ activated with GESTURE"))
 		 (push item result)))
     (reverse result)))
 
-(defun history-yank-next (stream input-buffer gesture numeric-argument)
-  (declare (ignore input-buffer gesture numeric-argument))
-  (let* ((accepting-type *active-history-type*)
-	 (quoted-sublists nil)
-         (history (and accepting-type
-                       (presentation-type-history accepting-type))))
-    (when history
-      (multiple-value-bind (object type)
-          (presentation-history-next history accepting-type)
-        (when type
-	  (when (and (equal type 'command-or-form)
-		     (listp object)
-		     (alexandria:starts-with-subseq "COM-" (symbol-name `,(car object))))
-	    (setf quoted-sublists (%quote-sublists object)))
-	  (when (null quoted-sublists)
-	    (setf quoted-sublists object))
-	  (let ((*print-case* :downcase))
-	    (presentation-replace-input stream quoted-sublists type
-					(stream-default-view stream)
-					:allow-other-keys t
-					:accept-result nil)))))))
-
-(defun history-yank-previous (stream input-buffer gesture numeric-argument)
-  (declare (ignore input-buffer gesture numeric-argument))
-  (let* ((accepting-type *active-history-type*)
-	 (quoted-sublists nil)
-         (history (and accepting-type
-                       (presentation-type-history accepting-type))))
-    (when history
-      (multiple-value-bind (object type)
-          (presentation-history-previous history accepting-type)
-        (when type
-	  (when (and (equal type 'command-or-form)
-		     (listp object)
-		     (alexandria:starts-with-subseq "COM-" (symbol-name `,(car object))))
+(defgeneric history-yank-next (stream input-buffer gesture numeric-argument)
+  (:method (stream input-buffer gesture numeric-argument)
+    (let* ((accepting-type *active-history-type*)
+	   (quoted-sublists nil)
+           (history (and accepting-type
+                         (presentation-type-history accepting-type))))
+      (when history
+        (multiple-value-bind (object type)
+            (presentation-history-next history accepting-type)
+          (when type
+	    (when (and (equal type 'command-or-form)
+		       (listp object)
+		       (alexandria:starts-with-subseq "COM-" (symbol-name `,(car object))))
 	      (setf quoted-sublists (%quote-sublists object)))
-	  (when (null quoted-sublists)
-	    (setf quoted-sublists object))
-	  (let ((*print-case* :downcase))
-	    (presentation-replace-input stream quoted-sublists type
-					(stream-default-view stream)
-					:allow-other-keys t
-					:accept-result nil)))))))
+	    (when (null quoted-sublists)
+	      (setf quoted-sublists object))
+	    (let ((*print-case* :downcase))
+	      (presentation-replace-input stream quoted-sublists type
+					  (stream-default-view stream)
+					  :allow-other-keys t
+					  :accept-result nil))))))))
+
+(defgeneric history-yank-previous (stream input-buffer gesture numeric-argument)
+  (:method (stream input-buffer gesture numeric-argument)
+    (let* ((accepting-type *active-history-type*)
+	   (quoted-sublists nil)
+           (history (and accepting-type
+                         (presentation-type-history accepting-type))))
+      (when history
+        (multiple-value-bind (object type)
+            (presentation-history-previous history accepting-type)
+          (when type
+	    (when (and (equal type 'command-or-form)
+		       (listp object)
+		       (alexandria:starts-with-subseq "COM-" (symbol-name `,(car object))))
+	      (setf quoted-sublists (%quote-sublists object)))
+	    (when (null quoted-sublists)
+	      (setf quoted-sublists object))
+	    (let ((*print-case* :downcase))
+	      (presentation-replace-input stream quoted-sublists type
+					  (stream-default-view stream)
+					  :allow-other-keys t
+					  :accept-result nil))))))))
 
 (add-input-editor-command '((#\n :meta)) 'history-yank-next)
 


### PR DESCRIPTION
This fix changes PRESENTATION-HISTORY-ADD from a regular function to a
generic function. This function is not exported, so there should be no
change in behaviour.

The purpose of making this function generic is to allow software to
override what is stored in the presentation history.