### PR TITLE
Add forms to handle command menu panes in same way as other panes.  F…

### DIFF
--- a/Core/clim-core/frames.lisp
+++ b/Core/clim-core/frames.lisp
@@ -730,6 +730,9 @@ documentation produced by presentations.")
        (:pointer-documentation `(make-clim-pointer-documentation-pane
                                  :name ',name
                                  ,@(cdr form)))
+       (:command-menu `(make-clim-command-menu-pane
+       			:name ',name
+       			,@(cdr form)))
        (otherwise `(make-pane ,(first form) :name ',name ,@(cdr form)))))
     ;; Non-standard pane designator fed to the `make-pane'
     (t `(make-pane ',(first form) :name ',name ,@(cdr form)))))

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -2847,6 +2847,9 @@ current background message was set."))
 (defun make-clim-pointer-documentation-pane (&rest options)
   (apply #'make-clim-stream-pane :type 'pointer-documentation-pane options))
 
+(defun make-clim-command-menu-pane (&rest options)
+  (apply #'make-clim-stream-pane :type 'command-menu-pane options))
+
 
 ;;;
 ;;; 29.4.5 Creating a Standalone CLIM Window


### PR DESCRIPTION
This addresses issue #754:

In an application frame, with command menu whose display function is clim:display-command-menu: Initially the frame displays incorrectly with the command menu items text printing vertically and overwriting the pane above the menu.

You can get the same behavior by calling
(redisplay-frame-pane :force-p t).

You can then get the display correct by issuing any command in the application-frame or by
by (redisplay-frame-pane :force-p nil).

The ultimate cause of the problem is that command-menu panes are handled differently than other standard pane types as the application-frame definition is expanded  (probably an error of omission).  This results in the command-menu-pane having a different class of pane as its parent and this class mishandles the resize request leading to the pane having a mirror-region of size 0:1, 0:1.

The fix simply provides the code to treat command-menu-panes like other panes:

In frames.lisp:
```
(defun do-pane-creation-form (name form)
  (cond
    ;; Single form which is a function call
    ((and (= (length form) 1)
	  (listp (first form)))
     `(coerce-pane-name ,(first form) ',name))
    ;; Standard pane denoted by a keyword (i.e `:application')
    ((keywordp (first form))
     (case (first form)
       (:application `(make-clim-application-pane
                       :name ',name
                       ,@(cdr form)))
       (:interactor `(make-clim-interactor-pane
                      :name ',name ,@(cdr form)
                      ,@(cdr form)))
       (:pointer-documentation `(make-clim-pointer-documentation-pane
                                 :name ',name
                                 ,@(cdr form)))
       **(:command-menu `(make-clim-command-menu-pane
       			:name ',name
       			,@(cdr form)))**
       (otherwise `(make-pane ,(first form) :name ',name ,@(cdr form)))))
    ;; Non-standard pane designator fed to the `make-pane'
    (t `(make-pane ',(first form) :name ',name ,@(cdr form)))))
```
and in panes.lisp

```
(defun make-clim-command-menu-pane (&rest options)
  (apply #'make-clim-stream-pane :type 'command-menu-pane options))
```