### PR TITLE
Fix pane spacing specifications that use :line and :character

### DIFF
--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -876,11 +876,28 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
            (:pixels (car x))
            (:point  (* (car x) (graft-pixels-per-inch (graft pane)) 1/72))
            (:mm     (* (car x) (graft-pixels-per-millimeter (graft pane))))
-           (:character (* (car x) (text-style-character-width (pane-text-style pane)
-                                                               (sheet-medium pane)
-                                                               #\m)))
-           (:line  (* (car x)
-                      (stream-line-height pane)))))))
+           (:character (device-units-in-character-expression pane x))
+           (:line (device-units-in-line-expression pane x))))))
+
+(defgeneric device-units-in-character-expression (pane character-expression))
+(defmethod device-units-in-character-expression (pane character-expression) 0)
+(defmethod device-units-in-character-expression ((pane single-child-composite-pane) character-expression)
+  (device-units-in-character-expression (sheet-child pane) character-expression))
+(defmethod device-units-in-character-expression ((pane composite-pane) character-expression)
+  (loop for child in (sheet-children pane) maximize (device-units-in-character-expression child character-expression)))
+(defmethod device-units-in-character-expression ((pane clim-stream-pane) character-expression)
+  (* (first character-expression) (text-style-character-width (pane-text-style pane)
+						      (sheet-medium pane)
+						      #\m)))
+
+(defgeneric device-units-in-line-expression (pane line-expression))
+(defmethod device-units-in-line-expression (pane line-expression) 0)
+(defmethod device-units-in-line-expression ((pane single-child-composite-pane) line-expression)
+  (device-units-in-line-expression (sheet-child pane) line-expression))
+(defmethod device-units-in-line-expression ((pane composite-pane) line-expression)
+  (loop for child in (sheet-children pane) maximize (device-units-in-line-expression child line-expression)))
+(defmethod device-units-in-line-expression ((pane clim-stream-pane) line-expression)
+  (* (first line-expression) (stream-line-height pane)))
 
 ;;; SINGLE-CHILD-COMPOSITE PANE
 

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -864,10 +864,10 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
 ;;;; Composite Panes
 ;;;;
 
-(defclass composite-pane (sheet-multiple-child-mixin
-			  basic-pane)
-  ()
-  (:documentation "protocol class"))
+(defgeneric device-units-in-character-expression (pane character-expression))
+(defgeneric device-units-in-line-expression (pane line-expression))
+(defmethod device-units-in-character-expression (pane character-expression) 0)
+(defmethod device-units-in-line-expression (pane line-expression) 0)
 
 (defmethod spacing-value-to-device-units (pane x)
   (cond ((realp x) x)
@@ -879,30 +879,20 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
            (:character (device-units-in-character-expression pane x))
            (:line (device-units-in-line-expression pane x))))))
 
-(defgeneric device-units-in-character-expression (pane character-expression))
-(defmethod device-units-in-character-expression (pane character-expression) 0)
-(defmethod device-units-in-character-expression ((pane single-child-composite-pane) character-expression)
-  (device-units-in-character-expression (sheet-child pane) character-expression))
+(defclass composite-pane (sheet-multiple-child-mixin
+			  basic-pane)
+  ()
+  (:documentation "protocol class"))
+
 (defmethod device-units-in-character-expression ((pane composite-pane) character-expression)
   (loop for child in (sheet-children pane) maximize (device-units-in-character-expression child character-expression)))
-(defmethod device-units-in-character-expression ((pane clim-stream-pane) character-expression)
-  (* (first character-expression) (text-style-character-width (pane-text-style pane)
-						      (sheet-medium pane)
-						      #\m)))
 
-(defgeneric device-units-in-line-expression (pane line-expression))
-(defmethod device-units-in-line-expression (pane line-expression) 0)
-(defmethod device-units-in-line-expression ((pane single-child-composite-pane) line-expression)
-  (device-units-in-line-expression (sheet-child pane) line-expression))
 (defmethod device-units-in-line-expression ((pane composite-pane) line-expression)
   (loop for child in (sheet-children pane) maximize (device-units-in-line-expression child line-expression)))
-(defmethod device-units-in-line-expression ((pane clim-stream-pane) line-expression)
-  (* (first line-expression) (stream-line-height pane)))
 
 ;;; SINGLE-CHILD-COMPOSITE PANE
 
 (defclass single-child-composite-pane (sheet-single-child-mixin basic-pane) ())
-
 
 (defmethod initialize-instance :after ((pane single-child-composite-pane)
 				       &rest args
@@ -923,6 +913,13 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
 (defmethod allocate-space ((pane single-child-composite-pane) width height)
   (when (sheet-child pane)
     (allocate-space (sheet-child pane) width height)))
+
+(defmethod device-units-in-character-expression ((pane single-child-composite-pane) character-expression)
+  (device-units-in-character-expression (sheet-child pane) character-expression))
+
+
+(defmethod device-units-in-line-expression ((pane single-child-composite-pane) line-expression)
+  (device-units-in-line-expression (sheet-child pane) line-expression))
 
 ;;; TOP-LEVEL-SHEET
 
@@ -2631,6 +2628,13 @@ SCROLLER-PANE appear on the ergonomic left hand side, or leave set to
      :height height
      :max-height +fill+)))
 
+(defmethod device-units-in-line-expression ((pane clim-stream-pane) line-expression)
+  (* (first line-expression) (stream-line-height pane)))
+(defmethod device-units-in-character-expression ((pane clim-stream-pane) character-expression)
+  (* (first character-expression) (text-style-character-width (pane-text-style pane)
+						      (sheet-medium pane)
+						      #\m)))
+
 (defmethod window-clear ((pane clim-stream-pane))
   (stream-close-text-output-record pane)
   (let ((output-history (stream-output-history pane)))
@@ -2863,6 +2867,9 @@ current background message was set."))
 
 (defun make-clim-pointer-documentation-pane (&rest options)
   (apply #'make-clim-stream-pane :type 'pointer-documentation-pane options))
+
+(defun make-clim-command-menu-pane (&rest options)
+  (apply #'make-clim-stream-pane :type 'command-menu-pane options))
 
 
 ;;;


### PR DESCRIPTION
Currently a pane specification that uses :height '(n :line) or :width '(n character) causes an error.  This is because the function spacing-value-to-device-units  (in panes.lisp) calls text-style-character-width or stream-line-height on the pane.  The problem is that the pane can be a composite pane (particularly if there are scroll bars or borders) and these panes don't handle the method.  The fix is to maximize the heights (or widths) of the children panes.