### PR TITLE
Fix the bug where define-command-table on an existing table throws aw…

### DIFF
--- a/Core/clim-core/commands.lisp
+++ b/Core/clim-core/commands.lisp
@@ -223,19 +223,27 @@ designator) inherits menu items."
 
 (make-command-table 'user-command-table)
 
-(defmacro define-command-table (name &key inherit-from menu inherit-menu)
-  `(let ((old-table (gethash ',name *command-tables* nil))
-	 (inherit-from-arg (or ',inherit-from '(global-command-table))))
-     (if old-table
-	 (with-slots (inherit-from menu) old-table
-	   (setq inherit-from inherit-from-arg
-		 menu (menu-items-from-list ',menu))
-	   old-table)
-	 (make-command-table ',name
-			     :inherit-from inherit-from-arg
-                             :inherit-menu ,inherit-menu
-			     :menu ',menu
-			     :errorp nil))))
+(defmacro define-command-table (name &key (inherit-from nil inherit-supplied-p)
+				       (menu nil menu-supplied-p)
+				       inherit-menu)
+  (let ((inherit-from-arg (or inherit-from '(global-command-table))))
+    (declare (ignorable inherit-from-arg))
+    `(let ((old-table (gethash ',name *command-tables* nil)))
+       (if old-table
+	   (with-slots (inherit-from menu) old-table
+	     ,(if inherit-supplied-p
+		  `(setq inherit-from ',inherit-from)
+		  `(setq inherit-from '(global-command-table)))
+	     ,@(when menu-supplied-p
+		`((setq menu (menu-items-from-list ',menu))))
+	     old-table)
+	   (make-command-table ',name
+			       :inherit-from ,(if inherit-supplied-p
+						  `',inherit-from-arg
+						  `'(global-command-table))
+			       :inherit-menu ,inherit-menu
+			       :menu ',menu
+			       :errorp nil)))))
 
 (defun remove-command-from-command-table (command-name
 					  command-table


### PR DESCRIPTION
…ay the menu items. Issue #751

Define-command-table loses old commands when redefining the command table.  Define-application-frame expands into (among many other things) an invocation of define-command-table so if during development the application-frame is redefined, you lose all the commands in the command menu.