### PR TITLE
panes: improve spacing-value-to-device-units

### DIFF
--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -66,7 +66,7 @@
 
 (climi::define-abstract-pane-mapping 'tab-layout 'tab-layout-pane)
 
-(defclass tab-layout (climi::composite-pane)
+(defclass tab-layout (climi::multiple-child-composite-pane)
     ((pages :initform nil :reader tab-layout-pages :initarg :pages)
      (enabled-page :initform nil :accessor tab-layout-enabled-page))
   (:documentation "The abstract tab layout pane is a composite pane arranging


### PR DESCRIPTION
- ensure cons arity with destructuring-bind
- use etypecase on x value (real or cons) to avoid returning nil
- maximize text metric value on children when called on composite pane
- provide disjoint method for basic pane and extended-output-stream