### PR TITLE
top-level-sheet-pane sheet-transformation

### DIFF
--- a/Core/clim-basic/events.lisp
+++ b/Core/clim-basic/events.lisp
@@ -220,12 +220,12 @@
 (define-event-class window-configuration-event (window-event)
   ((x :initarg :x :reader window-configuration-event-native-x)
    (y :initarg :y :reader window-configuration-event-native-y)
-   (width :initarg :width :reader window-configuration-event-width)
-   (height :initarg :height :reader window-configuration-event-height)))
+   (width :initarg :width :reader window-configuration-event-native-width)
+   (height :initarg :height :reader window-configuration-event-native-height)))
 
 (defmacro get-window-position ((sheet event) &body body)
   `(multiple-value-bind (x y)
-       (transform-position (sheet-native-transformation ,sheet)
+       (untransform-position (sheet-native-transformation (sheet-parent ,sheet))
 			   (window-configuration-event-native-x ,event)
 			   (window-configuration-event-native-y ,event))
      (declare (ignorable x y))
@@ -240,6 +240,24 @@
 
 (defmethod window-configuration-event-y ((event window-configuration-event))
   (get-window-position ((event-sheet event) event) y))
+
+(defgeneric window-configuration-event-width (window-configuration-event)
+  (:method ((event window-configuration-event))
+    (multiple-value-bind (width height)
+        (untransform-distance  (sheet-native-transformation
+                                (sheet-parent (event-sheet event)))
+                               (window-configuration-event-native-width event)
+                               (window-configuration-event-native-height event))
+      width)))
+
+(defgeneric window-configuration-event-height (window-configuration-event)
+  (:method ((event window-configuration-event))
+    (multiple-value-bind (width height)
+        (untransform-distance  (sheet-native-transformation
+                                (sheet-parent (event-sheet event)))
+                               (window-configuration-event-native-width event)
+                               (window-configuration-event-native-height event))
+      height)))
 
 (define-event-class window-unmap-event (window-event)
   ())

--- a/Core/clim-basic/mirrors.lisp
+++ b/Core/clim-basic/mirrors.lisp
@@ -176,10 +176,16 @@ very hard)."
   (let* ((parent (sheet-parent sheet))
          (sheet-region-in-native-parent
            ;; this now is the wanted sheet mirror region
-           (transform-region (sheet-native-transformation parent)
+          (if (graftp parent)
+              ;; For the TOP-LEVEL-SHEET-PANE (when the parent is a GRAFT) we don't
+              ;; clip the sheet-region with the parent-region. -- admich 2019-05-30
+              (transform-region (sheet-native-transformation parent)
+                                (transform-region (sheet-transformation sheet)
+                                                  (sheet-region sheet)))
+              (transform-region (sheet-native-transformation parent)
                              (region-intersection (sheet-region parent)
                                                   (transform-region (sheet-transformation sheet)
-                                                                    (sheet-region sheet))))))
+                                                                    (sheet-region sheet)))))))
     (when (region-equal sheet-region-in-native-parent +nowhere+)
       (%set-mirror-geometry sheet :invalidate-transformations t)
       (return-from update-mirror-geometry))

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -975,8 +975,8 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
 
 (defmethod handle-event ((sheet top-level-sheet-pane)
                          (event window-configuration-event))
-  (let ((x (window-configuration-event-native-x event))
-        (y (window-configuration-event-native-y event))
+  (let ((x (window-configuration-event-x event))
+        (y (window-configuration-event-y event))
         (width (window-configuration-event-width event))
         (height (window-configuration-event-height event)))
     (let ((*configuration-event-p* sheet))
@@ -984,7 +984,7 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
        sheet
        (make-bounding-rectangle 0 0 width height)
        ;; negative offsets are handled by the native transformation?
-       (make-translation-transformation (max 0 x) (max 0 y))))))
+       (make-translation-transformation x y)))))
 
 (defmethod handle-event ((pane top-level-sheet-pane)
 			 (event window-manager-delete-event))


### PR DESCRIPTION
This PR solve #769 about the wrong sheet-transformation of a top-level-sheet-pane when it start outside the screen. 

For this it  revert the changes of commit a894385 in PR #691 and find another solution to fix 
the bug of issue #499 solved by that PR.

There is also some changes in window-configuration-event.