### PR TITLE
Set pointer position

### DIFF
--- a/Backends/CLX/basic.lisp
+++ b/Backends/CLX/basic.lisp
@@ -110,24 +110,12 @@
 
 (defmethod pointer-position ((pointer clx-basic-pointer))
   (let* ((port (port pointer))
-	 (sheet (port-pointer-sheet port)))
-    (when sheet
-      (multiple-value-bind (x y same-screen-p)
-	  (xlib:query-pointer (sheet-xmirror sheet))
-	(when same-screen-p
-	  (untransform-position (sheet-native-transformation sheet) x y))))))
-
-(defmethod clim-internals::sheet-pointer-position (sheet (pointer clx-basic-pointer))
-  (if (sheet-direct-mirror sheet)
-      (multiple-value-bind (native-x native-y) (xlib:query-pointer (sheet-xmirror sheet))
-	(untransform-position (sheet-device-transformation sheet) native-x native-y))
-      (let* ((mirrored-ancestor (sheet-mirrored-ancestor sheet))
-	     (mirror (sheet-direct-xmirror mirrored-ancestor)))
-	(multiple-value-bind (native-x native-y) (xlib:query-pointer mirror)
-	  (multiple-value-bind (parent-x parent-y)
-	      (untransform-position (sheet-device-transformation mirrored-ancestor) native-x native-y)
-	    (untransform-position (sheet-delta-transformation sheet mirrored-ancestor) parent-x parent-y)
-	    )))))
+         (graft (graft port))
+         (xmirror (sheet-xmirror graft)))
+    (multiple-value-bind (x y same-screen-p)
+        (xlib:query-pointer xmirror)
+      (when same-screen-p
+        (untransform-position (sheet-native-transformation graft) x y)))))
 
 (defmethod set-sheet-pointer-cursor ((port clx-basic-port) (sheet mirrored-sheet-mixin) cursor)
   (let ((cursor (gethash (or cursor :default) (clx-port-cursor-table port)))

--- a/Backends/CLX/basic.lisp
+++ b/Backends/CLX/basic.lisp
@@ -117,6 +117,14 @@
       (when same-screen-p
         (untransform-position (sheet-native-transformation graft) x y)))))
 
+(clim-sys:defmethod* (setf pointer-position) (x y (pointer clx-basic-pointer))
+  (let* ((port (port pointer))
+         (graft (graft port))
+         (xmirror (sheet-xmirror graft)))
+    (multiple-value-bind (x y)
+        (transform-position (sheet-native-transformation graft) x y)
+      (xlib:warp-pointer xmirror (round x) (round y)))))
+
 (defmethod set-sheet-pointer-cursor ((port clx-basic-port) (sheet mirrored-sheet-mixin) cursor)
   (let ((cursor (gethash (or cursor :default) (clx-port-cursor-table port)))
 	(mirror (sheet-direct-xmirror sheet)))

--- a/Core/clim-basic/decls.lisp
+++ b/Core/clim-basic/decls.lisp
@@ -675,7 +675,7 @@ unspecified. "))
 (defgeneric stream-input-buffer (stream))
 (defgeneric (setf stream-input-buffer) (buffer stream))
 (defgeneric stream-pointer-position (stream &key pointer))
-;; (defgeneric (setf* stream-pointer-position))
+(defgeneric* (setf stream-pointer-position) (x y stream))
 (defgeneric stream-set-input-focus (stream))
 (defgeneric stream-read-gesture
     (stream &key timeout peek-p input-wait-test

--- a/Core/clim-basic/stream-input.lisp
+++ b/Core/clim-basic/stream-input.lisp
@@ -744,23 +744,10 @@ known gestures."
           (logandc2 (slot-value pointer 'button-state)
                     (pointer-event-button event)))))
 
-
-(defgeneric sheet-pointer-position (sheet pointer))
-
-(defmethod sheet-pointer-position (sheet pointer)
-  (multiple-value-bind (x y)
-      (pointer-position pointer)
-    (let ((pointer-sheet (port-pointer-sheet (port sheet))))
-      (if (eq sheet pointer-sheet)
-          (values x y)
-          ;; Is this right?
-          (multiple-value-bind (native-x native-y)
-              (transform-position (sheet-native-transformation sheet) x y)
-            (untransform-position (sheet-native-transformation pointer-sheet)
-                                  native-x
-                                  native-y))))))
-
 (defmethod stream-pointer-position ((stream standard-extended-input-stream)
                                     &key (pointer
                                           (port-pointer (port stream))))
-  (sheet-pointer-position stream pointer))
+  (multiple-value-bind (x y)
+      (pointer-position pointer)
+    (let ((graft (graft (port pointer))))
+      (untransform-position (sheet-delta-transformation stream graft) x y))))

--- a/Core/clim-basic/stream-input.lisp
+++ b/Core/clim-basic/stream-input.lisp
@@ -751,3 +751,10 @@ known gestures."
       (pointer-position pointer)
     (let ((graft (graft (port pointer))))
       (untransform-position (sheet-delta-transformation stream graft) x y))))
+
+(defmethod* (setf stream-pointer-position) (x y (stream standard-extended-input-stream))
+  (let ((graft (graft stream))
+        (pointer (port-pointer (port stream))))
+    (multiple-value-bind (x y)
+        (transform-position (sheet-delta-transformation stream graft) x y)
+      (setf (pointer-position pointer) (values x y)))))

--- a/Core/clim-core/pointer-tracking.lisp
+++ b/Core/clim-core/pointer-tracking.lisp
@@ -335,10 +335,6 @@ symbol)."
                    (when ox (draw ox oy))
                    (return-from dragging-drawing
                      (values x y)))))
-        ;; Make an initial draw. We need to convert the screen
-        ;; coordinates from the pointer into sheet-local coordinates.
-        (multiple-value-call #'transform-position
-          (sheet-native-transformation stream) (pointer-position pointer))
         (tracking-pointer (stream :pointer pointer
                                   :multiple-window multiple-window)
           (:pointer-motion (window x y)


### PR DESCRIPTION
This PR change the semantic of `pointer-position` that now return the position of the pointer in the graft coordinate. This is a possible interpretation of the clim specifications (section 22.4) different from what is written in Franz Manual (section 15.1).

The PR implements also the functions `(setf pointer-position)` and `(setf stream-pointer-position)` . 

This solve issue #768.

This PR have PR #774 as pre-requisite otherwise the position of `stream-pointer-position` when frame window start outside the screen it is not correct because the sheet-transformations are not correct.