### PR TITLE
Fix Issue #783, automagic-clx-server-path

### DIFF
--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -47,7 +47,7 @@
     (let* (; this code courtesy telent-clx.
            (slash-i (or (position #\/ name) -1))
            (colon-i (position #\: name :start (1+ slash-i)))
-           (decnet-colon-p (eql (elt name (1+ colon-i)) #\:))
+           (decnet-colon-p (and colon-i (eql (elt name (1+ colon-i)) #\:)))
            (host (subseq name (1+ slash-i) colon-i))
            (dot-i (and colon-i (position #\. name :start colon-i)))
            (display (and colon-i


### PR DESCRIPTION
The function supposes an occurence of at least one #\: in the DISPLAY
environment variable. This isn't guaranteed (for example, with XQuartz, DISPLAY
is set to computer-name.network-name), and in fact the use-localhost
restart of helpfully-automagic-clx-server-path passes an empty string onwards.