### PR TITLE
[wip] input-refactor: separate input-buffer from event-queue

### DIFF
--- a/Core/clim-basic/input.lisp
+++ b/Core/clim-basic/input.lisp
@@ -453,17 +453,10 @@ use condition-variables nor locks."))
                         (make-instance 'concurrent-event-queue)
                         (make-instance 'simple-event-queue))
           :reader sheet-event-queue
-          :initarg :input-buffer)
+          :initarg :event-queue)
    (port :initform nil
          :initarg :port
          :reader port)))
-
-(defmethod stream-input-buffer ((stream standard-sheet-input-mixin))
-  (sheet-event-queue stream))
-
-(defmethod (setf stream-input-buffer) (new-val
-                                       (stream standard-sheet-input-mixin))
-  (setf (slot-value stream 'queue) new-val))
 
 (defmethod dispatch-event ((sheet standard-sheet-input-mixin) event)
   (queue-event sheet event))
@@ -491,12 +484,10 @@ use condition-variables nor locks."))
 
 (defmethod event-peek ((sheet standard-sheet-input-mixin) &optional event-type)
   (with-slots (queue) sheet
-    (if event-type
-        (event-queue-peek-if (lambda (x)
-                               (typep x event-type))
-                             queue)
-        (event-queue-peek-if (lambda (x) (declare (ignore x)) t)
-                             queue))))
+    (let ((predicate (if event-type
+                         (lambda (x) (typep x event-type))
+                         (lambda (x) (declare (ignore x)) t))))
+      (event-queue-peek-if predicate queue))))
 
 (defmethod event-unread ((sheet standard-sheet-input-mixin) event)
   (with-slots (queue) sheet
@@ -506,18 +497,9 @@ use condition-variables nor locks."))
   (with-slots (queue) sheet
     (event-queue-listen queue)))
 
-;;; Support for callers that want to set an event queue for every pane.
 
 (defclass no-event-queue-mixin ()
   ())
-
-(defmethod initialize-instance :after ((obj no-event-queue-mixin)
-                                       &key input-buffer)
-  (declare (ignore input-buffer))
-  nil)
-
-(defmethod (setf stream-input-buffer) (new-val (stream no-event-queue-mixin))
-  new-val)
 
 (defclass immediate-sheet-input-mixin (no-event-queue-mixin)
   ())
@@ -526,7 +508,7 @@ use condition-variables nor locks."))
   (handle-event sheet event))
 
 (defmethod handle-event ((sheet immediate-sheet-input-mixin) event)
-  (declare (ignore event))
+  (declare (ignore sheet event))
   nil)
 
 (define-condition sheet-is-mute-for-input (error)
@@ -573,21 +555,7 @@ use condition-variables nor locks."))
 (defclass delegate-sheet-input-mixin ()
   ((delegate :initform nil
              :initarg :delegate
-             :accessor delegate-sheet-delegate) ))
-
-;;; Don't know if this event queue stuff is completely right, or if it
-;;; matters much...
-
-(defmethod initialize-instance :after ((obj delegate-sheet-input-mixin)
-                                       &key input-buffer)
-  (declare (ignore input-buffer)))
-
-(defmethod stream-input-buffer ((stream delegate-sheet-input-mixin))
-  (sheet-event-queue (delegate-sheet-delegate stream)))
-
-(defmethod (setf stream-input-buffer) (new-val
-                                       (stream delegate-sheet-input-mixin))
-  (setf (stream-input-buffer (delegate-sheet-delegate stream)) new-val))
+             :accessor delegate-sheet-delegate)))
 
 (defmethod dispatch-event ((sheet delegate-sheet-input-mixin) event)
   (dispatch-event (delegate-sheet-delegate sheet) event))

--- a/Core/clim-basic/protocol-classes.lisp
+++ b/Core/clim-basic/protocol-classes.lisp
@@ -191,10 +191,16 @@
 
 ;;;; Part VI: Extended Stream Input Facilities
 
+;;; This class is only hinted in the spec (hence it will remain in the
+;;; internals).
+(define-protocol-class input-stream
+    (fundamental-input-stream)
+  ())
+
 ;;; 22.2 Extended Input Streams
 
 (define-protocol-class extended-input-stream
-    (fundamental-character-input-stream)
+    (input-stream)
   ())
 
 ;;; 22.4 The Pointer Protocol

--- a/Core/clim-basic/stream-input.lisp
+++ b/Core/clim-basic/stream-input.lisp
@@ -1,128 +1,244 @@
 ;;; -*- Mode: Lisp; Package: CLIM-INTERNALS -*-
 
 ;;;  (c) copyright 1998,1999,2000 by Michael McDonald (mikemac@mikemac.com)
-;;;  (c) copyright 2000, 2014 by
-;;;           Robert Strandh (robert.strandh@gmail.com)
+;;;  (c) copyright 2000,2014 by Robert Strandh (robert.strandh@gmail.com)
 ;;;  (c) copyright 2001,2002 by Tim Moore (moore@bricoworks.com)
-
-;;; This library is free software; you can redistribute it and/or
-;;; modify it under the terms of the GNU Library General Public
-;;; License as published by the Free Software Foundation; either
-;;; version 2 of the License, or (at your option) any later version.
+;;;  (c) copyright 2019 by Daniel Kochmański (daniel@turtleware.eu)
 ;;;
-;;; This library is distributed in the hope that it will be useful,
-;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;;; Library General Public License for more details.
-;;;
-;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;;; Boston, MA  02111-1307  USA.
+;;; License: LGPL-2.1+
 
-(in-package :clim-internals)
+;;; Part VI: Extended Stream Input Facilities
+;;; Chapter 22: Extended Stream Input
 
-;;; X11 returns #\Return and #\Backspace where we want to see
-;;; #\Newline and #\Delete at the stream-read-char level.  Dunno if
-;;; this is the right place to do the transformation...
+(in-package #:clim-internals)
 
-;;;  Why exactly do we want to see #\Delete instead of #\Backspace?
-;;;  There is a separate Delete key, unless your keyboard is
-;;;  strange. --Hefner
-
-(defconstant +read-char-map+ '((#\Return . #\Newline)
-                               #+nil (#\Backspace . #\Delete)))
-
-(defvar *abort-gestures* '(:abort))
-
-(defvar *accelerator-gestures* nil)
+;; Input gesture object may be a character or event. Keywords are
+;; returned to indicate the failure to obtain a gesture. We could extend
+;; this list with a string (look up noise strings). -- jd
+(deftype input-gesture-object ()
+  `(or character event keyword))
 
 (defvar *input-wait-test* nil)
 (defvar *input-wait-handler* nil)
 (defvar *pointer-button-press-handler* nil)
 
-(define-condition abort-gesture (condition)
-  ((event :reader %abort-gesture-event :initarg :event)))
+
+;;; CLIM's input kernel is only hinted in the CLIM II Specification. -- jd 2019-06-24
+(defclass input-stream-kernel (standard-sheet-input-mixin)
+  ((buffer :initarg :input-buffer :accessor stream-input-buffer
+           :type (vector input-gesture-object))
+   (sp :accessor stream-scan-pointer
+       :type integer :documentation "Scan pointer.")
+   (ip :accessor stream-insertion-pointer
+       :type integer :documentation "Insertion pointer.")))
 
-(defmethod abort-gesture-event ((condition abort-gesture))
-  (%abort-gesture-event condition))
+(defmethod slot-unbound (class (instance input-stream-kernel) (slot-name (eql 'buffer)))
+  (setf (slot-value instance 'buffer)
+        (make-array 0 :adjustable t :fill-pointer 0)))
+
+(defmethod slot-unbound (class (instance input-stream-kernel) (slot-name (eql 'sp)))
+  (setf (slot-value instance 'sp) 0))
+
+(defmethod slot-unbound (class (instance input-stream-kernel) (slot-name (eql 'ip)))
+  (setf (slot-value instance 'ip)
+        (length (stream-input-buffer instance))))
+
+(defmethod (setf stream-input-buffer) :after (buf (stream input-stream-kernel))
+  (setf (stream-scan-pointer stream) 0
+        (stream-insertion-pointer stream) (length buf)))
+
+(defmethod (setf stream-scan-pointer) :before (sp (stream input-stream-kernel))
+  (let ((ip (stream-insertion-pointer stream)))
+    (unless (<= 0 sp ip)
+      (error "STREAM-SCAN-POINTER ~s is not in range [0; ~s]." sp ip))))
+
+(defmethod (setf stream-insertion-pointer) :before (ip (stream input-stream-kernel))
+  (let ((sp (stream-scan-pointer stream))
+        (fp (length (stream-input-buffer stream))))
+    (unless (<= sp ip fp)
+      (error "STREAM-INSERTION-POINTER ~s is not in range [~s; ~s]." ip sp fp))))
+
+(defgeneric stream-append-gesture (stream gesture)
+  (:method ((stream input-stream-kernel) gesture)
+    (with-slots (buffer ip) stream
+      (vector-push-extend gesture buffer)
+      (incf ip))))
+
+;;; This function is like "peek-no-hang" but only locally in the
+;;; buffer, i.e it does not trigger wait on event-queue.
+(defgeneric stream-gesture-available-p (stream)
+  (:method ((stream input-stream-kernel))
+    (with-slots (ip sp buffer) stream
+      (if (< sp ip)
+          (aref buffer sp)
+          nil))))
+
+;;; Default input-stream-kernel methods.
+
+;;; Event queue is accessed by streams only in STREAM-INPUT-WAIT.
+;;; INPUT-BUFFER is filled in handle-event methods. -- jd 2019-06-26
+(defmethod stream-input-wait ((stream input-stream-kernel) &key timeout input-wait-test)
+  (loop
+     with wait-fun = (and input-wait-test (curry input-wait-test stream))
+     until (stream-gesture-available-p stream)
+     do (multiple-value-bind (available reason)
+            (event-listen-or-wait stream :timeout timeout :wait-function wait-fun)
+          (when (null available)
+            (return-from stream-input-wait (values nil reason)))
+          ;; Defensive programming: we could do without when-let if we assume
+          ;; that nobody accessess asynchronously the queue. -- jd
+          (alexandria:when-let* ((event (event-read-no-hang stream))
+                                 (sheet (event-sheet event)))
+            (handle-event sheet event)))
+     finally (return t)))
+
+(defmethod stream-listen ((stream input-stream-kernel))
+  (stream-input-wait stream))
+
+(defmethod stream-read-gesture ((stream input-stream-kernel)
+                                &key timeout peek-p
+                                  (input-wait-test *input-wait-test*)
+                                  (input-wait-handler *input-wait-handler*)
+                                  (pointer-button-press-handler *pointer-button-press-handler*))
+  (let ((*input-wait-test* input-wait-test)
+        (*input-wait-handler* input-wait-handler)
+        (*pointer-button-press-handler* pointer-button-press-handler))
+    ;; Check for available input.
+    (multiple-value-bind (available reason)
+        (stream-input-wait stream :timeout timeout :input-wait-test input-wait-test)
+      (when (null available)
+        (maybe-funcall input-wait-handler stream)
+        (return-from stream-read-gesture (values nil reason))))
+    ;; Input is available (or the stream is exhausted).
+    (with-slots (sp ip buffer) stream
+      (assert (<= 0 sp ip (length buffer)))
+      (when (= sp ip)
+        (return-from stream-read-gesture (values nil :eof)))
+      (prog1 (aref buffer sp)
+        (unless peek-p
+          (incf sp))))))
+
+(defmethod stream-unread-gesture ((stream input-stream-kernel) gesture)
+  (with-slots (sp ip buffer) stream
+    (assert (<= 1 sp ip (length buffer)))
+    (assert (eql (aref buffer (1- sp)) gesture))
+    (decf sp))
+  nil)
+
+(defmethod stream-clear-input ((stream input-stream-kernel))
+  (with-slots (sp ip buffer) stream
+    (setf sp 0
+          ip 0)
+    ;; XXX: in principle input buffer should have a fill-pointer but in
+    ;; practice supporting strings as input buffers is profitable.  Such
+    ;; buffers will break if anyone tries to append to them. When
+    ;; cleared we swap the buffer with a fresh one. --jd 2019-06-26
+    (if (array-has-fill-pointer-p buffer)
+        (setf (fill-pointer buffer) 0)
+        (slot-makunbound stream 'buffer)))
+  nil)
+
+;;; Trampolines for stream-read-gesture and stream-unread-gesture.
+(defun read-gesture (&key (stream *standard-input*) timeout peek-p
+                       (input-wait-test *input-wait-test*)
+                       (input-wait-handler *input-wait-handler*)
+                       (pointer-button-press-handler *pointer-button-press-handler*))
+  (stream-read-gesture stream
+                       :timeout timeout
+                       :peek-p peek-p
+                       :input-wait-test input-wait-test
+                       :input-wait-handler input-wait-handler
+                       :pointer-button-press-handler pointer-button-press-handler))
+
+(defun unread-gesture (gesture &key (stream *standard-input*))
+  (stream-unread-gesture stream gesture))
+
+
+;;; 22.1 Basic Input Streams
+
+;;; Basic input streams are character streams. It should not happen
+;;; that input-buffer contains anything else than characters. This
+;;; class is disjoint to the extended-input-stream protocol.
+;;;
+;;; Part of the extended input stream protocol is mixed in thanks to
+;;; the input-stream-kernel (STREAM-INPUT-BUFFER, STREAM-SCAN-POINTER
+;;; and STREAM-INSERTION-POINTER accessors and :INPUT-BUFFER
+;;; initarg). It is good because this protocol makes sense here.
+
+(defclass standard-input-stream (input-stream-kernel
+                                 input-stream
+                                 fundamental-character-input-stream)
+  ())
+
+(defmethod handle-event :after ((client standard-input-stream) (event key-press-event))
+  (when-let ((ch (keyboard-event-character event)))
+    (stream-append-gesture client ch)))
+
+;;; X11 returns #\Return where we want to see #\Newline at the
+;;; stream-read-char level.  Dunno if this is the right place to do
+;;; the transformation... --moore
+(defun voodoo (char)
+  (check-type char (or character null))
+  (case char
+    (#\return #\newline)
+    (otherwise char)))
+
+(defmethod stream-read-char ((stream standard-input-stream))
+  (voodoo (stream-read-gesture stream
+                               :input-wait-test nil
+                               :input-wait-handler nil
+                               :pointer-button-press-handler nil)))
+
+(defmethod stream-read-char-no-hang ((stream standard-input-stream))
+  (voodoo (stream-read-gesture stream
+                               :timeout 0
+                               :input-wait-test nil
+                               :input-wait-handler nil
+                               :pointer-button-press-handler nil)))
+
+(defmethod stream-unread-char ((stream standard-input-stream) char)
+  ;; Normally we would simply call (stream-unread-gesture stream char)
+  ;; but standard-input-stream does some voodoo with the character fixup
+  ;; so we must skip the second assertion (the unread gesture is the
+  ;; same as the supplied one). -- jd 2019-06-25
+  (check-type char character)
+  (with-slots (sp ip buffer) stream
+    (assert (<= 1 sp ip (length buffer)))
+    ;; (assert (eql (aref buffer (1- sp)) gesture))
+    (decf sp))
+  nil)
+
+(defmethod stream-peek-char ((stream standard-input-stream))
+  (let ((char (stream-read-gesture stream :peek-p t)))
+    (check-type char character)
+    char))
+
+(defmethod stream-read-line ((stream standard-input-stream))
+  (with-slots (sp ip buffer) stream
+    (assert (<= 0 sp ip (length buffer)))
+    (let ((end (position #\newline buffer :start sp :end ip :test #'char=)))
+      (multiple-value-prog1 (values (subseq buffer sp (or end ip)) (not end))
+        (if (null end)
+            (setf sp ip)
+            (setf sp (1+ end)))))))
+
+
+;;; 22.2 Extended Input Streams
+
+;;; 22.2.2 Extended Input Stream Conditions
+(defvar *abort-gestures* '(:abort))
+(defvar *accelerator-gestures* nil)
+
+(define-condition abort-gesture (condition)
+  ((event :reader abort-gesture-event :initarg :event)))
 
 (define-condition accelerator-gesture (condition)
-  ((event :reader %accelerator-gesture-event :initarg :event)
-   (numeric-argument :reader %accelerator-gesture-numeric-argument
+  ((event :reader accelerator-gesture-event :initarg :event)
+   (numeric-argument :reader accelerator-gesture-numeric-argument
                      :initarg :numeric-argument
                      :initform 1)))
 
-(defmethod accelerator-gesture-event ((condition accelerator-gesture))
-  (%accelerator-gesture-event condition))
-
-(defmethod accelerator-gesture-numeric-argument
-    ((condition accelerator-gesture))
-  (%accelerator-gesture-numeric-argument condition))
-
-(defun char-for-read (char)
-  (let ((new-char (cdr (assoc char +read-char-map+))))
-    (or new-char char)))
-
-(defun unmap-char-for-read (char)
-  (let ((new-char (car (rassoc char +read-char-map+))))
-    (or new-char char)))
-
-(defclass input-kernel ()
-  ((input-buffer :initarg :input-buffer :accessor stream-input-buffer :type vector)))
-
-;;; Streams are subclasses of standard-sheet-input-mixin regardless of whether
-;;; or not we are multiprocessing.  In single-process mode the blocking calls to
-;;; stream-read-char, stream-read-gesture are what cause process-next-event to
-;;; be called.  It's most convenient to let process-next-event queue up events
-;;; for the stream and then see what we've got after it returns.
-
-(defclass standard-input-stream (input-kernel
-                                 fundamental-character-input-stream
-                                 standard-sheet-input-mixin)
-  ((unread-chars :initform nil :accessor stream-unread-chars)))
-
-;;; XXX: fixing stream shisophrenia is a subject of the next input-refactor pass.
-;;; 1. What about EOF?
-;;; 2. GESTURE-OBJECT should be already coerced to a character!
-;;;   2a. We don't handle modifiers here, so it is double wrong, see stream-process-gesture.
-;;; 3. HANDLE-EVENT should have been invoked on a completely different level. -- jd 2018-12-20
-(defmethod stream-read-char ((pane standard-input-stream))
-  (if (stream-unread-chars pane)
-      (pop (stream-unread-chars pane))
-      (let ((event (event-read pane)))  ; (1)
-        (if (and (typep event 'key-press-event)  ; (2)
-                 (keyboard-event-character event)) ; (2a)
-            (let ((char (char-for-read (keyboard-event-character event))))
-              (stream-write-char pane char)
-              (return-from stream-read-char char))
-            ;; (3)
-            (handle-event (event-sheet event) event)))))
-
-(defmethod stream-unread-char ((pane standard-input-stream) char)
-  (push char (stream-unread-chars pane)))
-
-(defmethod stream-read-char-no-hang ((pane standard-input-stream))
-  (if (stream-unread-chars pane)
-      (pop (stream-unread-chars pane))
-    (loop for event = (event-read-no-hang pane)
-        if (null event)
-           return nil
-        if (and (typep event 'key-press-event)
-                (keyboard-event-character event))
-          return (char-for-read (keyboard-event-character event))
-        else
-          do (handle-event (event-sheet event) event))))
-
-(defmethod stream-clear-input ((pane standard-input-stream))
-  (setf (stream-unread-chars pane) nil)
-  (loop for event = (event-read-no-hang pane)
-        if (null event)
-           return nil
-        else
-        do (handle-event (event-sheet event) event))
-  nil)
-
+;;;
 (defclass dead-key-merging-mixin ()
   ((state :initform *dead-key-table*)
    ;; Avoid name clash with standard-extended-input-stream.
@@ -173,284 +289,69 @@ keys read."))
         (call-next-method stream last-deadie-gesture))
       (call-next-method)))
 
-(defclass standard-extended-input-stream (input-kernel
-                                          extended-input-stream
-                                          dead-key-merging-mixin
-                                          standard-sheet-input-mixin)
-  ((pointer)
-   (cursor :initarg :text-cursor)
-   (last-gesture :accessor last-gesture :initform nil
-    :documentation "Holds the last gesture returned by stream-read-gesture
-(not peek-p), untransformed, so it can easily be unread.")))
+;;; Extended input streams are more versatile than basic input
+;;; streams. They allow manipulating arbitrary user gestures (not
+;;; necessarily characters), i.e pointer button presses. This class is
+;;; disjoint from STANDARD-INPUT-STREAM and does not implement
+;;; fundamental-character-input-stream protocol (read-char etc).
+
+(defclass standard-extended-input-stream (input-stream-kernel
+                                          extended-input-stream)
+  ())
+
+(defmethod handle-event :after ((client standard-extended-input-stream) (event key-press-event))
+  (if-let ((ch (keyboard-event-character event)))
+    (stream-append-gesture client ch)
+    (stream-append-gesture client event)))
+
+(defmethod handle-event :after ((client standard-extended-input-stream)
+                                (event pointer-event))
+  (stream-append-gesture client event))
+
+(defmethod stream-read-gesture ((stream standard-extended-input-stream)
+                                &key pointer-button-press-handler &allow-other-keys)
+  (multiple-value-bind (gesture unavailable-reason)
+      (call-next-method)
+    (if (null gesture)
+        (values nil unavailable-reason)
+        (flet ((abort-gesture-p (gesture)
+                 (loop for gesture-name in *abort-gestures*
+                    thereis (event-matches-gesture-name-p gesture gesture-name)))
+               (accelerator-gesture-p (gesture)
+                 (loop for gesture-name in *accelerator-gestures*
+                    thereis (event-matches-gesture-name-p gesture gesture-name))))
+          (cond
+            ((abort-gesture-p gesture)
+             (signal 'abort-gesture :event gesture))
+            ((accelerator-gesture-p gesture)
+             (signal 'accelerator-gesture :event gesture))
+            ((and pointer-button-press-handler
+                  (typep gesture 'pointer-button-press-event))
+             (format *debug-io* "calling pointer button press handler")
+             (funcall pointer-button-press-handler stream gesture))
+            (t
+             (return-from stream-read-gesture gesture)))))))
+
+;;; stream-input-buffer, (setf stream-input-buffer) are implemented
+;;; for input-stream-kernel.
 
 (defmethod stream-set-input-focus ((stream standard-extended-input-stream))
-  (let ((port (or (port stream)
-                  (port *application-frame*))))
+  (when-let ((port (port stream)))
     (prog1 (port-keyboard-input-focus port)
       (setf (port-keyboard-input-focus port) stream))))
 
+(defmethod invoke-with-input-focus ((stream standard-extended-input-stream) continuation)
+  (let ((old-stream (stream-set-input-focus stream)))
+    (unwind-protect (funcall continuation stream)
+      (when old-stream
+        (stream-set-input-focus old-stream)))))
+
 (defmacro with-input-focus ((stream) &body body)
-  (when (eq stream t)
-    (setq stream '*standard-input*))
-  (let ((old-stream (gensym "OLD-STREAM")))
-    `(let ((,old-stream (stream-set-input-focus ,stream)))
-       (unwind-protect (locally ,@body)
-         (when ,old-stream
-           (stream-set-input-focus ,old-stream))))))
-
-(defun read-gesture (&key
-                     (stream *standard-input*)
-                     timeout
-                     peek-p
-                     (input-wait-test *input-wait-test*)
-                     (input-wait-handler *input-wait-handler*)
-                     (pointer-button-press-handler
-                      *pointer-button-press-handler*))
-  (stream-read-gesture stream
-                       :timeout timeout
-                       :peek-p peek-p
-                       :input-wait-test input-wait-test
-                       :input-wait-handler input-wait-handler
-                       :pointer-button-press-handler
-                       pointer-button-press-handler))
-
-
-;;; Do streams care about any other events?
-(defun handle-non-stream-event (buffer)
-  (let* ((event (event-queue-peek buffer))
-         (sheet (and event (event-sheet event))))
-    (if (and event
-             (or (and (gadgetp sheet)
-                      (gadget-active-p sheet))
-                 (not (and (typep sheet 'clim-stream-pane)
-                           (or (typep event 'key-press-event)
-                               (typep event 'pointer-button-press-event))))))
-        (progn
-          (event-queue-read buffer)	;eat it
-          (handle-event (event-sheet event) event)
-          t)
-        nil)))
-
-(defun pop-gesture (buffer peek-p)
-  (if peek-p
-      (event-queue-peek buffer)
-      (event-queue-read-no-hang buffer)))
-
-(defmethod stream-process-gesture ((stream standard-extended-input-stream) gesture type)
-  (declare (ignore type))
-  (typecase gesture
-    ((or character symbol pointer-button-event)
-     (values gesture (type-of gesture)))
-    (key-press-event
-     (let ((modifiers (event-modifier-state gesture))
-           (character (keyboard-event-character gesture)))
-       (if (and (or (zerop modifiers)
-                    (eql modifiers +shift-key+))
-                character)
-           (values (char-for-read character) 'standard-character)
-           (values gesture (type-of gesture)))))
-    (otherwise
-     nil)))
-
-(defmethod stream-read-gesture ((stream standard-extended-input-stream)
-                                &key timeout peek-p
-                                (input-wait-test *input-wait-test*)
-                                (input-wait-handler *input-wait-handler*)
-                                (pointer-button-press-handler
-                                 *pointer-button-press-handler*))
-  (with-encapsulating-stream (estream stream)
-    (let ((*input-wait-test* input-wait-test)
-          (*input-wait-handler* input-wait-handler)
-          (*pointer-button-press-handler* pointer-button-press-handler)
-          (buffer (sheet-event-queue stream)))
-      (tagbody
-         ;; Wait for input... or not
-         ;; XXX decay timeout.
-       wait-for-char
-       (multiple-value-bind (available reason)
-           (stream-input-wait estream
-                              :timeout timeout
-                              :input-wait-test input-wait-test)
-         (unless available
-           (case reason
-             (:timeout
-              (assert timeout () "Reason is timeout but timeout is null!.")
-              (return-from stream-read-gesture
-                (values nil :timeout)))
-             (:input-wait-test
-              ;; input-wait-handler might leave the event for us.
-              ;; This is actually quite messy; I'd like to confine
-              ;; handle-event to stream-input-wait, but we can't loop
-              ;; back to it because the input handler will continue to
-              ;; decline to read the event :(
-              (let ((event (event-queue-peek buffer)))
-                (when input-wait-handler
-                  (funcall input-wait-handler stream))
-                (let ((current-event (event-queue-peek buffer)))
-                  (when (or (not current-event)
-                            (not (eq event current-event)))
-                    ;; If there's a new event input-wait-test needs to
-                    ;; take a look at it.
-                    (go wait-for-char)))))
-             (t (go wait-for-char)))))
-         ;; An event should  be in the stream buffer now.
-         (when (handle-non-stream-event buffer)
-           (go wait-for-char))
-         (let* ((raw-gesture (pop-gesture buffer peek-p))
-                (gesture (stream-process-gesture stream raw-gesture nil)))
-           ;; Sometimes key press events get generated with a key code for which
-           ;; there is no keysym.  This seems to happen on my machine when keys
-           ;; are hit rapidly in succession.  I'm not sure if this is a hardware
-           ;; problem with my keyboard, and this case is probably better handled
-           ;; in the backend, but for now the case below handles the problem. --
-           ;; moore
-           (cond ((null gesture)
-                  (go wait-for-char))
-                 ((and pointer-button-press-handler
-                       (typep gesture 'pointer-button-press-event))
-                  (funcall pointer-button-press-handler stream gesture))
-                 ((loop for gesture-name in *abort-gestures*
-                        thereis (event-matches-gesture-name-p gesture gesture-name))
-                  (signal 'abort-gesture :event gesture))
-                 ((loop for gesture-name in *accelerator-gestures*
-                        thereis (event-matches-gesture-name-p gesture gesture-name))
-                  (signal 'accelerator-gesture :event gesture))
-                 (t (setf (last-gesture stream) raw-gesture)
-                    (return-from stream-read-gesture gesture))))
-         (go wait-for-char)))))
-
-;;; XXX: this should look in the stream-input-buffer not in the queue.
-(defmethod stream-input-wait ((stream standard-extended-input-stream)
-                              &key timeout input-wait-test)
-  (block exit
-    (let ((buffer (sheet-event-queue stream)))
-      (tagbody
-       check-buffer
-         (when-let ((event (event-queue-peek buffer)))
-           (when (and input-wait-test (funcall input-wait-test stream))
-             (return-from exit (values nil :input-wait-test)))
-           (if (handle-non-stream-event buffer)
-               (go check-buffer)
-               (return-from exit t)))
-         ;; Event queue has been drained, time to block waiting for new events.
-         (unless (event-queue-listen-or-wait buffer :timeout timeout)
-           (return-from exit (values nil :timeout)))
-         (go check-buffer)))))
-
-(defun unread-gesture (gesture &key (stream *standard-input*))
-  (stream-unread-gesture stream gesture))
-
-;;; XXX: this should look in the stream-input-buffer not in the queue.
-(defmethod stream-unread-gesture ((stream standard-extended-input-stream)
-                                  gesture)
-  (declare (ignore gesture))
-  (with-encapsulating-stream (estream stream)
-    (let ((gesture (last-gesture stream)))
-      (when gesture
-        (setf (last-gesture stream) nil)
-        (event-queue-prepend (sheet-event-queue estream) gesture)))))
-
-;;; Standard stream methods on standard-extended-input-stream.  Ignore any
-;;; pointer gestures in the input buffer.
-;;;
-;;; Is stream-read-gesture allowed to return :eof?
-
-(defmethod stream-read-char ((stream standard-extended-input-stream))
-  (with-encapsulating-stream (estream stream)
-    (loop
-         with char and reason
-         do (setf (values char reason) (stream-read-gesture estream))
-         until (or (characterp char) (eq reason :eof))
-         finally (return (if (eq reason :eof)
-                             reason
-                             (char-for-read char))))))
-
-(defmethod stream-read-char-no-hang ((stream standard-extended-input-stream))
-  (with-encapsulating-stream (estream stream)
-    (loop
-       with char and reason
-       do (setf (values char reason) (stream-read-gesture estream :timeout 0))
-       until (or (characterp char) (eq reason :timeout) (eq reason :eof) )
-       finally (return (cond ((eq reason :timeout)
-                              nil)
-                             ((eq reason :eof)
-                              :eof)
-                             (t (char-for-read char)))))))
-
-(defmethod stream-unread-char ((stream standard-extended-input-stream)
-                               char)
-  (with-encapsulating-stream (estream stream)
-    (stream-unread-gesture estream (unmap-char-for-read char))))
-
-(defmethod stream-peek-char ((stream standard-extended-input-stream))
-  (with-encapsulating-stream (estream stream)
-    (loop
-       with char and reason
-       do (setf (values char reason) (stream-read-gesture estream :peek-p t))
-       until (or (characterp char) (eq reason :eof))
-       do (stream-read-gesture estream) ; consume pointer gesture
-       finally (return (if (eq reason :eof)
-                           reason
-                           (char-for-read char))))))
-
-(defmethod stream-listen ((stream standard-extended-input-stream))
-  (with-encapsulating-stream (estream stream)
-    (loop
-       with char and reason
-         do (setf (values char reason) (stream-read-gesture estream
-                                                            :timeout 0
-                                                            :peek-p t))
-         until (or (characterp char) (eq reason :eof) (eq reason :timeout))
-         do (stream-read-gesture estream) ; consume pointer gesture
-         finally (return (characterp char)))))
-
-(defmethod stream-clear-input ((stream standard-extended-input-stream))
-  (with-encapsulating-stream (estream stream)
-    (loop
-       with char and reason
-         do (setf (values char reason) (stream-read-gesture estream
-                                                            :timeout 0
-                                                            :peek-p t))
-         until (or (eq reason :eof) (eq reason :timeout))
-         do (stream-read-gesture estream) ; consume pointer gesture
-         ))
-  nil)
-
-;;; stream-read-line returns a second value of t if terminated by eof.
-(defmethod stream-read-line ((stream standard-extended-input-stream))
-  (with-encapsulating-stream (estream stream)
-    (let ((result (make-array 1
-                              :element-type 'character
-                              :adjustable t
-                              :fill-pointer 0)))
-      (loop for char = (stream-read-char estream)
-            while (and (characterp char) (not (char= char #\Newline)))
-            do (vector-push-extend char result)
-            finally (return (values (subseq result 0)
-                                    (not (characterp char))))))))
-
-;;; stream-read-gesture on string strings. Needed for accept-from-string.
-
-;;; XXX Evil hack because "string-stream" isn't the superclass of
-;;; string streams in CMUCL/SBCL...
-
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defvar *string-input-stream-class* (with-input-from-string (s "foo")
-                                        (class-name (class-of s)))))
-
-(defmethod stream-read-gesture ((stream #.*string-input-stream-class*)
-                                &key peek-p
-                                &allow-other-keys)
-  (let ((char (if peek-p
-                  (peek-char nil stream nil nil)
-                  (read-char stream nil nil))))
-    (if char
-        char
-        (values nil :eof))))
-
-(defmethod stream-unread-gesture ((stream #.*string-input-stream-class*)
-                                  gesture)
-  (unread-char gesture stream))
+  (setq stream (stream-designator-symbol stream '*standard-input*))
+  (with-gensyms (cont arg)
+    `(flet ((,cont (,arg) ,@body))
+       (declare (dynamic-extent #',cont))
+       (invoke-with-input-focus ,stream #',cont))))
 
 
 ;;; 22.3 Gestures and Gesture Names
@@ -502,10 +403,10 @@ known gestures."
       (values type device-name modifier-state))))
 
 (defun add-gesture-name (name type gesture-spec &key unique)
-      (let ((gesture-entry (multiple-value-list (realize-gesture-spec type gesture-spec))))
-        (if unique
-            (setf (gethash name *gesture-names*) (list gesture-entry))
-            (push gesture-entry (gethash name *gesture-names*)))))
+  (let ((gesture-entry (multiple-value-list (realize-gesture-spec type gesture-spec))))
+    (if unique
+        (setf (gethash name *gesture-names*) (list gesture-entry))
+        (push gesture-entry (gethash name *gesture-names*)))))
 
 (defgeneric character-gesture-name (name))
 
@@ -513,15 +414,14 @@ known gestures."
   name)
 
 (defmethod character-gesture-name ((name symbol))
-  (let ((entry (car (gethash name *gesture-names*))))
-    (if entry
-        (destructuring-bind (type device-name modifier-state)
-            entry
-          (if (and (eq type :keyboard)
-                   (eql modifier-state 0))
-              device-name
-              nil))
-        nil)))
+  (if-let ((entry (car (gethash name *gesture-names*))))
+    (destructuring-bind (type device-name modifier-state)
+        entry
+      (if (and (eq type :keyboard)
+               (eql modifier-state 0))
+          device-name
+          nil))
+    nil))
 
 (defgeneric %event-matches-gesture (event type device-name modifier-state))
 
@@ -699,7 +599,7 @@ known gestures."
 (defgeneric* (setf pointer-position) (x y pointer))
 
 (defgeneric synthesize-pointer-motion-event (pointer)
-  (:documentation "Create a CLIM pointer motion event based on the current pointer state."))
+  (:documentation "Create a CLIM pointer motion event based on the current pointer state.")) 
 
 (defgeneric pointer-cursor (pointer))
 
@@ -747,16 +647,71 @@ known gestures."
                     (pointer-event-button event)))))
 
 (defmethod stream-pointer-position ((stream standard-extended-input-stream)
-                                    &key (pointer
-                                          (port-pointer (port stream))))
-  (multiple-value-bind (x y)
-      (pointer-position pointer)
-    (let ((graft (graft (port pointer))))
-      (untransform-position (sheet-delta-transformation stream graft) x y))))
+                                    &key (pointer (port-pointer (port stream))))
+  (flet ((sheet-pointer-position (sheet pointer)
+           (multiple-value-bind (x y)
+               (pointer-position pointer)
+             (let ((pointer-sheet (port-pointer-sheet (port sheet))))
+               (if (eq sheet pointer-sheet)
+                   (values x y)
+                   ;; Is this right?
+                   (multiple-value-bind (native-x native-y)
+                       (transform-position (sheet-native-transformation sheet) x y)
+                     (untransform-position (sheet-native-transformation pointer-sheet)
+                                           native-x
+                                           native-y)))))))
+    (sheet-pointer-position stream pointer)))
+
 
 (defmethod* (setf stream-pointer-position) (x y (stream standard-extended-input-stream))
+  ;; XXX: defgeneric* doesn't expand properly when &key is present.
+  ;; &key (pointer (port-pointer (port stream)))
   (let ((graft (graft stream))
         (pointer (port-pointer (port stream))))
     (multiple-value-bind (x y)
         (transform-position (sheet-delta-transformation stream graft) x y)
       (setf (pointer-position pointer) (values x y)))))
+
+
+;;; 22.X The hacks
+
+;;; stream-read-gesture on string strings. Needed for
+;;; accept-from-string. We will implement it by creating a stream with
+;;; input-buffer assigned to the string later.
+;;;
+;;; XXX Evil hack because "string-stream" isn't the superclass of string
+;;; streams in CMUCL/SBCL...
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defvar *string-input-stream-class* (with-input-from-string (s "foo")
+                                        (class-name (class-of s)))))
+
+(defmethod stream-read-gesture ((stream #.*string-input-stream-class*)
+                                &key peek-p
+                                &allow-other-keys)
+  (let ((char (if peek-p
+                  (peek-char nil stream nil nil)
+                  (read-char stream nil nil))))
+    (if char
+        char
+        (values nil :eof))))
+
+(defmethod stream-unread-gesture ((stream #.*string-input-stream-class*)
+                                  gesture)
+  (unread-char gesture stream))
+
+;;; SEIS *must not* implement character protocol, our accept
+;;; implementation assumes it does though. We will implement them
+;;; temporarily until we remove this invalid assumption in the following
+;;; commits (to keep changes atomic).
+
+;;; eat all gestures which are not characters
+(defmethod stream-read-char-no-hang ((stream standard-extended-input-stream))
+  (loop
+     for ch = (stream-read-gesture stream)
+     when (or (characterp ch) (null ch))
+     return (voodoo ch)))
+
+;;; skip assertions for it is only a hack
+(defmethod stream-unread-char ((stream standard-extended-input-stream) char)
+  (decf (stream-scan-pointer stream)))

--- a/Core/clim-core/frames.lisp
+++ b/Core/clim-core/frames.lisp
@@ -141,8 +141,7 @@ input focus. This is a McCLIM extension."))
 			 :accessor frame-hilited-presentation)
    (process :accessor frame-process :initform nil)
    (client-settings :accessor client-settings :initform nil)
-   (event-queue :initarg :frame-event-queue
-                :initarg :input-buffer
+   (event-queue :initarg :event-queue
                 :initform nil
 		:accessor frame-event-queue
 		:documentation "The event queue that, by default, will be
@@ -615,17 +614,14 @@ documentation produced by presentations.")
 
 (defmethod make-pane-1 :around (fm (frame standard-application-frame) type
 				&rest args
-				&key (input-buffer nil input-buffer-p)
-                                     name
+				&key (event-queue nil evq-p)
 				&allow-other-keys)
-  (declare (ignore name input-buffer))
-  "Default input-buffer to the frame event queue."
-  (let ((pane (if input-buffer-p
-		  (call-next-method)
-		  (apply #'call-next-method fm frame type
-			 :input-buffer (frame-event-queue frame)
-			 args))))
-    pane))
+  "Default an event-queue to be shared with the frame."
+  (declare (ignore event-queue))
+  (if (null evq-p)
+      (let ((evq (frame-event-queue frame)))
+        (apply #'call-next-method fm frame type :event-queue evq args))
+      (call-next-method)))
 
 (defmethod adopt-frame ((fm frame-manager) (frame application-frame))
   (setf (slot-value fm 'frames) (cons frame (slot-value fm 'frames)))

--- a/Core/clim-core/presentation-defs.lisp
+++ b/Core/clim-core/presentation-defs.lisp
@@ -885,6 +885,7 @@ history will be unchanged."
                       ;; XXX what about pointer gestures?
                       ;; XXX and delimiter gestures?
                       (unless *recursive-accept-p*
+                        ;; XXX: read-char-no-hang on seos? cyt
                         (let ((ag (read-char-no-hang stream nil stream t)))
                           (unless (or (null ag) (eq ag stream))
                             (unless (activation-gesture-p ag)

--- a/Core/clim-core/presentation-defs.lisp
+++ b/Core/clim-core/presentation-defs.lisp
@@ -953,7 +953,7 @@ history will be unchanged."
 
 ;;; For ACCEPT-FROM-STRING, use this barebones input-editing-stream.
 (defclass string-input-editing-stream (input-editing-stream fundamental-character-input-stream)
-  ((input-buffer :accessor stream-input-buffer)
+  ((input-buffer :accessor stream-input-buffer :type vector)
    (insertion-pointer :accessor stream-insertion-pointer
                       :initform 0
                       :documentation "This is not used for anything at any point.")

--- a/Core/clim-core/presentation-translators.lisp
+++ b/Core/clim-core/presentation-translators.lisp
@@ -798,9 +798,10 @@ a presentation"
                                          :modifier-state 0
                                          :button +pointer-left-button+)))
 
+;;; XXX: this should look in the stream-input-buffer not in the queue.
 (defun highlight-applicable-presentation (frame stream input-context
                                           &optional (prefer-pointer-window t))
-  (let* ((queue (stream-input-buffer stream))
+  (let* ((queue (sheet-event-queue stream))
          (event (event-queue-peek queue))
          (sheet (and event (event-sheet event))))
     (when (and event

--- a/Core/clim-core/presentations.lisp
+++ b/Core/clim-core/presentations.lisp
@@ -1270,8 +1270,9 @@ function lambda list"))
                           This shouldn't happen!"
                          object type)))))
 
+;;; XXX: this should look in the stream-input-buffer not in the queue.
 (defun input-context-wait-test (stream)
-  (let* ((queue (stream-input-buffer stream))
+  (let* ((queue (sheet-event-queue stream))
          (event (event-queue-peek queue)))
     (when event
       (let ((sheet (event-sheet event)))

--- a/Core/clim-core/presentations.lisp
+++ b/Core/clim-core/presentations.lisp
@@ -1270,29 +1270,21 @@ function lambda list"))
                           This shouldn't happen!"
                          object type)))))
 
-;;; XXX: this should look in the stream-input-buffer not in the queue.
 (defun input-context-wait-test (stream)
-  (let* ((queue (sheet-event-queue stream))
-         (event (event-queue-peek queue)))
-    (when event
-      (let ((sheet (event-sheet event)))
-        (when (and (output-recording-stream-p sheet)
-                   (or (typep event 'pointer-event)
-                       (typep event 'keyboard-event))
-                   (not (gadgetp sheet)))
-          (return-from input-context-wait-test t))))
+  (if-let ((event (stream-gesture-available-p stream)))
+    (and (output-recording-stream-p stream)
+         (or (typep event 'pointer-event)
+             (typep event 'keyboard-event)))
     nil))
 
 (defun input-context-event-handler (stream)
-  (highlight-applicable-presentation *application-frame*
-                                     stream
-                                     *input-context*))
+  (highlight-applicable-presentation
+   *application-frame* stream *input-context*))
 
 (defun input-context-button-press-handler (stream button-event)
   (declare (ignore stream))
-  (frame-input-context-button-press-handler *application-frame*
-                                            (event-sheet button-event)
-                                            button-event))
+  (frame-input-context-button-press-handler
+   *application-frame* (event-sheet button-event) button-event))
 
 (defun highlight-current-presentation (frame input-context)
   (alexandria:when-let* ((port-pointer (port-pointer (port *application-frame*)))
@@ -1322,8 +1314,7 @@ function lambda list"))
                                     (return-from ,context-block
                                       (values object type event options))))
                           ,(if override nil '*input-context*)))
-                   (*pointer-button-press-handler*
-                    #'input-context-button-press-handler)
+                   (*pointer-button-press-handler* #'input-context-button-press-handler)
                    (*input-wait-test* #'input-context-wait-test)
                    (*input-wait-handler* #'input-context-event-handler))
                (return-from ,return-block ,form )))

--- a/Libraries/ESA/esa.lisp
+++ b/Libraries/ESA/esa.lisp
@@ -964,7 +964,7 @@ used.")
 	      (eql modifiers +shift-key+))
       (setq char (keyboard-event-character ev)))
     (if char
-        (climi::char-for-read char)
+        (climi::voodoo char)
 	event)))
 
 (defmethod convert-to-gesture ((ev pointer-button-press-event))


### PR DESCRIPTION
We remove invalid assumption that input-buffer is same thing as
event-queue for standard-extended-input-stream. To do that we split
the initargs and slots between standard-sheet-input-mixin and
standard-input-stream (along with appropriate accessors).

This change is incomplete, because stream reading operations still
assume that the input-buffer is an event-queue what leads to debugger
popping all the time. To make this commit atomically complete we
replace passages in the code which make this invalid assumption with
event-sheet-queue access (and add appropriate comment that this is
invalid). This will be fixed in upcoming commit. Software after this
change will work as before except that SEIS will signal unbound-slot
when we try to access STREAM-INPUT-BUFFER from the user code (access
from McCLIM has been replaced).

- add :type vector to the input-buffer slots
- untie input-buffer and event-queue
- remove stream-input-buffer references from sheet-input
- replace stream-input-buffer with sheet-event-queue where appropriate
- minor refactor of some code passages (stylistic)