### PR TITLE
Rename the spacing unit :pixels to :pixel (discussed in issue #742).

### DIFF
--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -872,7 +872,7 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
     (real x)
     (cons (destructuring-bind (value type) x
             (ecase type
-              (:pixels    value)
+              (:pixel     value)
               (:point     (* value (graft-pixels-per-inch (graft pane)) 1/72))
               (:mm        (* value (graft-pixels-per-millimeter (graft pane))))
               (:character (* value (stream-character-width pane #\m)))
@@ -889,7 +889,7 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
     (real x)
     (cons (destructuring-bind (value type) x
             (ecase type
-              (:pixels    value)
+              (:pixel     value)
               (:point     (* value (graft-pixels-per-inch (graft pane)) 1/72))
               (:mm        (* value (graft-pixels-per-millimeter (graft pane))))
               (:character 0)


### PR DESCRIPTION
The unit names are specified in http://bauhh.dyndns.org:8000/clim-spec/17-2.html#_922.