### PR TITLE
refactor 712 partial

### DIFF
--- a/Backends/CLX/graft.lisp
+++ b/Backends/CLX/graft.lisp
@@ -21,7 +21,7 @@
 
 ;;; CLX-GRAFT class
 
-(defclass clx-graft (standard-graft) ())
+(defclass clx-graft (graft) ())
 
 (defmethod graft-width ((graft clx-graft) &key (units :device))
   (let ((screen (clx-port-screen (port graft))))

--- a/Backends/CLX/package.lisp
+++ b/Backends/CLX/package.lisp
@@ -69,7 +69,6 @@
   (:import-from #:climi
 		#:standard-event-port-mixin
                 #:event-listen-or-wait
-		#:standard-graft
 		#:pointer-grab-sheet
 		#:%sheet-mirror-region
                 #:%sheet-mirror-transformation

--- a/Core/clim-basic/input.lisp
+++ b/Core/clim-basic/input.lisp
@@ -43,16 +43,15 @@
 (declaim (inline now compute-decay))
 (defun now ()
   (/ (get-internal-real-time)
-     1.0
-     internal-time-units-per-second))
+     #.(float internal-time-units-per-second)))
 
 ;; Given two alarm times compute remaining time (in seconds). If both times are
 ;; NIL returns NIL.
 (defun compute-decay (time-1 time-2)
-  (cond ((and time-1 time-2) (- (min time-1 time-2) (now)))
-        (time-1 (- time-1 (now)))
-        (time-2 (- time-2 (now)))
-        (T NIL)))
+  (cond ((and time-1 time-2) (max 0 (- (min time-1 time-2) (now))))
+        (time-1              (max 0 (- time-1 (now))))
+        (time-2              (max 0 (- time-2 (now))))
+        (T                   NIL)))
 
 ;; See if it's time to inject a scheduled event into the queue.
 (defgeneric check-schedule (queue)
@@ -149,7 +148,6 @@ use condition-variables nor locks."))
     (port-force-output port)))
 
 (defun %event-queue-read (queue)
-  (check-schedule queue)
   (let ((res (pop (event-queue-head queue))))
     (when (null (event-queue-head queue))
       (setf (event-queue-tail queue) nil))
@@ -157,31 +155,46 @@ use condition-variables nor locks."))
 
 (defmethod event-queue-read ((queue simple-event-queue))
   (do-port-force-output queue)
-  (let ((decay (compute-decay nil (event-schedule-time queue)))
-        (port (event-queue-port queue)))
-    (when decay (maxf decay 0))
-    (loop
-       as result = (%event-queue-read queue)
-       if result do (return result)
-       else do (process-next-event port :timeout decay))))
+  (check-schedule queue)
+  (process-next-event (event-queue-port queue) :timeout 0)
+  (loop
+     with port = (event-queue-port queue)
+     as result = (%event-queue-read queue)
+     if result do (return result)
+     else do
+       (if-let ((decay (compute-decay nil (event-schedule-time queue))))
+         (process-next-event port :timeout decay)
+         (process-next-event port))
+       (check-schedule queue)))
 
 (defmethod event-queue-read-no-hang ((queue simple-event-queue))
   (do-port-force-output queue)
+  (check-schedule queue)
   (process-next-event (event-queue-port queue) :timeout 0)
   (%event-queue-read queue))
 
 (defmethod event-queue-read-with-timeout ((queue simple-event-queue) timeout wait-function)
   (do-port-force-output queue)
-  (let ((port (event-queue-port queue))
-        (timeout-time (and timeout (+ timeout (now)))))
-    ;; timeout-time may be past-due already but we may have an event waiting to be
-    ;; processed for some time. Do preemptive check. -- jd 2018-12-30
-    (process-next-event port :timeout 0)
-    (let ((decay (compute-decay timeout-time (event-schedule-time queue))))
-      (when decay (maxf decay 0))
-      (if-let ((event (%event-queue-read queue)))
-        event
-        (process-next-event port :wait-function wait-function :timeout decay)))))
+  ;; Preemptive check (timeout may be past due). -- jd 2018-12-30
+  (check-schedule queue)
+  (process-next-event (event-queue-port queue) :timeout 0)
+  (loop
+     with port = (event-queue-port queue)
+     with timeout-time = (and timeout (+ timeout (now)))
+     do
+       (cond ((event-queue-head queue)
+              (return (%event-queue-read queue)))
+             ((and timeout-time (> (now) timeout-time))
+              (return (values nil :timeout)))
+             ((multiple-value-bind (available reason)
+                  (let* ((schedule-time (event-schedule-time queue))
+                         (decay (compute-decay timeout-time schedule-time)))
+                    (process-next-event port
+                                        :timeout decay
+                                        :wait-function wait-function))
+                (and (null available) (eql reason :wait-function)))
+              (return (values nil :wait-function)))
+             (t (check-schedule queue)))))
 
 (defmethod event-queue-append ((queue simple-event-queue) item)
   (labels ((append-event ()
@@ -288,78 +301,74 @@ use condition-variables nor locks."))
 (defmethod event-queue-peek ((queue simple-event-queue))
   (do-port-force-output queue)
   (check-schedule queue)
-  (or (first (event-queue-head queue))
-      (when (process-next-event (event-queue-port queue) :timeout 0)
-        (first (event-queue-head queue)))))
+  (process-next-event (event-queue-port queue) :timeout 0)
+  (first (event-queue-head queue)))
 
 (defmethod event-queue-peek-if (predicate (queue simple-event-queue))
   (do-port-force-output queue)
+  (check-schedule queue)
   ;; Slurp as many elements as available.
   (loop until (null (process-next-event (event-queue-port queue) :timeout 0)))
-  ;; Check-schedule may append scheduled event in a queue.
-  (check-schedule queue)
   (find-if predicate (event-queue-head queue)))
 
 (defmethod event-queue-listen-or-wait ((queue simple-event-queue)
                                        &key timeout wait-function)
   (do-port-force-output queue)
-  (let ((port (event-queue-port queue))
-        (timeout-time (and timeout (+ timeout (now)))))
-    ;; timeout-time may be past-due already but we may have an event waiting to be
-    ;; processed for some time. Do preemptive check. -- jd 2018-12-30
-    (process-next-event port :timeout 0)
-    (loop
-       as decay = (compute-decay timeout-time (event-schedule-time queue))
-       do
-         (when decay (maxf decay 0))
-         (check-schedule queue)
-         (cond ((event-queue-head queue)
-                (return t))
-               ((maybe-funcall wait-function)
-                (return (values nil :wait-function)))
-               ((and timeout-time (> (now) timeout-time))
-                (return (values nil :timeout)))
-               (T
-                (process-next-event port :timeout decay :wait-function wait-function))))))
+  (check-schedule queue)
+  (process-next-event (event-queue-port queue) :timeout 0)
+  (loop
+     with port = (event-queue-port queue)
+     with timeout-time = (and timeout (+ timeout (now)))
+     do
+       (cond ((event-queue-head queue)
+              (return t))
+             ((and timeout-time (> (now) timeout-time))
+              (return (values nil :timeout)))
+             ((multiple-value-bind (available reason)
+                  (let* ((schedule-time (event-schedule-time queue))
+                         (decay (compute-decay timeout-time schedule-time)))
+                    (process-next-event port
+                                        :timeout decay
+                                        :wait-function wait-function))
+                (and (null available)
+                     (eql reason :wait-function)))
+              (return (values nil :wait-function)))
+             (t (check-schedule queue)))))
 
 (defmethod event-queue-listen ((queue simple-event-queue))
   (event-queue-listen-or-wait queue :timeout 0))
 
 
+;;; XXX SBCL doesn't reacquire lock when condition-variable
+;;; prematurely returns (i.e due to timeout). That means we can't use
+;;; recursive locks for the concurrent-event-queue. --jd 2019-06-26
+
 (defclass concurrent-event-queue (simple-event-queue)
-  ((lock :initform (make-recursive-lock "event queue")
+  ((lock :initform (make-lock "Event queue")
          :reader event-queue-lock)
    (processes
-         :initform (make-condition-variable)
-         :accessor event-queue-processes
-         :documentation "Condition variable for waiting processes")))
-
-(defmethod check-schedule :around ((queue concurrent-event-queue))
-  (with-recursive-lock-held ((event-queue-lock queue))
-    (call-next-method)))
-
-(defmethod schedule-event-queue :around ((queue concurrent-event-queue) event delay)
-  (with-recursive-lock-held ((event-queue-lock queue))
-    (call-next-method)))
+    :initform (make-condition-variable)
+    :accessor event-queue-processes
+    :documentation "Condition variable for waiting processes")))
 
 (defmethod event-queue-read ((queue concurrent-event-queue))
   (do-port-force-output queue)
   (let ((lock (event-queue-lock queue))
         (cv (event-queue-processes queue)))
     (loop
-       as decay = (compute-decay nil (event-schedule-time queue))
-       do (with-recursive-lock-held (lock)
-            (if-let ((result (%event-queue-read queue)))
-              (return result)
-              (condition-wait cv lock decay))))))
+       (check-schedule queue)
+       (with-lock-held (lock)
+         (if-let ((result (%event-queue-read queue)))
+           (return result)
+           (let* ((schedule-time (event-schedule-time queue))
+                  (decay (compute-decay nil schedule-time)))
+             (condition-wait cv lock decay)))))))
 
 (defmethod event-queue-read-no-hang ((queue concurrent-event-queue))
   (do-port-force-output queue)
-  (with-recursive-lock-held ((event-queue-lock queue))
+  (check-schedule queue)
+  (with-lock-held ((event-queue-lock queue))
     (%event-queue-read queue)))
-
-;;; XXX Should we do something with the wait function? I suspect that
-;;; it's not compatible with the brave new world of native threads.
 
 (defmethod event-queue-read-with-timeout ((queue concurrent-event-queue)
                                           timeout wait-function)
@@ -369,10 +378,9 @@ use condition-variables nor locks."))
      with lock = (event-queue-lock queue)
      with cv = (event-queue-processes queue)
      with timeout-time = (and timeout (+ timeout (now)))
-     as decay = (compute-decay timeout-time (event-schedule-time queue))
      do
-       (when decay (maxf decay 0))
-       (with-recursive-lock-held (lock)
+       (check-schedule queue)
+       (with-lock-held (lock)
          (if-let ((event (%event-queue-read queue)))
            (return event)
            (cond ((maybe-funcall wait-function)
@@ -380,33 +388,31 @@ use condition-variables nor locks."))
                  ((and timeout-time (> (now) timeout-time))
                   (return (values nil :timeout)))
                  (t
-                  (condition-wait cv lock decay)))))))
+                  (let* ((schedule-time (event-schedule-time queue))
+                         (decay (compute-decay timeout-time schedule-time)))
+                    (condition-wait cv lock decay))))))))
 
 (defmethod event-queue-append ((queue concurrent-event-queue) item)
-  (with-recursive-lock-held ((event-queue-lock queue))
+  (with-lock-held ((event-queue-lock queue))
     (call-next-method)
     (condition-notify (event-queue-processes queue))))
 
 (defmethod event-queue-prepend ((queue concurrent-event-queue) item)
-  (with-recursive-lock-held ((event-queue-lock queue))
+  (with-lock-held ((event-queue-lock queue))
     (call-next-method)
     (condition-notify (event-queue-processes queue))))
 
 (defmethod event-queue-peek ((queue concurrent-event-queue))
   (do-port-force-output queue)
-  (with-recursive-lock-held ((event-queue-lock queue))
-    (check-schedule queue)
+  (check-schedule queue)
+  (with-lock-held ((event-queue-lock queue))
     (first (event-queue-head queue))))
 
 (defmethod event-queue-peek-if (predicate (queue concurrent-event-queue))
   (do-port-force-output queue)
-  (with-recursive-lock-held ((event-queue-lock queue))
-    (find-if predicate (event-queue-head queue))))
-
-(defmethod event-queue-listen ((queue concurrent-event-queue))
-  (do-port-force-output queue)
   (check-schedule queue)
-  (not (null (event-queue-head queue))))
+  (with-lock-held ((event-queue-lock queue))
+    (find-if predicate (event-queue-head queue))))
 
 (defmethod event-queue-listen-or-wait ((queue concurrent-event-queue)
                                        &key timeout wait-function)
@@ -416,24 +422,28 @@ use condition-variables nor locks."))
      with lock = (event-queue-lock queue)
      with cv = (event-queue-processes queue)
      with timeout-time = (and timeout (+ timeout (now)))
-     as decay = (compute-decay timeout-time (event-schedule-time queue))
      do
-     ;; We CLAMPF decay when wait-function is present to ensure that
-     ;; we don't get stuck until next event arrives (or the timeout
-     ;; happens). It is busy wait with a lousy grain. -- jd 2019-06-06
-       (when decay (if wait-function
-                       (clampf decay 0 0.01)
-                       (maxf decay 0)))
-       (with-recursive-lock-held (lock)
-         (check-schedule queue)
+       (check-schedule queue)
+       (with-lock-held (lock)
          (cond ((event-queue-head queue)
                 (return t))
                ((maybe-funcall wait-function)
                 (return (values nil :wait-function)))
                ((and timeout-time (> (now) timeout-time))
                 (return (values nil :timeout)))
-               (T
-                (condition-wait cv lock decay))))))
+               (wait-function
+                ;; We CLAMP decay when wait-function is present to
+                ;; ensure that we don't get stuck until next event
+                ;; arrives (or the timeout happens). It is busy wait
+                ;; with a lousy grain. -- jd 2019-06-06
+                (if-let ((decay (compute-decay timeout-time
+                                               (event-schedule-time queue))))
+                  (condition-wait cv lock (min 0.01 decay))
+                  (condition-wait cv lock 0.01)))
+               (t
+                (let ((decay (compute-decay timeout-time
+                                            (event-schedule-time queue))))
+                  (condition-wait cv lock decay)))))))
 
 
 ;;; STANDARD-SHEET-INPUT-MIXIN

--- a/Documentation/Manual/Texinfo/developer-manual.txi
+++ b/Documentation/Manual/Texinfo/developer-manual.txi
@@ -94,8 +94,6 @@ synthesize-pointer-motion-event
 @verbatim
 GRAFT (in grafts.lisp)
 -----------------------------------
-;;; Use climb:standard-graft as superclass
-
 ;;; Originally in CLIM
 graft        ; root window/screen
 graft-height ; screen height


### PR DESCRIPTION
This change unifies wait-function interpretation across different APIs and removes recursive locks from the concurrent-event-queue. Some minor fixes follow. This change is part of work for #712 without any stream-related changes (which are work in progress).