### PR TITLE
add dejavu font path for guix system

### DIFF
--- a/Extensions/fonts/fontconfig.lisp
+++ b/Extensions/fonts/fontconfig.lisp
@@ -32,6 +32,7 @@
              #p"/usr/X11R6/lib/X11/fonts/TTF/"
              #p"/opt/X11/share/fonts/TTF/"
              #p"/opt/X11/share/fonts/"
+             #p"~/.guix-profile/share/fonts/truetype/"
              #p"/Library/Fonts/"
              #p"C:/Windows/Fonts/")))
 


### PR DESCRIPTION
Guix doesn't follow FHS. 
The fontconfig package in Guix looks for fonts in `$HOME/.guix-profile` by default and dejavu is located in `~/.guix-profile/share/fonts/truetype/`.