### PR TITLE
Menu: fixes and cleanup

### DIFF
--- a/Core/clim-basic/events.lisp
+++ b/Core/clim-basic/events.lisp
@@ -188,7 +188,6 @@
 (define-event-class pointer-enter-event    (pointer-boundary-event) ())
 (define-event-class pointer-exit-event     (pointer-boundary-event) ())
 
-;;; Menu implementation uses pointer-ungrab-leave-event.
 (define-event-class pointer-ungrab-enter-event (pointer-enter-event) ())
 (define-event-class pointer-ungrab-leave-event (pointer-exit-event)  ())
 

--- a/Core/clim-core/frames.lisp
+++ b/Core/clim-core/frames.lisp
@@ -270,8 +270,7 @@ documentation produced by presentations.")
         (prog1
             (call-next-method)
           (alexandria:when-let ((menu-bar-pane (frame-menu-bar-pane frame)))
-                               (update-menu-bar menu-bar-pane
-                                                new-command-table)))
+            (update-menu-bar menu-bar-pane new-command-table)))
         (call-next-method))))
 
 (defmethod generate-panes :before (fm  (frame application-frame))

--- a/Core/clim-core/menu.lisp
+++ b/Core/clim-core/menu.lisp
@@ -20,65 +20,42 @@
 
 (in-package :clim-internals)
 
+(defgeneric menu-root (button))
+
+(defgeneric menu-children (pane))
+
+(defgeneric arm-menu (button))
+
+(defgeneric disarm-menu (button))
+
+(defgeneric arm-branch (pane))
+
+(defgeneric destroy-substructure (pane))
+
 (defmethod stream-force-output ((pane menu-button-pane))
   (with-sheet-medium (medium pane)
     (medium-force-output medium)))
 
-(defgeneric menu-root (button))
-
 (defmethod menu-root ((button menu-button-pane))
   (menu-root (gadget-client button)))
 
-(defgeneric arm-menu (button))
-
-(defgeneric menu-children (pane))
-
 (defmethod arm-menu ((button menu-button-pane))
-  (with-slots (client armed id) button
+  (with-slots (client armed) button
     (unless armed
       (arm-menu client)
       (mapc #'disarm-menu (menu-children client))
       (arm-gadget button t))
     (dispatch-repaint button (sheet-region button))))
 
-(defgeneric disarm-menu (button))
-
 (defmethod disarm-menu ((button menu-button-pane))
-  (with-slots (client armed id) button
+  (with-slots (armed) button
     (when armed
       (disarm-gadget button)
       (dispatch-repaint button (sheet-region button))
       (stream-force-output button))))
 
-(defun menu-draw-highlighted (gadget)
-  (when (sheet-mirror gadget)           ;XXX only do this when the gadget is realized.
-    (with-slots (label) gadget
-      (with-bounding-rectangle* (x1 y1 x2 y2) (sheet-region gadget)
-        (let ((w (- x2 x1))
-              (h (- y2 y1)))
-          (draw-rectangle* gadget -1 -1 x2 y2
-                           :ink (gadget-highlighted-color gadget)
-                           :filled t)
-          (draw-edges-lines* gadget +white+ 0 0 +black+ (1- w) (1- h))
-          (draw-label* gadget x1 y1 x2 y2))))))
-
-(defun menu-draw-unhighlighted (gadget)
-  (when (sheet-mirror gadget)           ;XXX only do this when the gadget is realized.
-    (with-slots (label) gadget
-      (with-bounding-rectangle* (x1 y1 x2 y2) (sheet-region gadget)
-        (let ((w (- x2 x1))
-              (h (- y2 y1)))
-          (draw-rectangle* gadget -1 -1 w h ;-1 -1 x2 y2
-                           :ink +background-ink+
-                           :filled t)
-          (draw-label* gadget x1 y1 x2 y2))))))
-
-(defgeneric arm-branch (pane))
-
-(defgeneric destroy-substructure (pane))
-
 (defmethod handle-event ((pane menu-button-pane) (event pointer-enter-event))
-  (when (slot-value (slot-value pane 'client) 'armed)
+  (when (slot-value (gadget-client pane) 'armed)
     (arm-branch pane)))
 
 (defmethod handle-event ((pane menu-button-pane) (event pointer-button-press-event))
@@ -120,8 +97,8 @@
 (defmethod menu-children ((submenu menu-button-submenu-pane))
   (with-slots (submenu-frame) submenu
     (if submenu-frame
-	(sheet-children (first (sheet-children (frame-panes submenu-frame))))
-	'())))
+        (sheet-children (first (sheet-children (frame-panes submenu-frame))))
+        '())))
 
 (defclass submenu-border (border-pane) ())
 
@@ -152,19 +129,18 @@ account, and create a list of menu buttons."
                             :background *3d-normal-color* :contents items))
          (raised (make-pane-1 manager frame 'submenu-border :contents (list rack))))
     (with-slots (bottomp) sub-menu
-      (multiple-value-bind (xmin ymin xmax ymax)
-	  (bounding-rectangle* (sheet-region sub-menu))
-	(multiple-value-bind (x y)
-	    (transform-position (sheet-delta-transformation sub-menu nil)
-				(if bottomp xmin xmax)
-				(if bottomp ymax ymin))
-	  (with-slots (frame-manager submenu-frame) sub-menu
-	    (setf frame-manager manager
-		  submenu-frame (make-menu-frame raised :left x :top y))
-	    (adopt-frame manager submenu-frame)
-	    (enable-frame submenu-frame)
-	    (with-sheet-medium (medium raised)
-	      (medium-force-output medium))))))))
+      (with-bounding-rectangle* (xmin ymin xmax ymax) (sheet-region sub-menu)
+        (multiple-value-bind (x y)
+            (transform-position (sheet-delta-transformation sub-menu nil)
+                                (if bottomp xmin xmax)
+                                (if bottomp ymax ymin))
+          (with-slots (frame-manager submenu-frame) sub-menu
+            (setf frame-manager manager
+                  submenu-frame (make-menu-frame raised :left x :top y))
+            (adopt-frame manager submenu-frame)
+            (enable-frame submenu-frame)
+            (with-sheet-medium (medium raised)
+              (medium-force-output medium))))))))
 
 (defmethod destroy-substructure ((sub-menu menu-button-submenu-pane))
   (with-slots (frame-manager submenu-frame) sub-menu
@@ -173,7 +149,7 @@ account, and create a list of menu buttons."
       (disown-frame frame-manager submenu-frame)
       (disarm-gadget sub-menu)
       (dispatch-repaint sub-menu +everywhere+)
-      (setf submenu-frame nil) )))
+      (setf submenu-frame nil))))
 
 (defmethod arm-branch ((sub-menu menu-button-submenu-pane))
   (with-slots (client frame-manager submenu-frame) sub-menu
@@ -221,8 +197,7 @@ account, and create a list of menu buttons."
 
   (defmethod handle-repaint ((pane menu-button-vertical-submenu-pane) region)
     (call-next-method)
-    (multiple-value-bind (x1 y1 x2 y2)
-        (bounding-rectangle* (sheet-region pane))
+    (with-bounding-rectangle* (x1 y1 x2 y2) (sheet-region pane)
       (when (and (> (- x2 x1) total-width)
                  (> (- y2 y1) total-height))
         (let* ((center (/ (+ y1 y2) 2))
@@ -246,106 +221,90 @@ account, and create a list of menu buttons."
 
 (defmethod compose-space ((gadget menu-divider-leaf-pane) &key width height)
   (declare (ignorable width height))
-  (flet ((make-sr (w h)
-           (make-space-requirement :min-width w   :width w
-                                   :min-height h  :height h :max-height h)))
-    (let ((label (slot-value gadget 'label)))
-      (if label
-          (multiple-value-bind (width height fx fy baseline)
-              (text-size gadget label :text-style *labelled-divider-text-style*)
-            (declare (ignore fx fy height baseline))
-            (make-sr width (+ 0
-                              (text-style-ascent *labelled-divider-text-style* gadget)
-                              (text-style-descent *labelled-divider-text-style* gadget))))
-          (make-sr 0 4)))))
-
+  (multiple-value-bind (width height)
+      (if-let ((label (slot-value gadget 'label)))
+        (text-size gadget label :text-style *labelled-divider-text-style*)
+        (values 0 4))
+    (make-space-requirement
+     :min-width width :width width
+     :min-height height :height height :max-height height)))
 
 (defmethod handle-repaint ((pane menu-divider-leaf-pane) region)
-  (let ((label (slot-value pane 'label)))
-    (multiple-value-bind (x1 y1 x2 y2)
-        (bounding-rectangle* (sheet-region pane))
-      (declare (ignore y2))
-      (if label
-          (multiple-value-bind (width height fx fy baseline)
-              (text-size pane label :text-style *labelled-divider-text-style*)
-            (declare (ignore height fx fy))
-            (let ((tx0 (+ x1 (/ (- (- x2 x1) width) 2)))
-                  (ty0 (+ 1 y1 baseline)))
-            (draw-line* pane tx0 (1+ ty0) (+ tx0 width) (1+ ty0) :ink *3d-dark-color*)
-            (draw-text* pane label tx0 ty0
-                        :text-style *labelled-divider-text-style*)))
-          (progn
-            (draw-line* pane x1 (1+ y1) x2 (1+ y1) :ink *3d-dark-color*)
-            (draw-line* pane x1 (+ 2 y1) x2 (+ 2 y1) :ink *3d-light-color*))))))
+  (with-bounding-rectangle* (x1 y1 x2 y2) (sheet-region pane)
+    (declare (ignore y2))
+    (if-let ((label (slot-value pane 'label)))
+      (multiple-value-bind (width height fx fy baseline)
+          (text-size pane label :text-style *labelled-divider-text-style*)
+        (declare (ignore height fx fy))
+        (let ((tx0 (+ x1 (/ (- (- x2 x1) width) 2)))
+              (ty0 (+ 1 y1 baseline)))
+          (draw-line* pane tx0 (1+ ty0) (+ tx0 width) (1+ ty0) :ink *3d-dark-color*)
+          (draw-text* pane label tx0 ty0
+                      :text-style *labelled-divider-text-style*)))
+      (progn
+        (draw-line* pane x1 (1+ y1) x2 (1+ y1) :ink *3d-dark-color*)
+        (draw-line* pane x1 (+ 2 y1) x2 (+ 2 y1) :ink *3d-light-color*)))))
 
 
 ;;; Menu creation from command tables
 
 (defun make-menu-button-from-menu-item (item client
                                         &key (bottomp nil)
-                                        (vertical nil)
-                                        command-table
-                                        (presentation-type 'menu-item))
+                                             (vertical nil)
+                                             command-table
+                                             (presentation-type 'menu-item))
   (declare (ignore command-table))
   (let* ((name (command-menu-item-name item))
          (type (command-menu-item-type item))
          (value (command-menu-item-value item))
          (frame (pane-frame client))
          (manager (frame-manager frame)))
-    (case type
-      (:command
-       (let ((command-name (if (consp value) (car value) value)))
-         (if (command-enabled command-name frame)
-             (make-pane-1 manager frame 'menu-button-leaf-pane
-                          :label name
-                          :client client
-                          :value-changed-callback
-                          #'(lambda (gadget val)
-                              (declare (ignore gadget val))
-                              (throw-object-ptype item presentation-type)))
-             (let ((pane (make-pane-1 manager frame 'menu-button-leaf-pane
-                            :label name
-                            :client client
-                            :value-changed-callback
-                            #'(lambda (gadget val)
+    (flet ((make-sub-pane (class &rest initargs &key &allow-other-keys)
+             (apply #'make-pane-1 manager frame class
+                    :label name :client client initargs)))
+      (case type
+        (:command
+         (let ((command-name (if (consp value) (car value) value)))
+           (if (command-enabled command-name frame)
+               (make-sub-pane 'menu-button-leaf-pane
+                              :value-changed-callback
+                              (lambda (gadget val)
                                 (declare (ignore gadget val))
-                                nil))))
-               (deactivate-gadget pane)
-               pane))))
-      (:function
-        (make-pane-1 manager frame 'menu-button-leaf-pane
-                     :label name
-                     :client client
-                     :value-changed-callback
-                     #'(lambda (gadget val)
-                         (declare (ignore gadget val))
-                         ;; FIXME: the spec requires us to pass a gesture to the
-                         ;; function, but value-changed-callback doesn't provide
-                         ;; one, so we pass NIL for now.
-                         ;; FIXME: We don't have a numeric argument, either.
-                         (let ((command (funcall value nil nil)))
-                           (throw-object-ptype command 'command)))))
-      (:divider
-       (make-pane-1 manager frame 'menu-divider-leaf-pane
-                    :label name
-                    :client client))
-      (:menu
-        (make-pane-1 manager frame (if vertical
-                                       'menu-button-vertical-submenu-pane
-                                       'menu-button-submenu-pane)
-		     :label name
-		     :client client
-		     :frame-manager manager
-		     :command-table value
-		     :bottomp bottomp))
-      (otherwise (error "Don't know how to create a menu button for ~W" type)))))
+                                (throw-object-ptype item presentation-type)))
+               (let ((pane (make-sub-pane 'menu-button-leaf-pane
+                                          :value-changed-callback
+                                          (lambda (gadget val)
+                                            (declare (ignore gadget val))
+                                            nil))))
+                 (deactivate-gadget pane)
+                 pane))))
+        (:function
+         (make-sub-pane 'menu-button-leaf-pane
+                        :value-changed-callback
+                        (lambda (gadget val)
+                          (declare (ignore gadget val))
+                          ;; FIXME: the spec requires us to pass a gesture to the
+                          ;; function, but value-changed-callback doesn't provide
+                          ;; one, so we pass NIL for now.
+                          ;; FIXME: We don't have a numeric argument, either.
+                          (let ((command (funcall value nil nil)))
+                            (throw-object-ptype command 'command)))))
+        (:divider
+         (make-sub-pane 'menu-divider-leaf-pane))
+        (:menu
+         (make-sub-pane (if vertical
+                            'menu-button-vertical-submenu-pane
+                            'menu-button-submenu-pane)
+                        :frame-manager manager
+                        :command-table value
+                        :bottomp bottomp))
+        (otherwise (error "Don't know how to create a menu button for ~W" type))))))
 
 ;;
 ;; MENU-BAR
 ;;
-(defclass menu-button-hrack-pane (hrack-pane) ())
 
-(defclass menu-bar (menu-button-hrack-pane)
+(defclass menu-bar (hrack-pane)
   ((items :initform nil)
    (armed :initform nil)))
 
@@ -361,8 +320,8 @@ account, and create a list of menu buttons."
 
 (defmethod destroy-substructure ((object menu-bar))
   (loop for child in (menu-children object)
-	do (progn (destroy-substructure child)
-		  (dispatch-repaint child (sheet-region child))))
+        do (destroy-substructure child)
+           (dispatch-repaint child (sheet-region child)))
   (setf (slot-value object 'armed) nil))
 
 (defmethod arm-menu ((object menu-bar))
@@ -419,23 +378,21 @@ account, and create a list of menu buttons."
     ((pane menu-bar) real-width real-height)
   (with-slots (x-spacing) pane
     (let ((widths
-	   (box-layout-mixin/horizontally-allocate-space-aux*
-	    pane real-width real-height))
-	  (x 2))
-      (loop
-	  for child in (box-layout-mixin-clients pane)
-	  for width in widths
-	  do
-	    (when (box-client-pane child)
-	      (layout-child (box-client-pane child)
-			    :expand
-			    :expand
-			    x
-			    2
-			    width
-			    (- real-height 4)))
-	    (incf x width)
-	    (incf x x-spacing)))))
+            (box-layout-mixin/horizontally-allocate-space-aux*
+             pane real-width real-height))
+          (x 2))
+      (loop for child in (box-layout-mixin-clients pane)
+            for width in widths
+            do (when (box-client-pane child)
+                 (layout-child (box-client-pane child)
+                               :expand
+                               :expand
+                               x
+                               2
+                               width
+                               (- real-height 4)))
+               (incf x width)
+               (incf x x-spacing)))))
 
 (defmethod display-command-table-menu ((command-table standard-command-table)
                                        (stream fundamental-output-stream)

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -1379,8 +1379,6 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
 (defmethod initialize-instance :after ((pane box-pane) &key contents)
   (setf (%pane-contents pane) contents))
 
-(defgeneric %pane-contests (pane contents))
-
 (defmethod (setf %pane-contents) (contents (pane box-pane))
   (labels ((parse-box-content (content)
 	     "Parses a box/rack content and returns a BOX-CLIENT instance."


### PR DESCRIPTION
* Destroy submenu structure depending on port's pointer sheet 

* Use correct frame when (de)activating menu items 

* The functions `menu-draw-[un]highlighted` are not used anywhere. The `(handle-repaint menu-button-pane t)` method seems to be an improved version of these functions.

* Remove unused slot bindings.

* Use `if-let`, `with-bounding-rectangle*` where appropriate.