### PR TITLE
Freetype: Fix crash due to missing method

### DIFF
--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -523,6 +523,9 @@ or NIL if the current transformation is the identity transformation."
             (t
              (text-extents font string start end))))))
 
+(defmethod climb:font-glyph-dx ((font freetype-font) character)
+  (nth-value 2 (climb:font-text-extents font (format nil "~c" (code-char character)))))
+
 (defmethod climb:text-bounding-rectangle* ((medium clx-freetype-medium) string
                                            &key
                                              text-style


### PR DESCRIPTION
The function font-glyph-dx did not have an applicable method when
used with a freetype font. Fixes #846