### PR TITLE
Sort out dependency issues between design.lisp and regions.lisp

### DIFF
--- a/Core/clim-basic/clim-basic.asd
+++ b/Core/clim-basic/clim-basic.asd
@@ -13,7 +13,6 @@
    (:file "multiprocessing" :depends-on ("decls")) ; legacy mp backends are in Lisp-Dep/mp-*.lisp
    (:file "utils" :depends-on ("decls" "multiprocessing"))
    (:file "X11-colors" :depends-on ("decls" "protocol-classes" "multiprocessing" "design" "geometry"))
-   (:file "design" :depends-on ("decls" "protocol-classes" "utils"))
    (:file "dead-keys" :depends-on ("decls"))
    (:module "geometry"
     :depends-on ("decls" "protocol-classes" "multiprocessing" "utils" "setf-star")
@@ -26,6 +25,7 @@
                  (:file "region-transformations")
                  (:file "region-predicates")
                  (:file "region-composition")))
+   (:file "design" :depends-on ("decls" "protocol-classes" "utils" "geometry"))
    (:file "pattern" :depends-on ("decls" "protocol-classes" "utils" "design"))
    (:file "sheets" :depends-on ("decls" "protocol-classes" "multiprocessing" "utils" "geometry"))
    (:file "mirrors" :depends-on ("sheets"))

--- a/Core/clim-basic/design.lisp
+++ b/Core/clim-basic/design.lisp
@@ -277,26 +277,6 @@
         (subseq contrasting-colors 0 n)
         (aref contrasting-colors k))))
 
-;;;; Design <-> Region Equivalences
-
-;;; As Gilbert points in his notes, transparent ink is in every
-;;; respect interchangable with the nowhere region, and likewise
-;;; foreground ink is interchangable with the everywhere region.
-;;; By defining the following mixins and adding them to the
-;;; appropriate ink/region class pairs, we can reduce the number
-;;; of methods necessary.
-
-;;;
-;;; define these variables here so we can use them here in
-;;; design.lisp, but don't set them to their eventual values until we
-;;; get to region.lisp. Note that these are named as constants, but
-;;; aren't truly constants.
-(defvar +everywhere+)
-(defvar +nowhere+)
-
-(defclass everywhere-mixin () ())
-(defclass nowhere-mixin    () ())
-
 ;;; The two default colors
 
 (defconstant +white+ (make-named-color "white" 1.0000 1.0000 1.0000))
@@ -509,16 +489,12 @@ identity-transformation) then source design is returned."
 (defclass in-compositum (masked-compositum) ())
 
 (defmethod compose-in ((ink design) (mask design))
-  (make-instance 'in-compositum
-    :ink ink
-    :mask mask))
+  (make-instance 'in-compositum :ink ink :mask mask))
 
 (defclass out-compositum (masked-compositum) ())
 
 (defmethod compose-out ((ink design) (mask design))
-  (make-instance 'out-compositum
-    :ink ink
-    :mask mask))
+  (make-instance 'out-compositum :ink ink :mask mask))
 
 (defclass over-compositum (design)
   ((foreground :initarg :foreground :reader compositum-foreground)

--- a/Core/clim-basic/geometry/regions.lisp
+++ b/Core/clim-basic/geometry/regions.lisp
@@ -53,13 +53,26 @@
 
 (in-package :clim-internals)
 
-(defclass nowhere-region (region nowhere-mixin) ())
+;;;; Design <-> Region Equivalences
+
+;;; As Gilbert points in his notes, transparent ink is in every
+;;; respect interchangable with the nowhere region, and likewise
+;;; foreground ink is interchangable with the everywhere region.
+;;; By defining the following mixins and adding them to the
+;;; appropriate ink/region class pairs, we can reduce the number
+;;; of methods necessary (in design.lisp).
+
+(defclass everywhere-mixin () ())
+(defclass nowhere-mixin    () ())
+
+(defclass nowhere-region    (region nowhere-mixin)    ())
 (defclass everywhere-region (region everywhere-mixin) ())
 
-;;; coordinate is defined in coordinates.lisp
+;;; Note that these are named as constants, but aren't truly
+;;; constants.
 
-(setf +everywhere+ (make-instance 'everywhere-region))
-(setf +nowhere+ (make-instance 'nowhere-region))
+(defvar +everywhere+ (make-instance 'everywhere-region))
+(defvar +nowhere+ (make-instance 'nowhere-region))
 
 ;;; 2.5.1.2 Composition of CLIM Regions
 


### PR DESCRIPTION
Before this change, the compile and load order of design.lisp and regions.lisp was not explicitly specified and loading design.lisp first lead to a warning due to `+identity-transformation+` not being defined yet.

Generally speaking, the geometry module (including `regions.lisp`) is more fundamental and should be compiled and loaded first. The only obstacle were `+{no,every}where+`, `{no,every}where-mixin` which are defined in `design.lisp` but initialized in `regions.lisp`. To allow compiling and loading `regions.lisp` first (and avoid the definition and initialization of `+{no,every}where+` in distinct places), `+{no,every}where+` and `{no,every}where-mixin` are now defined in `regions.lisp`.