### PR TITLE
Fixes for the TEXT-STYLE-TO-FONT removal

### DIFF
--- a/Backends/CLX/fonts.lisp
+++ b/Backends/CLX/fonts.lisp
@@ -57,12 +57,13 @@
                     (open-font display
                                (format nil "-~a-~a-*-*-~d-*-*-*-*-*-~a"
                                        family-name face-name size encoding))))
-;;; xxx: this part is a bit problematic - we either list all fonts
-;;; with any possible encoding (what leads to the situation, when our
-;;; font can't render a simple string "abcd") or we end with only a
-;;; partial list of fonts. since we have mcclim-ttf extension which
-;;; handles unicode characters well, this mechanism of getting fonts
-;;; is deprecated and there is no big harm.
+             ;; XXX: this part is a bit problematic - we either list
+             ;; all fonts with any possible encoding (what leads to
+             ;; the situation, when our font can't render a simple
+             ;; string "abcd") or we end with only a partial list of
+             ;; fonts. since we have mcclim-ttf extension which
+             ;; handles unicode characters well, this mechanism of
+             ;; getting fonts is deprecated and there is no big harm.
              (or (try "iso8859-1")
                  (progn
                    (setf family :sans-serif)

--- a/Core/clim-basic/medium.lisp
+++ b/Core/clim-basic/medium.lisp
@@ -206,16 +206,14 @@
                               (style2 device-font-text-style))
   (eq style1 style2))
 
-;; the standard-text-style are registered in a port slot.
-(defmethod text-style-mapping :around ((port basic-port) text-style
+(defmethod text-style-mapping :around ((port basic-port)
+                                       (text-style standard-text-style)
                                        &optional character-set
                                        &aux (text-style (parse-text-style text-style)))
   (declare (ignore character-set))
-  (if  (typep text-style 'standard-text-style)
-       (alexandria:if-let (font (gethash text-style (port-text-style-mappings port)))
-         font
-         (setf (gethash text-style (port-text-style-mappings port)) (call-next-method)))
-       (call-next-method)))
+  ;; Cache `standard-text-style' instances.
+  (ensure-gethash text-style (port-text-style-mappings port)
+                  (call-next-method)))
 
 (defmethod (setf text-style-mapping) (mapping (port basic-port)
                                       text-style

--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -514,7 +514,7 @@ or NIL if the current transformation is the identity transformation."
                   with sizes = nil
                   for (string family style) in blocks
                   for new-text-style = (if family (clim:make-text-style family style size) text-style)
-                  do (let ((font (text-style-mapping port new-text-style)))
+                  do (let ((font (clim:text-style-mapping port new-text-style)))
                        (setf sizes (multiple-value-list (text-extents font string 0 (length string))))
                        (incf curr-x (car sizes)))
                   finally

--- a/Extensions/render/backend/port.lisp
+++ b/Extensions/render/backend/port.lisp
@@ -53,7 +53,7 @@
          (multiple-value-call #'find-and-make-truetype-font
            (clim:text-style-components text-style))))
     (or (find-truetype-font port text-style)
-                  (invoke-with-truetype-path-restart #'find-font))))
+        (invoke-with-truetype-path-restart #'find-font))))
 
 (defmethod text-style-mapping ((port render-port-mixin) (gs-text-style cons) &optional character-set)
   (declare (ignore character-set))

--- a/Tests/util/test-page.lisp
+++ b/Tests/util/test-page.lisp
@@ -36,11 +36,22 @@
                     stream (loop :for i :from 0 :to end :by .1
                                  :collect (sqrt i)
                                  :collect (* (/ i end) (sin i)))
-                    :filled nil :closed nil :line-thickness 2))))))
+                    :filled nil :closed nil :line-thickness 2)))))
+           (character-width (x y)
+             (with-translation (stream x y)
+               (loop :with width = (stream-character-width stream #\M)
+                     :with height = (nth-value 1 (text-size stream "Ty"))
+                     :for position :from 0 :by width
+                     :for character :across "AILTMy"
+                     :do (draw-text* stream (string character) position 0)
+                         (draw-rectangle* stream position 0 (+ position width) (- height)
+                                          :filled nil :ink +red+
+                                          :line-dashes '(4 4) :line-thickness .3)))))
     (text 0 0 200)
     (wheels 208 0 80)
-    (graph 0 0 200 100)))
+    (graph 0 -108 200 100)
+    (character-width 0 140)))
 
 (defun print-test-page (stream)
-  (with-room-for-graphics (stream)
+  (with-room-for-graphics (stream :first-quadrant nil)
     (%print-test-page stream)))


### PR DESCRIPTION
This fixes minor problems introduced in b2e1930b.

* The `text-style-mapping` can be specialized to `standard-text-style` instead of checking the type in the body. It can also be written more concisely using `alexandria:ensure-gethash`.

* One of the `text-style-mapping` calls in the freetype backend lacked the `clim:` package prefix.

* Indentation fixes.

* Test `stream-character-width` in the `print-test-page` test function.