### PR TITLE
dialog : wrap stream argument in with-encapsulating-stream

### DIFF
--- a/Core/clim-core/dialog.lisp
+++ b/Core/clim-core/dialog.lisp
@@ -408,11 +408,12 @@ highlighting, etc." ))
     (flet ((do-prompt (stream)
              (apply #'prompt-for-accept stream type view rest-args))
            (do-accept-present-default (stream)
-             (funcall-presentation-generic-function
-              accept-present-default
-              type (encapsulating-stream-stream stream) view
-              (value query)
-              default-supplied-p nil query-identifier)))
+	     (with-encapsulating-stream (maybe-encapsulating-stream stream)
+	       (funcall-presentation-generic-function
+		accept-present-default
+		type (encapsulating-stream-stream maybe-encapsulating-stream) view
+		(value query)
+		default-supplied-p nil query-identifier))))
       (let ((query-record nil))
         (if align
             (formatting-row (stream)


### PR DESCRIPTION
calling encapsulating-stream-stream can fail because not every stream
here is an encapsulating-stream.(e.g. in #859, stream is interactor
pane which does not have an encapsulating stream). Wrapping stream in with-encapsulating-stream fixes this.

Fixes #859