### PR TITLE
Casual improvements

### DIFF
--- a/Core/clim-basic/text-formatting.lisp
+++ b/Core/clim-basic/text-formatting.lisp
@@ -44,7 +44,9 @@
                   (setf (getf text-margins ,edge) ,default))))
     (thunk :left   '(:absolute 0))
     (thunk :top    '(:absolute 0))
-    (thunk :right  (or text-margin '(:relative 0)))
+    (thunk :right  (if text-margin
+                       `(:absolute ,text-margin)
+                       `(:relative 0)))
     (thunk :bottom '(:relative 0))
     (setf (stream-text-margins instance) text-margins)))
 

--- a/Core/clim-core/bordered-output.lisp
+++ b/Core/clim-core/bordered-output.lisp
@@ -456,8 +456,29 @@
                           (draw-line* stream left bottom right bottom
                                       :ink ink
                                       :line-style line-style)))
-                       (updating-output-record  nil)
-                       (compound-output-record  (fn child))))))
+                       (updating-output-record nil)
+                       (compound-output-record (fn child))))))
+      (fn record))))
+
+(define-border-type :crossout (stream record
+                                       (ink (medium-ink stream))
+                                       line-style
+                                       line-unit
+                                       line-thickness
+                                       line-cap-shape
+                                       line-dashes)
+  (let ((line-style (%%line-style-for-method)))
+    (labels ((fn (record)
+               (loop for child across (output-record-children record) do
+                     (typecase child
+                       (text-displayed-output-record
+                        (with-bounding-rectangle* (left top right bottom) child
+                          (let ((middle (/ (+ bottom top) 2)))
+                            (draw-line* stream left middle right middle
+                                        :ink ink
+                                        :line-style line-style))))
+                       (updating-output-record nil)
+                       (compound-output-record (fn child))))))
       (fn record))))
 
 (define-border-type :inset (stream left top right bottom


### PR DESCRIPTION
- fix issue with invalid spec for text-margin
- allow specifying margin as a number (then it is assumed to be relative)
- add new border shape specifier `:crossout` (similar to `:underline`)

I've also reported #881 but it doesn't look like an easy one so I'm not investigating further.