### PR TITLE
Implement %invalidate-cached-device-regions

### DIFF
--- a/Core/clim-basic/windowing/sheets.lisp
+++ b/Core/clim-basic/windowing/sheets.lisp
@@ -81,7 +81,8 @@
 ;;; non standard protocol
 
 (defgeneric %invalidate-cached-device-transformations (sheet))
-(defgeneric %invalidate-cached-device-regions (sheet))
+(defgeneric %invalidate-cached-device-regions (sheet)
+  (:method (sheet) nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;


### PR DESCRIPTION
This provides a default implementation for
%invalidate-cached-device-regions so that the application will not
crash even if a sheet does not specialise this method.

Fixes #895