### PR TITLE
utils: parse-space: use function instead of a macro

### DIFF
--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -498,8 +498,12 @@ STREAM in the direction DIRECTION."
                              (ecase direction
                                (:horizontal width)
                                (:vertical height))))
-    (function (let ((record (with-output-to-output-record (stream)
-                              (funcall specification))))
+    (function (let ((record
+                      (invoke-with-output-to-output-record
+                       stream (lambda (s o)
+                                (declare (ignore s o))
+                                (funcall specification))
+                       'standard-sequence-output-record)))
                 (ecase direction
                   (:horizontal (bounding-rectangle-width record))
                   (:vertical (bounding-rectangle-height record)))))


### PR DESCRIPTION
Macro with-output-to-output-record is not defined until later (so when
it is compiled it is assumed to be a function and a warning is
signaled). Use invoke-with-output-to-output-record which is already
declared. Fixes #893.