### PR TITLE
display string in pointer-documentation-pane

### DIFF
--- a/Core/clim-core/frames.lisp
+++ b/Core/clim-core/frames.lisp
@@ -1317,7 +1317,7 @@ alive.")
             (%stream% stream)
             (%doc-state% frame-documentation-state)
             (%event% event))
-        (declare (special %input-context% %stream% %doc-state% %event&))
+        (declare (special %input-context% %stream% %doc-state% %event%))
         (if (and documentation-record
                  (output-record-parent documentation-record))
             (redisplay documentation-record *pointer-documentation-output*)


### PR DESCRIPTION
Old version of FRAME-DISPLAY-POINTER-DOCUMENTATION-STRING didn't
trigger the redisplay of the pointer-documentation-pane so the string
were not visible (e.g documentation in some scigraph commands).


----

#