### PR TITLE
Fix accepting-values keybindings

### DIFF
--- a/Core/clim-core/dialog.lisp
+++ b/Core/clim-core/dialog.lisp
@@ -440,19 +440,23 @@ highlighting, etc." ))
   (apply #'prompt-for-accept-1 stream type :display-default nil args))
 
 (define-command (com-query-exit :command-table accept-values
-                                :keystroke (#\] :control)
+                                :keystroke (#\[ :control)
                                 :name nil
                                 :provide-output-destination-keyword nil)
     ()
   (signal 'av-exit))
 
+(add-keystroke-to-command-table 'accept-values '(#\Return :meta) :command #'com-query-exit)
+
 (define-command (com-query-abort :command-table accept-values
-                                 :keystroke (#\z :control)
+                                 :keystroke (#\] :control)
                                  :name nil
                                  :provide-output-destination-keyword nil)
     ()
   (and (find-restart 'abort)
        (invoke-restart 'abort)))
+
+(add-keystroke-to-command-table 'accept-values '(#\g :control) :command #'com-query-abort)
 
 (define-command (com-change-query :command-table accept-values
                                   :name nil

--- a/Core/clim-core/dialog.lisp
+++ b/Core/clim-core/dialog.lisp
@@ -446,7 +446,7 @@ highlighting, etc." ))
     ()
   (signal 'av-exit))
 
-(add-keystroke-to-command-table 'accept-values '(#\Return :meta) :command #'com-query-exit)
+(add-keystroke-to-command-table 'accept-values '(#\Return :meta) :command 'com-query-exit :errorp nil)
 
 (define-command (com-query-abort :command-table accept-values
                                  :keystroke (#\] :control)
@@ -456,7 +456,7 @@ highlighting, etc." ))
   (and (find-restart 'abort)
        (invoke-restart 'abort)))
 
-(add-keystroke-to-command-table 'accept-values '(#\g :control) :command #'com-query-abort)
+(add-keystroke-to-command-table 'accept-values '(#\g :control) :command 'com-query-abort :errorp nil)
 
 (define-command (com-change-query :command-table accept-values
                                   :name nil


### PR DESCRIPTION
#654 describes problems with the keybindings for accepting-values, and so I've made an attempt at fixing one of them.

No command for OK existed, so I created one. It is bound to `C-[` and `M-RET`. `M-RET` was added based on @lokedhs's suggestion that it is more intuitive.

Exit works like you'd expect OK to. I haven't changed this since the OK button uses the command to confirm, and some people might have gotten used to pressing `C-]` to confirm.

This is my first contribution to McCLIM, so please let me know if I've done something wrong.