### PR TITLE
[WIP] Add docstring printing to clim-lisp:describe-object

### DIFF
--- a/Core/clim-core/describe.lisp
+++ b/Core/clim-core/describe.lisp
@@ -85,6 +85,9 @@
                    #-(or excl cmu sbcl clisp lispworks) "( ??? )"))
       (when arglist
         (present-simply arglist stream)))
+    (when (documentation (symbol-function object) t)
+      (format stream "~%      and has the docstring:~%")
+      (format stream "      ~S" (documentation (symbol-function object) t)))
     (terpri))
   (format stream "   it has a property list of ~S~%" (symbol-plist object)))
 


### PR DESCRIPTION
I've added basic docstring printing to `clim-lisp:describe-object`.
Relevant issue: #381 