### PR TITLE
Listener: open pathnames with #\Space

### DIFF
--- a/Apps/Listener/file-types.lisp
+++ b/Apps/Listener/file-types.lisp
@@ -490,7 +490,7 @@
 ;; seem to open any file with quotes in the name. (how embarassing!)
 
 (defun quote-shell-characters (string)
-  (let ((shell-chars '(#\` #\$ #\\ #\" #\')))
+  (let ((shell-chars '(#\` #\$ #\\ #\" #\' #\Space)))
   (with-output-to-string (out)
     (with-input-from-string (in string)
       (loop for c = (read-char in nil) while c do


### PR DESCRIPTION
If in a pathname there is a #\Space character it is necessary to
escape it with a backslash when the view command string is generated.


----

#