### PR TITLE
make-pane-1: add a new protocol to resolve abstract pane names

### DIFF
--- a/Backends/CLX-fb/frame-manager.lisp
+++ b/Backends/CLX-fb/frame-manager.lisp
@@ -37,10 +37,10 @@
         (setf concrete-pane-class (find-class class-symbol)))))
   concrete-pane-class)
 
-(defmethod make-pane-1 ((fm clx-fb-frame-manager) (frame application-frame) type &rest args)
-  (apply #'make-instance
-	 (maybe-mirroring fm (clim-clx::find-concrete-pane-class type))
-	 :frame frame
-	 :manager fm
-	 :port (port frame)
-	 args))
+(defmethod find-concrete-pane-class ((fm clx-fb-frame-manager)
+                                     pane-type &optional (errorp t))
+  ;; This backend doesn't have any specialized pane implementations
+  ;; but depending on circumstances it may add optional mirroring to
+  ;; the class. Such automatically defined concrete class has the same
+  ;; name but with a gensym prefix and symbol in the backend package.
+  (maybe-mirroring fm (find-concrete-pane-class t pane-type errorp)))

--- a/Backends/CLX/frame-manager.lisp
+++ b/Backends/CLX/frame-manager.lisp
@@ -94,12 +94,6 @@
         (setf concrete-pane-class (find-class class-symbol)))))
   concrete-pane-class)
 
-(defmethod make-pane-1 ((fm clx-frame-manager) (frame application-frame) type &rest args)
-  (apply #'make-instance (find-concrete-pane-class fm type)
-	 :frame frame :manager fm :port (port frame)
-         args))
-
-
 (defmethod adopt-frame :before ((fm clx-frame-manager) (frame menu-frame))
   ;; Temporary kludge.
   (when (eq (slot-value frame 'climi::top) nil)

--- a/Backends/Null/frame-manager.lisp
+++ b/Backends/Null/frame-manager.lisp
@@ -22,22 +22,9 @@
 (defclass null-frame-manager (frame-manager)
   ())
 
-;;; FIXME: maybe this or something like it belongs in CLIMI?
-(defun generic-concrete-pane-class (name)
-  (let* ((concrete-name (get name 'climi::concrete-pane-class-name))
-         (maybe-name (concatenate 'string (symbol-name name) 
-                                  (symbol-name '#:-pane)))
-         (maybe-symbol (find-symbol maybe-name :climi))
-         (maybe-class (find-class maybe-symbol nil)))
-    (or maybe-class
-        (find-class concrete-name nil)
-        (find-class (if (keywordp name) 
-                        (intern (symbol-name name) :climi)
-                        name) nil))))
-
 (defmethod make-pane-1
     ((fm null-frame-manager) (frame application-frame) type &rest initargs)
-  (apply #'make-instance (generic-concrete-pane-class type)
+  (apply #'make-instance (find-concrete-pane-class fm type)
 	 :frame frame :manager fm :port (port frame)
 	 initargs))
 

--- a/Backends/Null/frame-manager.lisp
+++ b/Backends/Null/frame-manager.lisp
@@ -22,12 +22,6 @@
 (defclass null-frame-manager (frame-manager)
   ())
 
-(defmethod make-pane-1
-    ((fm null-frame-manager) (frame application-frame) type &rest initargs)
-  (apply #'make-instance (find-concrete-pane-class fm type)
-	 :frame frame :manager fm :port (port frame)
-	 initargs))
-
 (defmethod adopt-frame :after
     ((fm null-frame-manager) (frame application-frame))
   ())

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -403,6 +403,11 @@ returned or error is signaled depending on the argument ERRORP.")
                     (error "Concrete class for a pane ~s not found." pane-type)))))
           (find-class pane-type errorp)))))
 
+(defmethod make-pane-1 ((fm frame-manager) (frame application-frame) type &rest args)
+  (apply #'make-instance (find-concrete-pane-class fm type)
+	 :frame frame :manager fm :port (port frame)
+         args))
+
 (defun make-pane (type &rest args)
   (apply #'make-pane-1 (or *pane-realizer*
 			   (frame-manager *application-frame*))

--- a/package.lisp
+++ b/package.lisp
@@ -1990,7 +1990,7 @@
   (:nicknames :climb)
   (:use :clim :clim-extensions)
   (:export
-   ;; Originally in CLIM-INTERNALS
+   ;; CLIM-INTERNALS
    #:make-graft
    #:medium-draw-circle*
    #:mirror-transformation
@@ -2012,6 +2012,7 @@
    #:window-manager-focus-event
    #:with-port
    #:invoke-with-port
+   #:find-concrete-pane-class
    ;; Text-style
    #:text-style-character-width
    #:text-bounding-rectangle*


### PR DESCRIPTION
Until now each backend had their own ad-hoc method. Now we introduce a
common protocol which unifies behavior and allows other clients to
resolve a pane-type to a concrete class. New function is called
find-concrete-pane-class and is specialized on a frame-manager.

This approach saves us some mess in clx's frame-manager
implementation.