### PR TITLE
Fix various

### DIFF
--- a/Backends/CLX-fb/frame-manager.lisp
+++ b/Backends/CLX-fb/frame-manager.lisp
@@ -9,16 +9,16 @@
 ;;; if the pane is a subclass of basic-pane and it is not mirrored we create a new class.
 (defun maybe-mirroring (fm concrete-pane-class)
   (when (and (not (subtypep concrete-pane-class 'mirrored-sheet-mixin))
-	     (funcall (clim-clx::mirroring-p fm) concrete-pane-class))
+             (funcall (clim-clx::mirroring-p fm) concrete-pane-class))
     (let* ((concrete-pane-class-symbol (if (typep concrete-pane-class 'class)
-                                          (class-name concrete-pane-class)
-                                          concrete-pane-class)))
+                                           (class-name concrete-pane-class)
+                                           concrete-pane-class)))
       (multiple-value-bind (class-symbol foundp)
           (alexandria:ensure-symbol
            (alexandria:symbolicate (clim-clx::class-gensym fm) "-"
                                    (symbol-name concrete-pane-class-symbol))
            :clim-clx-fb)
-	(unless foundp
+        (unless foundp
           (let ((superclasses (if (subtypep concrete-pane-class 'sheet-with-medium-mixin)
                                   (list 'clx-fb-mirrored-sheet-mixin
                                         'climi::always-repaint-background-mixin
@@ -38,9 +38,11 @@
   concrete-pane-class)
 
 (defmethod make-pane-1 ((fm clx-fb-frame-manager) (frame application-frame) type &rest args)
+  ;; This backend doesn't have any specialized pane implementations
+  ;; but depending on circumstances it may add optional mirroring to
+  ;; the class. Such automatically defined concrete class has the same
+  ;; name but with a gensym prefix and symbol in the backend package.
   (apply #'make-instance
-	 (maybe-mirroring fm (clim-clx::find-concrete-pane-class type))
-	 :frame frame
-	 :manager fm
-	 :port (port frame)
-	 args))
+         (maybe-mirroring fm (find-concrete-pane-class type))
+         :frame frame :manager fm :port (port frame)
+         args))

--- a/Backends/CLX/frame-manager.lisp
+++ b/Backends/CLX/frame-manager.lisp
@@ -58,56 +58,11 @@
 
 ;; Abstract pane lookup logic
 
-(defun find-first-defined-class (types)
-  (first
-   (remove-if #'null
-              (mapcar (lambda (class-name)
-                        (find-class class-name nil))
-                      types))))
-
-(defun find-symbol-from-spec (package-spec name-components)
-  (flet ((coerce-name-element (name-elt)
-           (typecase name-elt
-             (symbol (symbol-name name-elt))
-             (sequence (coerce name-elt 'string))
-             (t (princ-to-string name-elt)))))
-  (find-symbol
-   (apply #'concatenate 'string (mapcar #'coerce-name-element name-components))
-   package-spec)))
-
-(defun find-symbols (name-specs)
-  (remove-if #'null (mapcar #'(lambda (x) (find-symbol-from-spec (first x) (rest x))) name-specs)))
-
-(defun generate-standard-pane-specs (type)
-  (let ((mapping (get type 'climi::concrete-pane-class-name)))
-    `((,(symbol-package mapping) ,mapping)
-      (:climi ,mapping)
-      (:climi ,type #:-pane)
-      (:climi ,type))))
-
-(defun generate-clx-pane-specs (type)
-  (append
-   `((:clim-clx #:clx- ,type #:-pane)
-     (:clim-clx #:clx- ,type)
-     (:climi #:clx- ,type #:-pane)
-     (:climi #:clx- ,type))
-   (generate-standard-pane-specs type)))
-
-(defun find-concrete-pane-class (type)
-  (if (or (eql (symbol-package type)
-               (find-package '#:clim))
-          (eql (symbol-package type)
-               (find-package '#:climi))
-          (eql (symbol-package type)
-               (find-package '#:keyword))
-	  (get type 'climi::concrete-pane-class-name))
-      (find-first-defined-class (find-symbols (generate-clx-pane-specs type)))
-      type))
-
-;;; This is an example of how make-pane-1 might create specialized instances of
-;;; the generic pane types based upon the type of the frame-manager. However, in
-;;; the CLX case, we don't expect there to be any CLX specific panes. CLX uses
-;;; the default generic panes instead.
+;;; This is an example of how make-pane-1 might create specialized
+;;; instances of the generic pane types based upon the type of the
+;;; frame-manager. However, in the CLX case, we don't expect there to
+;;; be any CLX specific panes. CLX uses the default generic panes
+;;; instead.
 (defun maybe-mirroring (fm concrete-pane-class)
   (when (funcall (mirroring-p fm) concrete-pane-class)
     (let ((concrete-pane-class-symbol (if (typep concrete-pane-class 'class)
@@ -115,7 +70,8 @@
                                           concrete-pane-class)))
       (multiple-value-bind (class-symbol foundp)
           (alexandria:ensure-symbol
-           (alexandria:symbolicate (class-gensym fm) "-" (symbol-name concrete-pane-class-symbol))
+           (alexandria:symbolicate (class-gensym fm) "-"
+                                   (symbol-name concrete-pane-class-symbol))
            :clim-clx)
         (unless foundp
           (eval
@@ -126,18 +82,18 @@
                  ,concrete-pane-class-symbol)
               ()
               (:metaclass ,(type-of (find-class concrete-pane-class-symbol))))))
-        ;; (format *debug-io* "dummy class mirror ~A: ~A~%" concrete-pane-class-symbol class-symbol)
         (setf concrete-pane-class (find-class class-symbol)))))
   concrete-pane-class)
 
 (defmethod make-pane-1 ((fm clx-frame-manager) (frame application-frame) type &rest args)
+  ;; This backend doesn't have any specialized pane implementations
+  ;; but depending on circumstances it may add optional mirroring to
+  ;; the class. Such automatically defined concrete class has the same
+  ;; name but with a gensym prefix and symbol in the backend package.
   (apply #'make-instance
-	 (maybe-mirroring fm (find-concrete-pane-class type))
-	 :frame frame
-	 :manager fm
-	 :port (port frame)
-	 args))
-
+         (maybe-mirroring fm (find-concrete-pane-class type))
+         :frame frame :manager fm :port (port frame)
+         args))
 
 (defmethod adopt-frame :before ((fm clx-frame-manager) (frame menu-frame))
   ;; Temporary kludge.

--- a/Backends/Null/frame-manager.lisp
+++ b/Backends/Null/frame-manager.lisp
@@ -22,25 +22,6 @@
 (defclass null-frame-manager (frame-manager)
   ())
 
-;;; FIXME: maybe this or something like it belongs in CLIMI?
-(defun generic-concrete-pane-class (name)
-  (let* ((concrete-name (get name 'climi::concrete-pane-class-name))
-         (maybe-name (concatenate 'string (symbol-name name) 
-                                  (symbol-name '#:-pane)))
-         (maybe-symbol (find-symbol maybe-name :climi))
-         (maybe-class (find-class maybe-symbol nil)))
-    (or maybe-class
-        (find-class concrete-name nil)
-        (find-class (if (keywordp name) 
-                        (intern (symbol-name name) :climi)
-                        name) nil))))
-
-(defmethod make-pane-1
-    ((fm null-frame-manager) (frame application-frame) type &rest initargs)
-  (apply #'make-instance (generic-concrete-pane-class type)
-	 :frame frame :manager fm :port (port frame)
-	 initargs))
-
 (defmethod adopt-frame :after
     ((fm null-frame-manager) (frame application-frame))
   ())

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -363,11 +363,49 @@ order to produce a double-click")
   (print-unreadable-object (pane sink :type t :identity t)
     (prin1 (pane-name pane) sink)))
 
+(defun find-concrete-pane-class (pane-type &optional (errorp t))
+  "Resolves abstract pane type PANE-TYPE to a concrete pane
+class. When the PANE-TYPE can't be resolved NIL is returned or error
+is signaled depending on the argument ERRORP."
+  ;; Default method tries to resolve the abstract pane type
+  ;; PANE-TYPE as specified by a convention mentioned in the
+  ;; spec. Function is a little complicated because we preserve old
+  ;; semantics adding rules to the class name resolution. Resolution
+  ;; works as follows:
+  ;;
+  ;; 1. Abstract mapping always takes a priority. When it exists we
+  ;;    don't look further.
+  ;; 2. When the symbol is in clim/climi/keyword package:
+  ;;    - look for a class `climi::{SYMBOL-NAME}-pane'
+  ;;    - look for a class `climi::{SYMBOL-NAME}'
+  ;; 3. Otherwise find a class named by the symbol.
+  (flet ((try-mapped (symbol)
+           (when-let ((mapped (get symbol 'concrete-pane-class-name)))
+             (return-from find-concrete-pane-class
+               (find-class mapped errorp)))))
+    (try-mapped pane-type)
+    (if (let ((symbol-package (symbol-package pane-type)))
+          (or (eql symbol-package (find-package '#:clim))
+              (eql symbol-package (find-package '#:climi))
+              (eql symbol-package (find-package '#:keyword))))
+        (let* ((symbol-name (symbol-name pane-type))
+               (clim-symbol (find-symbol symbol-name '#:climi)))
+          (try-mapped clim-symbol)
+          (let* ((proper-name   (concatenate 'string symbol-name (string '#:-pane)))
+                 (proper-symbol (find-symbol proper-name '#:climi)))
+            (try-mapped proper-symbol)
+            (or (and proper-symbol (find-class proper-symbol nil))
+                (and clim-symbol   (find-class clim-symbol   nil))
+                (when errorp
+                  (error "Concrete class for a pane ~s not found." pane-type)))))
+        (find-class pane-type errorp))))
+
+(defmethod make-pane-1 ((fm frame-manager) (frame application-frame) type &rest args)
+  (apply #'make-instance (find-concrete-pane-class fm type)
+	 :frame frame :manager fm :port (port frame)
+         args))
+
 (defun make-pane (type &rest args)
-  (when (eql (symbol-package type)
-             (symbol-package :foo))
-    (setf type (or (find-symbol (symbol-name type) (find-package :clim))
-                   type)))
   (apply #'make-pane-1 (or *pane-realizer*
 			   (frame-manager *application-frame*))
 	 *application-frame* type args))

--- a/package.lisp
+++ b/package.lisp
@@ -1990,7 +1990,7 @@
   (:nicknames :climb)
   (:use :clim :clim-extensions)
   (:export
-   ;; Originally in CLIM-INTERNALS
+   ;; CLIM-INTERNALS
    #:make-graft
    #:medium-draw-circle*
    #:mirror-transformation
@@ -2012,6 +2012,7 @@
    #:window-manager-focus-event
    #:with-port
    #:invoke-with-port
+   #:find-concrete-pane-class
    ;; Text-style
    #:text-style-character-width
    #:text-bounding-rectangle*


### PR DESCRIPTION
Supersedes #931 

Based on the second commit you may access the original type spec. If you want to see, what is a "generic" resolution you may use a function `find-concrete-pane-class pane-type &optional (errorp t)`.

Second commit is specially tailored for re-initialization in #929, however I'm not sure if re-initialization of instances would be the right thing to do -- i.e it is not guaranteed that `make-pane-1` method won't change in a meantime, or that it doesn't pick the concrete pane class based on some arbitrary criteria which are desired by person redefining the frame.

@scymtym is reinitialization (instead of regenerating them) of panes such a big gain?