### PR TITLE
[hack][suggestion] redefinition on update suggestion

### DIFF
--- a/Core/clim-core/redefinition.lisp
+++ b/Core/clim-core/redefinition.lisp
@@ -22,42 +22,13 @@
 ;;; This is used for notifying application frame classes after aspects
 ;;; such as the class itself, the `generate-panes' method or the
 ;;; command table have been redefined. The notification sequence
-;;; begins with a call to `note-frame-class-redefined' which either
-;;; directly calls `handle-frame-class-redefinition' or schedules the
-;;; call to be made when leaving a
-;;; `with-delayed-redefinition-notifications'.
+;;; begins with a call to `note-frame-class-redefined' which calls
+;;; `handle-frame-class-redefinition'.
 ;;;
 ;;; This protocol is probably most commonly initiated by re-evaluating
 ;;; the `define-application-frame' form that defined the frame class
-;;; in question, but any event that causes the `reinitialize-instance'
-;;; method of the class to execute also triggers it. In the context of
-;;; `define-application-frame',
-;;; `with-delayed-redefinition-notifications' delays the
-;;; `note-frame-class-redefinition' call until after all aspects
-;;; (`generate-panes' method, command table definition, etc) have been
-;;; executed.
-
-(defgeneric handle-frame-class-redefinition (class)
-  (:method ((class t))))
-
-(defvar *delayed-redefinition-notifications*)
-
-(defun invoke-with-delayed-redefinition-notifications (thunk)
-  (if (boundp '*delayed-redefinition-notifications*)
-      (funcall thunk)
-      (let ((*delayed-redefinition-notifications* '()))
-        (multiple-value-prog1
-            (funcall thunk)
-          (mapc #'handle-frame-class-redefinition
-                *delayed-redefinition-notifications*)))))
-
-(defmacro with-delayed-redefinition-notifications (() &body body)
-  `(invoke-with-delayed-redefinition-notifications (lambda () ,@body)))
-
-(defun note-frame-class-redefined (class)
-  (if (boundp '*delayed-redefinition-notifications*)
-      (pushnew class *delayed-redefinition-notifications* :test #'eq)
-      (handle-frame-class-redefinition class)))
+;;; in question, but `note-frame-class-redefined' may be called by a
+;;; programmer at any time.
 
 ;;; `frame-class-redefined-event'
 ;;;
@@ -98,80 +69,39 @@
                (setf (frame-current-layout client) new-layout)
             (layout-frame client width height))))))
 
-;;; `redefinition-updates-instances-class'
-;;;
-;;; A metaclass for `application-frame' subclasses that update their
-;;; instances when redefined.
-;;;
-;;; Such a subclasses tracks created instances via a list of weak
-;;; pointers stored in the class. When the class is redefined, a
-;;; `frame-class-redefined-event' is dispatched to each frame in that
-;;; list (unless it has become garbage in the meantime).
+(defun note-frame-class-redefined (class)
+  (handle-frame-class-redefinition class))
 
-(defclass redefinition-updates-instances-class (standard-class)
-  ((%instances :accessor instances
-               :initform '())))
-
-(defmethod c2mop:validate-superclass
-    ((class      redefinition-updates-instances-class)
-     (superclass standard-class))
-  t)
-
-(defmethod shared-initialize :before
-    ((instance   redefinition-updates-instances-class)
-     (slot-names t)
-     &key (direct-superclasses nil direct-superclasses-supplied-p))
-  (when direct-superclasses-supplied-p
-    (unless (some (alexandria:rcurry #'subtypep 'application-frame)
-                  direct-superclasses)
-      (error "~@<Instances of ~S must be subclasses of ~S.~@:>"
-             'redefinition-updates-instances-class 'application-frame))))
-
-(defmethod reinitialize-instance :after
-    ((instance redefinition-updates-instances-class) &key)
-  ;; Trigger redefinition notification protocol which will directly or
-  ;; call `handle-frame-class-redefinition' or schedule it for later.
-  (note-frame-class-redefined instance))
-
-(defmethod make-instance :around ((class redefinition-updates-instances-class)
-                                  &key)
-  ;; Store a weak pointer to the created instance for updating it when
-  ;; CLASS is redefines.
-  (let ((instance (call-next-method)))
-    (push (tg:make-weak-pointer instance) (instances class))
-    instance))
-
-(defmethod handle-frame-class-redefinition
-    ((class redefinition-updates-instances-class))
-  (let ((remaining         '())
-        (new-layouts       nil)
-        (new-command-table nil))
-    (labels ((initarg-value (name)
-               (alexandria:when-let* ((initargs (c2mop:class-default-initargs class))
-                                      (initarg  (find name initargs :key #'first)))
-                 (funcall (third initarg))))
-             (new-layouts ()
-               (or new-layouts
-                   (setf new-layouts (initarg-value :layouts))))
-             (new-command-table ()
-               (or new-command-table
-                   (setf new-command-table (initarg-value :command-table))))
-             (update (instance)
-               (with-simple-restart (continue "~@<Skip updating frame ~A~@:>"
-                                              instance)
-                 (event-queue-append
-                  (frame-event-queue instance)
-                  (make-instance 'frame-class-redefined-event
-                                 :sheet             instance
-                                 :new-layouts       (new-layouts)
-                                 :new-command-table (new-command-table)))))
-             (maybe-update (weak-instance)
-               ;; Update instances that haven't become garbage and
-               ;; haven't been CHANGE-CLASSed. Implicitly drop other
-               ;; instances.
+(defun handle-frame-class-redefinition
+    (class &aux (class-name (class-name class)))
+  (if-let ((instances (member-if #'tg:weak-pointer-value
+                                 (get class-name 'instances))))
+    (let ((remaining         '())
+          (new-layouts       nil)
+          (new-command-table nil))
+      (when-let ((initargs (c2mop:class-default-initargs class)))
+        (flet ((initarg-value (name)
+                 ;; Third element of the canonicalized default initarg is a
+                 ;; thunk which when called evaluates a default value form
+                 ;; in its proper lexical context and returns the result.
+                 (when-let ((initarg (find name initargs :key #'first)))
+                   (funcall (third initarg)))))
+          (setf new-layouts       (initarg-value :layouts)
+                new-command-table (initarg-value :command-table))))
+      (loop for weak-instance in instances
+            do
+               ;; Update instances that haven't become garbage.
                (when-let ((live-instance (tg:weak-pointer-value weak-instance)))
                  (when (typep live-instance class)
                    (push weak-instance remaining)
-                   (update live-instance)))))
-      (mapc #'maybe-update (instances class)))
-    (setf (instances class) remaining)))
+                   (with-simple-restart
+                       (continue "~@<Skip updating frame ~A~@:>" live-instance)
+                     (event-queue-append
+                      (frame-event-queue live-instance)
+                      (make-instance 'frame-class-redefined-event
+                                     :sheet             live-instance
+                                     :new-layouts       new-layouts
+                                     :new-command-table new-command-table)))))
+            finally
+               (setf (get class-name 'instances) remaining)))
+    (setf (get class-name 'instances) nil)))


### PR DESCRIPTION
Some notes from looking into `wip-redefinition-update` :

* Can't redefine the application frame if `update-instances-on-redefinition` option has changed

```
Cannot CHANGE-CLASS objects into CLASS metaobjects.
   [Condition of type SB-PCL::METAOBJECT-INITIALIZATION-VIOLATION]
See also:
  The Art of the Metaobject Protocol, CLASS [:initialization]
```

* `with-delayed-redefinition-notifications` macro is unnecessary

Protocol has not enough justification. It is used in a single place
where a function call at the end of define-application-frame would
suffice:

```
  ,@(when update-instances-on-redefinition 
      `(;(handle-frame-class-redefinition (find-class ',name))
        (note-frame-class-redefinition (find-class ',name))))
```


Another reason why `with-drn` is not very useful outside of
define-application-frame is that redefining the application frame
superclass (i.e a mixin) does not trigger update in the subclass
instances. I don't see any compelling scenario where this is useful.


* `reinitialize-instance :after` method is unnecessary

Given we put note-frame-class-redefinition at the end of
define-application-frame we do not need delayed
reinitialize-instance. Since the mechanism is named
on-redefinition then I wouldn't expect reinitialization to trigger
the update (that would conflate two different mechanisms).
