### PR TITLE
Cleanup split gadgets

### DIFF
--- a/Core/clim-basic/protocol-classes.lisp
+++ b/Core/clim-basic/protocol-classes.lisp
@@ -237,31 +237,7 @@
 ;;; 30.3 Basic Gadget Classes
 ;;; XXX Slots definitions should be banished.
 (define-protocol-class gadget (pane)
-  ((id                :initarg :id
-                      :initform (gensym "GADGET")
-                      :accessor gadget-id)
-   (client            :initarg :client
-                      :initform *application-frame*
-                      :accessor gadget-client)
-   (armed-callback    :initarg :armed-callback
-                      :initform nil
-                      :reader gadget-armed-callback)
-   (disarmed-callback :initarg :disarmed-callback
-                      :initform nil
-                      :reader gadget-disarmed-callback)
-   ;; [Arthur] I'm not so sure about the value for :initform.
-   ;; Maybe T is better? Or maybe we should call
-   ;; ACTIVATE-GADGET after creating a gadget?
-   ;;
-   ;; I think, T is correct here --GB
-
-   (active-p            :initform t :initarg :active
-                        :reader gadget-active-p)
-   ;;
-   ;; I am not so lucky with the armed slot in GADGET --GB
-   (armed               :initform nil)
-
-   ))
+  ())
 
 
 ;;;; Part VIII: Appendices

--- a/Core/clim-core/clim-core.asd
+++ b/Core/clim-core/clim-core.asd
@@ -1,5 +1,7 @@
-(defsystem #:clim-core
-  :depends-on (#:clim-basic #+sbcl (:require #:sb-introspect))
+(in-package #:asdf-user)
+
+(defsystem "clim-core"
+  :depends-on ("clim-basic" #+sbcl (:require "sb-introspect"))
   :components
   ((:file "defresource")
    (:file "presentations")
@@ -13,8 +15,14 @@
    (:file "dialog-views" :depends-on ("presentations" "incremental-redisplay"
                                       "bordered-output" "presentation-defs" "gadgets" "dialog"))
    (:file "presentation-defs" :depends-on ("input-editing" "presentations"))
-   (:file "gadgets" :depends-on ("commands" "input-editing"
-                                 "frames" "incremental-redisplay" "panes"))
+   (:module "gadgets"
+    :depends-on ("commands" "input-editing" "frames" "incremental-redisplay" "panes")
+    :serial t
+    :components ((:file "base")
+                 (:file "abstract")
+                 (:file "mixins")
+                 (:file "drawing-utilities")
+                 (:file "concrete")))
    (:file "describe" :depends-on ("presentations" "presentation-translators" "presentation-defs" "table-formatting"))
    (:file "commands" :depends-on ("input-editing" "presentations"
                                   "presentation-defs"))

--- a/Core/clim-core/gadgets.lisp
+++ b/Core/clim-core/gadgets.lisp
@@ -198,8 +198,22 @@
                         ;; immediate-repainting-mixin
                         basic-pane
                         gadget)
-  ()
-  (:default-initargs :text-style (make-text-style :sans-serif nil nil)))
+  ((id                :initarg :id                :accessor gadget-id)
+   (client            :initarg :client            :accessor gadget-client)
+   (armed-callback    :initarg :armed-callback    :reader gadget-armed-callback)
+   (disarmed-callback :initarg :disarmed-callback :reader gadget-disarmed-callback)
+   ;; I'm not so sure about the value for :initform. Maybe T is
+   ;; better? Or maybe we should call ACTIVATE-GADGET after creating a
+   ;; gadget? -- AL
+   ;;
+   ;; I think, T is correct here --GB
+   (active-p          :initform t                 :reader gadget-active-p)
+   (armed             :initform nil               :reader gadget-armed-p))
+  (:default-initargs :text-style (make-text-style :sans-serif nil nil)
+                     :id (gensym "GADGET")
+                     :client *application-frame*
+                     :armed-callback nil
+                     :disarmed-callback nil))
 
 (defgeneric armed-callback (gadget client gadget-id)
   (:argument-precedence-order client gadget-id gadget))

--- a/Core/clim-core/gadgets/abstract.lisp
+++ b/Core/clim-core/gadgets/abstract.lisp
@@ -1,0 +1,336 @@
+(in-package #:climi)
+
+;;;; -------------------------------------------------------------------------
+;;;;
+;;;;  30.4 Abstract Gadget Classes
+;;;;
+
+;;; 30.4.1 The abstract push-button Gadget
+
+(defclass push-button (labelled-gadget-mixin action-gadget)
+  ())
+
+;;; 30.4.2 The abstract toggle-button Gadget
+
+(defclass toggle-button (labelled-gadget-mixin value-gadget)
+  ()
+  (:documentation "The value is either t either nil"))
+
+;;; 30.4.3 The abstract menu-button Gadget
+
+(defclass menu-button (labelled-gadget-mixin value-gadget)
+  ()
+  (:documentation "The value is a button"))
+
+;;; 30.4.4 The abstract scroll-bar Gadget
+
+(defgeneric drag-callback (pane client gadget-id value)
+  (:argument-precedence-order client gadget-id value pane))
+
+(defgeneric scroll-to-top-callback (scroll-bar client gadget-id)
+  (:argument-precedence-order client gadget-id scroll-bar))
+
+(defgeneric scroll-to-bottom-callback (scroll-bar client gadget-id)
+  (:argument-precedence-order client gadget-id scroll-bar))
+
+(defgeneric scroll-up-line-callback (scroll-bar client gadget-id)
+  (:argument-precedence-order client gadget-id scroll-bar))
+
+(defgeneric scroll-up-page-callback (scroll-bar client gadget-id)
+  (:argument-precedence-order client gadget-id scroll-bar))
+
+(defgeneric scroll-down-line-callback (scroll-bar client gadget-id)
+  (:argument-precedence-order client gadget-id scroll-bar))
+
+(defgeneric scroll-down-page-callback (scroll-bar client gadget-id)
+  (:argument-precedence-order client gadget-id scroll-bar))
+
+(defclass scroll-bar (value-gadget oriented-gadget-mixin range-gadget-mixin)
+  ((drag-callback :initarg :drag-callback
+                  :initform nil
+                  :reader scroll-bar-drag-callback)
+   (scroll-to-bottom-callback :initarg :scroll-to-bottom-callback
+                              :initform nil
+                              :reader scroll-bar-scroll-to-bottom-callback)
+   (scroll-to-top-callback :initarg :scroll-to-top-callback
+                           :initform nil
+                           :reader scroll-bar-scroll-to-top-callback)
+   (scroll-down-line-callback :initarg :scroll-down-line-callback
+                              :initform nil
+                              :reader scroll-bar-scroll-down-line-callback)
+   (scroll-up-line-callback :initarg :scroll-up-line-callback
+                            :initform nil
+                            :reader scroll-bar-scroll-up-line-callback)
+   (scroll-down-page-callback :initarg :scroll-down-page-callback
+                              :initform nil
+                              :reader scroll-bar-scroll-down-page-callback)
+   (scroll-up-page-callback :initarg :scroll-up-page-callback
+                            :initform nil
+                            :reader scroll-bar-scroll-up-page-callback)
+   (thumb-size :initarg :thumb-size :initform 1/4
+               :accessor scroll-bar-thumb-size
+               :documentation "The size of the scroll bar thumb (slug) in the
+  units of the gadget value. When the scroll bar is drawn the empty region of
+  the scroll bar and the thumb are drawn in proportion  to the values of the
+  gadget range and thumb size."))
+  (:default-initargs :value 0
+                     :min-value 0
+                     :max-value 1
+                     :orientation :vertical))
+
+(defmethod drag-callback ((pane scroll-bar) client gadget-id value)
+  (declare (ignore client gadget-id))
+  (invoke-callback pane (scroll-bar-drag-callback pane) value))
+
+(defmethod scroll-to-top-callback ((pane scroll-bar) client gadget-id)
+  (declare (ignore client gadget-id))
+  (invoke-callback pane (scroll-bar-scroll-to-top-callback pane)))
+
+(defmethod scroll-to-bottom-callback ((pane scroll-bar) client gadget-id)
+  (declare (ignore client gadget-id))
+  (invoke-callback pane (scroll-bar-scroll-to-bottom-callback pane)))
+
+(defmethod scroll-up-line-callback ((pane scroll-bar) client gadget-id)
+  (declare (ignore client gadget-id))
+  (invoke-callback pane (scroll-bar-scroll-up-line-callback pane)))
+
+(defmethod scroll-up-page-callback ((pane scroll-bar) client gadget-id)
+  (declare (ignore client gadget-id))
+  (invoke-callback pane (scroll-bar-scroll-up-page-callback pane)))
+
+(defmethod scroll-down-line-callback ((pane scroll-bar) client gadget-id)
+  (declare (ignore client gadget-id))
+  (invoke-callback pane (scroll-bar-scroll-down-line-callback pane)))
+
+(defmethod scroll-down-page-callback ((pane scroll-bar) client gadget-id)
+  (declare (ignore client gadget-id))
+  (invoke-callback pane (scroll-bar-scroll-down-page-callback pane)))
+
+;;; 30.4.5 The abstract slider Gadget
+
+(defclass slider (labelled-gadget-mixin
+                  value-gadget
+                  oriented-gadget-mixin
+                  range-gadget-mixin)
+  ((drag-callback  :initform nil
+                   :initarg :drag-callback
+                   :reader slider-drag-callback)
+   (show-value-p   :type boolean
+                   :initform nil
+                   :initarg :show-value-p
+                   :accessor gadget-show-value-p)
+   (decimal-places :initform 0
+                   :initarg :decimal-places
+                   :reader slider-decimal-places)
+   (number-of-quanta :initform nil
+                     :initarg :number-of-quanta
+                     :reader slider-number-of-quanta))
+  (:documentation "The value is a real number, and default value for orientation is :vertical,
+and must never be nil.")
+  (:default-initargs :orientation :vertical))
+
+(defmethod drag-callback ((pane slider) client gadget-id value)
+  (declare (ignore client gadget-id))
+  (when (slider-drag-callback pane)
+    (funcall (slider-drag-callback pane) pane value)))
+
+;;; 30.4.6 The abstract radio-box and check-box Gadgets
+
+;; The only real difference between a RADIO-BOX and a CHECK-BOX is the
+;; number of allowed selections.
+
+(defclass radio-box (value-gadget oriented-gadget-mixin)
+  ()
+  (:documentation "The value is a button")
+  (:default-initargs
+   :value nil))
+
+;; RADIO-BOX-CURRENT-SELECTION is just a synonym for GADGET-VALUE:
+
+(defgeneric radio-box-current-selection (radio-box))
+
+(defmethod radio-box-current-selection ((radio-box radio-box))
+  (gadget-value radio-box))
+
+(defgeneric (setf radio-box-current-selection) (new-value radio-box))
+
+(defmethod (setf radio-box-current-selection) (new-value (radio-box radio-box))
+  (setf (gadget-value radio-box) new-value))
+
+(defgeneric radio-box-selections (radio-box))
+
+(defmethod radio-box-selections ((pane radio-box))
+  (loop for child in (sheet-children pane)
+        when (typep child 'toggle-button)
+          collect child))
+
+(defmethod value-changed-callback :before (value-gadget (client radio-box) gadget-id value)
+  (declare (ignorable value-gadget gadget-id value))
+  ;; Note that we ignore 'value', this is because if value is non-NIL,
+  ;; then the toggle button was turned off, which would make no
+  ;; toggle-button turned on => constraint "always exactly one
+  ;; selected" missed. So simply turning this toggle button on again
+  ;; fixes it.
+  (unless (or (and (not value)
+                   (not (eq (gadget-value client) value-gadget)))
+              (and value
+                   (eq (gadget-value client) value-gadget)))
+    (setf (gadget-value client :invoke-callback t) value-gadget)))
+
+;;;; CHECK-BOX
+
+(defclass check-box (value-gadget oriented-gadget-mixin)
+  ()
+  (:documentation "The value is a list of buttons")
+  (:default-initargs
+   :value nil
+   :orientation :vertical))
+
+;; CHECK-BOX-CURRENT-SELECTION is just a synonym for GADGET-VALUE:
+
+(defgeneric check-box-current-selection (check-box))
+
+(defmethod check-box-current-selection ((check-box check-box))
+  (gadget-value check-box))
+
+(defgeneric (setf check-box-current-selection) (new-value check-box))
+
+(defmethod (setf check-box-current-selection) (new-value (check-box check-box))
+  (setf (gadget-value check-box) new-value))
+
+(defmethod check-box-selections ((pane check-box))
+  (loop for child in (sheet-children pane)
+        when (typep child 'toggle-button)
+          collect child))
+
+(defmethod value-changed-callback :before (value-gadget (client check-box) gadget-id value)
+  (declare (ignorable gadget-id))
+  (if value
+      (setf (gadget-value client :invoke-callback t)
+            (adjoin value-gadget (gadget-value client)))
+      (setf (gadget-value client :invoke-callback t)
+            (remove value-gadget (gadget-value client)))))
+
+(defmethod (setf gadget-value) :after (buttons (check-box check-box) &key invoke-callback)
+  ;; this is silly, but works ...
+  (dolist (c (sheet-children check-box))
+    (unless (eq (not (null (member c buttons)))
+                (not (null (gadget-value c))))
+      (setf (gadget-value c :invoke-callback invoke-callback) (member c buttons)) )))
+
+(defmacro with-radio-box ((&rest options
+                           &key (type :one-of) (orientation :vertical) &allow-other-keys)
+                          &body body)
+  (let ((contents (gensym "CONTENTS-"))
+        (selected-p (gensym "SELECTED-P-"))
+        (initial-selection (gensym "INITIAL-SELECTION-")))
+    `(let ((,contents nil)
+           (,selected-p nil)
+           (,initial-selection nil))
+       (declare (special ,selected-p))
+       (flet ((make-pane (type &rest options)
+                (cond ((eq type 'toggle-button)
+                       (let ((pane (apply #'make-pane type
+                                          :value ,selected-p
+                                          :indicator-type ',type
+                                          options)))
+                         (push pane ,contents)
+                         (when ,selected-p
+                           (push pane ,initial-selection))))
+                      (t
+                       (error "oops")))))
+         (macrolet ((radio-box-current-selection (subform)
+                      `(let ((,',selected-p t))
+                         (declare (special ,',selected-p))
+                         ,(cond ((stringp subform)
+                                 `(make-pane 'toggle-button :label ,subform))
+                                (t
+                                 subform)))))
+           ,@(mapcar (lambda (form)
+                       (cond ((stringp form)
+                              `(make-pane 'toggle-button :label ,form))
+                             (t
+                              form)))
+                     body)))
+       (make-pane ',(if (eq type :one-of)
+                        'radio-box
+                        'check-box)
+                  :orientation ',orientation
+                  :current-selection ,(if (eq type :one-of)
+                                          `(or (first ,initial-selection)
+                                               (first ,contents))
+                                          `,initial-selection)
+                  :choices (reverse ,contents)
+                  ,@options))))
+
+;;; 30.4.7 The abstract list-pane and option-pane Gadgets
+
+(defclass meta-list-pane ()
+  ((mode        :initarg :mode
+                :initform :exclusive
+                :reader list-pane-mode
+                :type (member :one-of :some-of :exclusive :nonexclusive))
+   (items       :initarg :items
+                :initform nil
+                :reader list-pane-items
+                :type sequence)
+   (name-key    :initarg :name-key
+                :initform #'princ-to-string
+                :reader list-pane-name-key
+                :documentation "A function to be applied to items to gain a printable representation")
+   (value-key   :initarg :value-key
+                :initform #'identity
+                :reader list-pane-value-key
+                :documentation "A function to be applied to items to gain its value
+                                for the purpose of GADGET-VALUE.")
+   (presentation-type-key :initarg :presentation-type-key
+                          :initform (constantly nil)
+                          :reader list-pane-presentation-type-key
+                          :documentation "A function to be applied to items to find the presentation types for their values, or NIL.")
+   (test        :initarg :test
+                :initform #'eql
+                :reader list-pane-test
+                :documentation "A function to compare two items for equality.")))
+
+(defclass list-pane (meta-list-pane value-gadget)
+  ((visible-items :initarg :visible-items ; Clim 2.2 compatibility
+                  :initform nil
+                  :documentation "Maximum number of visible items in list"))
+  (:documentation
+   "The instantiable class that implements an abstract list pane, that is, a gadget
+    whose semantics are similar to a radio box or check box, but whose visual
+    appearance is a list of buttons.")
+  (:default-initargs :value nil))
+
+(defclass option-pane (meta-list-pane value-gadget)
+  ()
+  (:documentation
+   "The instantiable class that implements an abstract option pane, that is, a
+    gadget whose semantics are identical to a list pane, but whose visual
+    appearance is a single push button which, when pressed, pops up a menu of
+    selections."))
+
+;;; 30.4.8 The abstract text-field Gadget
+
+(defclass text-field (value-gadget action-gadget)
+  ((editable-p :accessor editable-p :initarg editable-p :initform t))
+  (:documentation "The value is a string")
+  (:default-initargs :value ""))
+
+(defmethod initialize-instance :after ((gadget text-field) &rest rest)
+  (unless (getf rest :normal)
+    (setf (slot-value gadget 'current-color) +white+
+          (slot-value gadget 'normal) +white+)))
+
+;;; 30.4.9 The abstract text-editor Gadget
+
+(defclass text-editor (text-field)
+  ((ncolumns :reader text-editor-ncolumns
+             :initarg :ncolumns
+             :initform nil
+             :type (or null integer))
+   (nlines :reader text-editor-nlines
+           :initarg :nlines
+           :initform nil
+           :type (or null integer)))
+  (:documentation "The value is a string"))

--- a/Core/clim-core/gadgets/base.lisp
+++ b/Core/clim-core/gadgets/base.lisp
@@ -1,0 +1,401 @@
+;;; -*- Mode: Lisp; Package: CLIM-INTERNALS -*-
+
+;;;  (c) copyright 2000 by
+;;;      Arthur Lemmens (lemmens@simplex.nl),
+;;;      Iban Hatchondo (hatchond@emi.u-bordeaux.fr)
+;;;      and Julien Boninfante (boninfan@emi.u-bordeaux.fr)
+;;;  (c) copyright 2001 by
+;;;      Lionel Salabartan (salabart@emi.u-bordeaux.fr)
+;;;  (c) copyright 2001 by Michael McDonald (mikemac@mikemac.com)
+;;;  (c) copyright 2001 by Gilbert Baumann <unk6@rz.uni-karlsruhe.de>
+;;;  (c) copyright 2014 by Robert Strandh (robert.strandh@gmail.com)
+
+;;; This library is free software; you can redistribute it and/or
+;;; modify it under the terms of the GNU Library General Public
+;;; License as published by the Free Software Foundation; either
+;;; version 2 of the License, or (at your option) any later version.
+;;;
+;;; This library is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;;; Library General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU Library General Public
+;;; License along with this library; if not, write to the
+;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;;; Boston, MA  02111-1307  USA.
+
+(in-package :clim-internals)
+
+;;;; Notes
+
+;; The spec says ORIENTED-GADGET-MIXIN, we call it ORIENTED-GADGET and
+;; later define ORIENTED-GADGET-MIXIN with the remark "Try to be
+;; compatible with Lispworks' CLIM."
+;;
+;; This makes me suspect, that either "ORIENTED-GADGET-MIXIN" in the
+;; spec is a typo, or all other classes like e.g. ACTION-GADGET should
+;; really be named e.g. ACTION-GADGET-MIXIN. Also that would make more
+;; sense to me. --GB
+
+;; We have: LABELLED-GADGET, the spec has LABELLED-GADGET-MIXIN. Typo?
+;; Compatibility?
+
+;; Why is there GADGET-LABEL-TEXT-STYLE? The spec says, that just the
+;; pane's text-style should be borrowed.
+
+;; RANGE-GADGET / RANGE-GADGET-MIXIN: same thing as with
+;; ORIENTED-GADGET-MIXIN.
+
+;; Why is there no (SETF GADGET-RANGE*) in the spec? Omission?
+
+;; I would like to make COMPOSE-LABEL-SPACE and DRAW-LABEL* into some
+;; sort of label protocol, so that application programmers can
+;; programm their own sort of labels alleviateing the need for
+;; something like a drawn button gadget.
+;;
+;; Q: Can we make it so that a mixin class can override another mixin
+;;    class?
+;;
+;;    All the programmer should need to do is e.g.
+;;
+;;    (defclass pattern-label-mixin ()
+;;      (pattern :initarg :pattern))
+;;
+;;    (defmethod compose-label-space ((me pattern-label-mixin))
+;;      (with-slots (pattern) me
+;;        (make-space-requirement :width (pattern-width pattern)
+;;                                :height (pattern-height pattern))))
+;;
+;;    (defmethod draw-label ((me pattern-label-mixin) x1 y1 x2 y2)
+;;      (with-slots (pattern) me
+;;        (draw-design me (transform-region (make-translation-transformation x1 y1)
+;;                                          pattern))))
+;;
+;;    (defclass patterned-button (pattern-label-mixin push-button-pane)
+;;      ())
+;;
+;; But then this probably is backwards. Specifing that :LABEL can be
+;; another pane probably is much easier and would still allow for the
+;; backend to choose the concrete widget class for us.
+;;
+;; --GB
+
+;; - Should RADIO-BOX-PANE and CHECK-BOX-PANE use rack or box layout?
+
+;; - :CHOICES initarg to RADIO-BOX and CHECK-BOX is from Franz' user
+;;   guide.
+
+;;;; TODO
+
+;; - the scroll-bar needs more work:
+;;    . dragging should not change the value, the value should only
+;;      be changed after releasing the mouse.
+;;    . it should arm/disarm
+;;    . it should be deactivatable
+
+;; - the slider needs a total overhaul
+
+;; - TEXT-FILED, TEXT-AREA dito
+
+;; - GADGET-COLOR-MIXIN is currently kind of dangling, we should reuse
+;;   it for effective-gadget-foreground et al.
+
+;; - The color of a 3Dish border should be derived from a gadget's
+;;   background.
+
+;; - Somehow engrafting the push button's medium does not work. The
+;;   text-style initarg does not make it to the sheets medium.
+
+;; - make NIL a valid label, and take it into account when applying
+;;   spacing.
+
+;;;; --------------------------------------------------------------------------
+;;;;
+;;;;  30.3 Basic Gadget Classes
+;;;;
+
+;;; XXX I'm not sure that *application-frame* should be rebound like this. What
+;;; about gadgets in accepting-values windows? An accepting-values window
+;;; shouldn't be bound to *application-frame*. -- moore
+(defun invoke-callback (pane callback &rest more-arguments)
+  (when callback
+    (let ((*application-frame* (pane-frame pane)))
+      (apply callback pane more-arguments))))
+
+;;
+;; gadget subclasses
+;;
+
+;;
+;; gadget's colors
+;;
+
+(defclass gadget-color-mixin ()
+  ((normal :type color
+           :initform +gray80+
+           :initarg :normal
+           :accessor gadget-normal-color)
+   (highlighted :type color
+                :initform +gray85+
+                :initarg :highlighted
+                :accessor gadget-highlighted-color)
+   (pushed-and-highlighted :type color
+                           :initform +gray75+
+                           :initarg :pushed-and-highlighted
+                           :accessor gadget-pushed-and-highlighted-color)
+   (current-color :type color
+                  :accessor gadget-current-color))
+  (:documentation "This class define the gadgets colors."))
+
+(defmethod initialize-instance :after ((gadget gadget-color-mixin) &rest args)
+  (declare (ignore args))
+  (setf (slot-value gadget 'current-color) (gadget-normal-color gadget)))
+
+(defmethod (setf gadget-current-color) :after (color (gadget gadget-color-mixin))
+  (declare (ignore color))
+  (dispatch-repaint gadget (sheet-region gadget)))
+
+#|
+;; Labelled-gadget
+
+(defgeneric draw-label (gadget label x y))
+
+(defmethod compose-space ((pane labelled-gadget) &key width height)
+  (declare (ignore width height))
+  (compose-space-aux pane (gadget-label pane)))
+
+(defmethod compose-space-aux ((pane labelled-gadget) (label string))
+  (with-sheet-medium (medium pane)
+    (let ((as (text-style-ascent (gadget-label-text-style pane) pane))
+          (ds (text-style-descent (gadget-label-text-style pane) pane)))
+      (multiple-value-bind (width height)
+          (text-size medium (gadget-label pane)
+                     :text-style (gadget-label-text-style pane))
+        (setf height (+ as ds))
+        ;; FIXME remove explicit values
+        ;; instead use spacer pane in derived classes
+        (let ((tw (* 1.3 width))
+              (th (* 2.5 height)))
+          (setf th (+ 6 height))
+          (make-space-requirement :width tw :height th
+                                  :max-width 400 :max-height 400
+                                  :min-width tw :min-height th))))))
+
+(defmethod draw-label ((pane labelled-gadget) (label string) x y)
+  (draw-text* pane label
+              x y
+              :align-x (gadget-label-align-x pane)
+              :align-y (gadget-label-align-y pane)
+              :text-style (gadget-label-text-style pane)))
+|#
+
+(defclass basic-gadget (;; sheet-leaf-mixin ; <- this cannot go here...
+                        gadget-color-mixin
+                        ;; These are inherited from pane, via
+                        ;; clim-sheet-input-mixin and clim-repainting-mixin
+                        ;; immediate-sheet-input-mixin
+                        ;; immediate-repainting-mixin
+                        basic-pane
+                        gadget)
+  ((id                :initarg :id                :accessor gadget-id)
+   (client            :initarg :client            :accessor gadget-client)
+   (armed-callback    :initarg :armed-callback    :reader gadget-armed-callback)
+   (disarmed-callback :initarg :disarmed-callback :reader gadget-disarmed-callback)
+   ;; I'm not so sure about the value for :initform. Maybe T is
+   ;; better? Or maybe we should call ACTIVATE-GADGET after creating a
+   ;; gadget? -- AL
+   ;;
+   ;; I think, T is correct here --GB
+   (active-p          :initform t                 :reader gadget-active-p)
+   (armed             :initform nil               :reader gadget-armed-p))
+  (:default-initargs :text-style (make-text-style :sans-serif nil nil)
+                     :id (gensym "GADGET")
+                     :client *application-frame*
+                     :armed-callback nil
+                     :disarmed-callback nil))
+
+;; "The default methods (on basic-gadget) call the function stored in
+;; gadget-armed-callback or gadget-disarmed-callback with one
+;; argument, the gadget."
+
+(defgeneric armed-callback (gadget client gadget-id)
+  (:argument-precedence-order client gadget-id gadget)
+  (:method ((gadget basic-gadget) client gadget-id)
+    (declare (ignore client gadget-id))
+    (invoke-callback gadget (gadget-armed-callback gadget))))
+
+(defgeneric disarmed-callback (gadget client gadget-id)
+  (:argument-precedence-order client gadget-id gadget)
+  (:method  ((gadget basic-gadget) client gadget-id)
+    (declare (ignore client gadget-id))
+    (invoke-callback gadget (gadget-disarmed-callback gadget))))
+
+;;
+;; arming and disarming gadgets
+;;
+
+;; Redrawing is supposed to be handled on an :AFTER method on arm- and
+;; disarm-callback.
+
+(defgeneric arm-gadget (gadget &optional value)
+  (:method ((gadget basic-gadget) &optional (value t))
+    (with-slots (armed) gadget
+      (unless (eql armed value)
+        (setf armed value)
+        (if value
+            (armed-callback gadget (gadget-client gadget) (gadget-id gadget))
+            (disarmed-callback gadget (gadget-client gadget) (gadget-id gadget)))))))
+
+(defgeneric disarm-gadget (gadget)
+  (:method ((gadget basic-gadget))
+    (arm-gadget gadget nil)))
+
+;;;
+;;; Activation
+;;;
+
+(defgeneric activate-gadget (gadget)
+  (:method ((gadget basic-gadget))
+    (with-slots (active-p) gadget
+      (unless active-p
+        (setf active-p t)
+        (note-gadget-activated (gadget-client gadget) gadget)))))
+
+(defgeneric deactivate-gadget (gadget)
+  (:method ((gadget basic-gadget))
+    (with-slots (active-p) gadget
+      (when active-p
+        (setf active-p nil)
+        (note-gadget-deactivated (gadget-client gadget) gadget)))))
+
+(defgeneric note-gadget-activated (client gadget)
+  ;; Default: do nothing
+  (:method (client gadget)
+    (declare (ignore client gadget))))
+
+(defgeneric note-gadget-deactivated (client gadget)
+  ;; Default: do nothing
+  (:method (client gadget)
+    (declare (ignore client gadget))))
+
+
+;;;
+;;; Value-gadget
+;;;
+
+(defclass value-gadget (basic-gadget)
+  ((value :initarg :value
+          :reader gadget-value)
+   (value-changed-callback :initarg :value-changed-callback
+                           :reader gadget-value-changed-callback))
+  (:default-initargs :value nil
+                     :value-changed-callback nil))
+
+(defmethod (setf gadget-value) (value (gadget value-gadget) &key invoke-callback)
+  (declare (ignore invoke-callback))
+  (setf (slot-value gadget 'value) value))
+
+;;; Try to call the callback after all other (setf gadget-value) methods have
+;;; been called. The gadget methods, which may update graphical appearance,
+;;; will be run even if the callback does a non-local exit (like throwing a
+;;; presentation).
+
+(defmethod (setf gadget-value) :around (value (gadget value-gadget)
+                                        &key invoke-callback)
+  (multiple-value-prog1
+      (call-next-method)
+    (when invoke-callback
+      (value-changed-callback gadget
+                              (gadget-client gadget)
+                              (gadget-id gadget)
+                              value))))
+
+(defgeneric value-changed-callback (gadget client gadget-id value)
+  (:argument-precedence-order client gadget-id value gadget)
+  (:method  ((gadget value-gadget) client gadget-id value)
+    (declare (ignore client gadget-id))
+    (invoke-callback gadget (gadget-value-changed-callback gadget) value)))
+
+;;;
+;;; Action-gadget
+;;;
+
+(defclass action-gadget (basic-gadget)
+  ((activate-callback :initarg :activate-callback
+                      :reader gadget-activate-callback))
+  (:default-initargs :activate-callback nil))
+
+(defgeneric activate-callback (action-gadget client gadget-id)
+  (:argument-precedence-order client gadget-id action-gadget)
+  (:method  ((gadget action-gadget) client gadget-id)
+    (declare (ignore client gadget-id))
+    (invoke-callback gadget (gadget-activate-callback gadget))))
+
+;;;
+;;; Oriented-gadget
+;;;
+
+(defclass oriented-gadget ()
+  ((orientation :type    (member :vertical :horizontal)
+                :initarg :orientation
+                :reader  gadget-orientation))
+  (:default-initargs :orientation :horizontal))
+
+(defclass oriented-gadget-mixin (oriented-gadget)
+  ;; Try to be compatible with Lispworks' CLIM.
+  ())
+
+;;;;
+;;;; Labelled-gadget
+;;;;
+
+(defclass labelled-gadget ()
+  ((label       :initarg :label
+                :initform ""
+                :accessor gadget-label)
+   ;; These slots are defined in BASIC-PANE (which is a superclass of
+   ;; basic-gadget). Should we provide different names? Check the
+   ;; meaning etc etc.
+   #+nil
+   (align-x     :initarg :align-x
+                :accessor gadget-label-align-x)
+   #+nil
+   (align-y     :initarg :align-y
+                :accessor gadget-label-align-y)
+   #+nil
+   (text-style  :initform *default-text-style*
+                :initarg :text-style
+                :accessor gadget-text-style)))
+
+(defclass labelled-gadget-mixin (labelled-gadget)
+  ;; Try to be compatible with Lispworks' CLIM.
+  ())
+
+;;;;
+;;;; Range-gadget
+;;;;
+
+(defclass range-gadget ()
+  ((min-value :initarg :min-value :accessor gadget-min-value)
+   (max-value :initarg :max-value :accessor gadget-max-value))
+  (:default-initargs :min-value 0
+                     :max-value 1))
+
+(defclass range-gadget-mixin (range-gadget)
+  ;; Try to be compatible with Lispworks' CLIM.
+  ())
+
+(defgeneric gadget-range (range-gadget)
+  (:documentation
+   "Returns the difference of the maximum and minimum value of RANGE-GADGET.")
+  (:method ((gadget range-gadget))
+    (- (gadget-max-value gadget)
+       (gadget-min-value gadget))))
+
+(defgeneric gadget-range* (range-gadget)
+  (:documentation
+   "Returns the minimum and maximum value of RANGE-GADGET as two values.")
+  (:method ((gadget range-gadget))
+    (values (gadget-min-value gadget)
+            (gadget-max-value gadget))))

--- a/Core/clim-core/gadgets/concrete.lisp
+++ b/Core/clim-core/gadgets/concrete.lisp
@@ -1,1142 +1,8 @@
-;;; -*- Mode: Lisp; Package: CLIM-INTERNALS -*-
+(in-package #:climi)
 
-;;;  (c) copyright 2000 by
-;;;      Arthur Lemmens (lemmens@simplex.nl),
-;;;      Iban Hatchondo (hatchond@emi.u-bordeaux.fr)
-;;;      and Julien Boninfante (boninfan@emi.u-bordeaux.fr)
-;;;  (c) copyright 2001 by
-;;;      Lionel Salabartan (salabart@emi.u-bordeaux.fr)
-;;;  (c) copyright 2001 by Michael McDonald (mikemac@mikemac.com)
-;;;  (c) copyright 2001 by Gilbert Baumann <unk6@rz.uni-karlsruhe.de>
-;;;  (c) copyright 2014 by Robert Strandh (robert.strandh@gmail.com)
-
-;;; This library is free software; you can redistribute it and/or
-;;; modify it under the terms of the GNU Library General Public
-;;; License as published by the Free Software Foundation; either
-;;; version 2 of the License, or (at your option) any later version.
-;;;
-;;; This library is distributed in the hope that it will be useful,
-;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;;; Library General Public License for more details.
-;;;
-;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;;; Boston, MA  02111-1307  USA.
-
-(in-package :clim-internals)
-
-;;;; Notes
-
-;; The spec says ORIENTED-GADGET-MIXIN, we call it ORIENTED-GADGET and
-;; later define ORIENTED-GADGET-MIXIN with the remark "Try to be
-;; compatible with Lispworks' CLIM."
-;;
-;; This makes me suspect, that either "ORIENTED-GADGET-MIXIN" in the
-;; spec is a typo, or all other classes like e.g. ACTION-GADGET should
-;; really be named e.g. ACTION-GADGET-MIXIN. Also that would make more
-;; sense to me. --GB
-
-;; We have: LABELLED-GADGET, the spec has LABELLED-GADGET-MIXIN. Typo?
-;; Compatibility?
-
-;; Why is there GADGET-LABEL-TEXT-STYLE? The spec says, that just the
-;; pane's text-style should be borrowed.
-
-;; RANGE-GADGET / RANGE-GADGET-MIXIN: same thing as with
-;; ORIENTED-GADGET-MIXIN.
-
-;; Why is there no (SETF GADGET-RANGE*) in the spec? Omission?
-
-;; I would like to make COMPOSE-LABEL-SPACE and DRAW-LABEL* into some
-;; sort of label protocol, so that application programmers can
-;; programm their own sort of labels alleviateing the need for
-;; something like a drawn button gadget.
-;;
-;; Q: Can we make it so that a mixin class can override another mixin
-;;    class?
-;;
-;;    All the programmer should need to do is e.g.
-;;
-;;    (defclass pattern-label-mixin ()
-;;      (pattern :initarg :pattern))
-;;
-;;    (defmethod compose-label-space ((me pattern-label-mixin))
-;;      (with-slots (pattern) me
-;;        (make-space-requirement :width (pattern-width pattern)
-;;                                :height (pattern-height pattern))))
-;;
-;;    (defmethod draw-label ((me pattern-label-mixin) x1 y1 x2 y2)
-;;      (with-slots (pattern) me
-;;        (draw-design me (transform-region (make-translation-transformation x1 y1)
-;;                                          pattern))))
-;;
-;;    (defclass patterned-button (pattern-label-mixin push-button-pane)
-;;      ())
-;;
-;; But then this probably is backwards. Specifing that :LABEL can be
-;; another pane probably is much easier and would still allow for the
-;; backend to choose the concrete widget class for us.
-;;
-;; --GB
-
-;; - Should RADIO-BOX-PANE and CHECK-BOX-PANE use rack or box layout?
-
-;; - :CHOICES initarg to RADIO-BOX and CHECK-BOX is from Franz' user
-;;   guide.
-
-;;;; TODO
-
-;; - the scroll-bar needs more work:
-;;    . dragging should not change the value, the value should only
-;;      be changed after releasing the mouse.
-;;    . it should arm/disarm
-;;    . it should be deactivatable
-
-;; - the slider needs a total overhaul
-
-;; - TEXT-FILED, TEXT-AREA dito
-
-;; - GADGET-COLOR-MIXIN is currently kind of dangling, we should reuse
-;;   it for effective-gadget-foreground et al.
-
-;; - The color of a 3Dish border should be derived from a gadget's
-;;   background.
-
-;; - Somehow engrafting the push button's medium does not work. The
-;;   text-style initarg does not make it to the sheets medium.
-
-;; - make NIL a valid label, and take it into account when applying
-;;   spacing.
-
-;;;; --------------------------------------------------------------------------
-;;;;
-;;;;  30.3 Basic Gadget Classes
-;;;;
-
-;;; XXX I'm not sure that *application-frame* should be rebound like this. What
-;;; about gadgets in accepting-values windows? An accepting-values window
-;;; shouldn't be bound to *application-frame*. -- moore
-(defun invoke-callback (pane callback &rest more-arguments)
-  (when callback
-    (let ((*application-frame* (pane-frame pane)))
-      (apply callback pane more-arguments))))
-
-;;
-;; gadget subclasses
-;;
-
-;;
-;; gadget's colors
-;;
-
-(defclass gadget-color-mixin ()
-  ((normal :type color
-           :initform +gray80+
-           :initarg :normal
-           :accessor gadget-normal-color)
-   (highlighted :type color
-                :initform +gray85+
-                :initarg :highlighted
-                :accessor gadget-highlighted-color)
-   (pushed-and-highlighted :type color
-                           :initform +gray75+
-                           :initarg :pushed-and-highlighted
-                           :accessor gadget-pushed-and-highlighted-color)
-   (current-color :type color
-                  :accessor gadget-current-color))
-  (:documentation "This class define the gadgets colors."))
-
-(defmethod initialize-instance :after ((gadget gadget-color-mixin) &rest args)
-  (declare (ignore args))
-  (setf (slot-value gadget 'current-color) (gadget-normal-color gadget)))
-
-(defmethod (setf gadget-current-color) :after (color (gadget gadget-color-mixin))
-  (declare (ignore color))
-  (dispatch-repaint gadget (sheet-region gadget)))
-
-#||
-;; Labelled-gadget
-
-(defgeneric draw-label (gadget label x y))
-
-(defmethod compose-space ((pane labelled-gadget) &key width height)
-  (declare (ignore width height))
-  (compose-space-aux pane (gadget-label pane)))
-
-(defmethod compose-space-aux ((pane labelled-gadget) (label string))
-  (with-sheet-medium (medium pane)
-    (let ((as (text-style-ascent (gadget-label-text-style pane) pane))
-          (ds (text-style-descent (gadget-label-text-style pane) pane)))
-      (multiple-value-bind (width height)
-          (text-size medium (gadget-label pane)
-                     :text-style (gadget-label-text-style pane))
-        (setf height (+ as ds))
-        ;; FIXME remove explicit values
-        ;; instead use spacer pane in derived classes
-        (let ((tw (* 1.3 width))
-              (th (* 2.5 height)))
-          (setf th (+ 6 height))
-          (make-space-requirement :width tw :height th
-                                  :max-width 400 :max-height 400
-                                  :min-width tw :min-height th))))))
-
-(defmethod draw-label ((pane labelled-gadget) (label string) x y)
-  (draw-text* pane label
-              x y
-              :align-x (gadget-label-align-x pane)
-              :align-y (gadget-label-align-y pane)
-              :text-style (gadget-label-text-style pane)))
-||#
-
-(defclass basic-gadget (;; sheet-leaf-mixin ; <- this cannot go here...
-                        gadget-color-mixin
-                        ;; These are inherited from pane, via
-                        ;; clim-sheet-input-mixin and clim-repainting-mixin
-                        ;; immediate-sheet-input-mixin
-                        ;; immediate-repainting-mixin
-                        basic-pane
-                        gadget)
-  ((id                :initarg :id                :accessor gadget-id)
-   (client            :initarg :client            :accessor gadget-client)
-   (armed-callback    :initarg :armed-callback    :reader gadget-armed-callback)
-   (disarmed-callback :initarg :disarmed-callback :reader gadget-disarmed-callback)
-   ;; I'm not so sure about the value for :initform. Maybe T is
-   ;; better? Or maybe we should call ACTIVATE-GADGET after creating a
-   ;; gadget? -- AL
-   ;;
-   ;; I think, T is correct here --GB
-   (active-p          :initform t                 :reader gadget-active-p)
-   (armed             :initform nil               :reader gadget-armed-p))
-  (:default-initargs :text-style (make-text-style :sans-serif nil nil)
-                     :id (gensym "GADGET")
-                     :client *application-frame*
-                     :armed-callback nil
-                     :disarmed-callback nil))
-
-(defgeneric armed-callback (gadget client gadget-id)
-  (:argument-precedence-order client gadget-id gadget))
-
-(defgeneric disarmed-callback (gadget client gadget-id)
-  (:argument-precedence-order client gadget-id gadget))
-
-;; "The default methods (on basic-gadget) call the function stored
-;; in gadget-armed-callback or gadget-disarmed-callback with one argument,
-;; the gadget."
-
-(defmethod armed-callback ((gadget basic-gadget) client gadget-id)
-  (declare (ignore client gadget-id))
-  (invoke-callback gadget (gadget-armed-callback gadget)))
-
-(defmethod disarmed-callback ((gadget basic-gadget) client gadget-id)
-  (declare (ignore client gadget-id))
-  (invoke-callback gadget (gadget-disarmed-callback gadget)))
-
-;;
-;; arming and disarming gadgets
-;;
-
-;; Redrawing is supposed to be handled on an :AFTER method on arm- and
-;; disarm-callback.
-
-(defgeneric arm-gadget (gadget &optional value))
-
-(defmethod arm-gadget ((gadget basic-gadget) &optional (value t))
-  (with-slots (armed) gadget
-    (unless (eql armed value)
-      (setf armed value)
-      (if value
-          (armed-callback gadget (gadget-client gadget) (gadget-id gadget))
-          (disarmed-callback gadget (gadget-client gadget) (gadget-id gadget))))))
-
-(defgeneric disarm-gadget (gadget))
-
-(defmethod disarm-gadget ((gadget basic-gadget))
-  (arm-gadget gadget nil))
-
-;;;
-;;; Activation
-;;;
-
-(defgeneric activate-gadget (gadget))
-(defgeneric deactivate-gadget (gadget))
-(defgeneric note-gadget-activated (client gadget))
-(defgeneric note-gadget-deactivated (client gadget))
-
-(defmethod activate-gadget ((gadget gadget))
-  (with-slots (active-p) gadget
-    (unless active-p
-      (setf active-p t)
-      (note-gadget-activated (gadget-client gadget) gadget))))
-
-(defmethod deactivate-gadget ((gadget gadget))
-  (with-slots (active-p) gadget
-    (when active-p
-      (setf active-p nil)
-      (note-gadget-deactivated (gadget-client gadget) gadget))))
-
-(defmethod note-gadget-activated (client (gadget gadget))
-  (declare (ignore client))
-  ;; Default: do nothing
-  )
-
-(defmethod note-gadget-deactivated (client (gadget gadget))
-  (declare (ignore client))
-  ;; Default: do nothing
-  )
-
-;;;
-;;; Value-gadget
-;;;
-
-(defclass value-gadget (basic-gadget)
-  ((value :initarg :value
-          :reader gadget-value)
-   (value-changed-callback :initarg :value-changed-callback
-                           :initform nil
-                           :reader gadget-value-changed-callback)))
-
-(defmethod (setf gadget-value) (value (gadget value-gadget) &key invoke-callback)
-  (declare (ignore invoke-callback))
-  (setf (slot-value gadget 'value) value))
-
-;;; Try to call the callback after all other (setf gadget-value) methods have
-;;; been called. The gadget methods, which may update graphical appearance,
-;;; will be run even if the callback does a non-local exit (like throwing a
-;;; presentation).
-
-(defmethod (setf gadget-value) :around (value (gadget value-gadget)
-                                        &key invoke-callback)
-  (multiple-value-prog1
-      (call-next-method)
-    (when invoke-callback
-      (value-changed-callback gadget
-                              (gadget-client gadget)
-                              (gadget-id gadget)
-                              value))))
-
-(defgeneric value-changed-callback (gadget client gadget-id value)
-  (:argument-precedence-order client gadget-id value gadget))
-
-(defmethod value-changed-callback ((gadget value-gadget) client gadget-id value)
-  (declare (ignore client gadget-id))
-  (invoke-callback gadget (gadget-value-changed-callback gadget) value))
-
-;;;
-;;; Action-gadget
-;;;
-
-(defclass action-gadget (basic-gadget)
-  ((activate-callback :initarg :activate-callback
-                      :initform nil
-                      :reader gadget-activate-callback)))
-
-(defgeneric activate-callback (action-gadget client gadget-id)
-  (:argument-precedence-order client gadget-id action-gadget))
-
-(defmethod activate-callback ((gadget action-gadget) client gadget-id)
-  (declare (ignore client gadget-id))
-  (invoke-callback gadget (gadget-activate-callback gadget)))
-
-;;;
-;;; Oriented-gadget
-;;;
-
-(defclass oriented-gadget ()
-  ((orientation :type    (member :vertical :horizontal)
-                :initarg :orientation
-                :reader  gadget-orientation))
-  (:default-initargs :orientation :horizontal))
-
-(defclass oriented-gadget-mixin (oriented-gadget)
-  ;; Try to be compatible with Lispworks' CLIM.
-  ())
-
-;;;;
-;;;; labelled-gadget
-;;;;
-
-(defclass labelled-gadget ()
-  ((label       :initarg :label
-                :initform ""
-                :accessor gadget-label)
-   #+nil
-   (align-x     :initarg :align-x
-                :accessor gadget-label-align-x)
-   #+nil
-   (align-y     :initarg :align-y
-                :accessor gadget-label-align-y)
-   #+nil
-   (text-style  :initform *default-text-style*
-                :initarg :text-style
-                :accessor gadget-text-style)))
-
-(defclass labelled-gadget-mixin (labelled-gadget)
-  ;; Try to be compatible with Lispworks' CLIM.
-  ())
-
-;;;;
-;;;; Range-gadget
-;;;;
-
-(defclass range-gadget ()
-  ((min-value :initarg :min-value
-              :accessor gadget-min-value
-              :initform 0)
-   (max-value :initarg :max-value
-              :accessor gadget-max-value
-              :initform 1)))
-
-(defclass range-gadget-mixin (range-gadget)
-  ;; Try to be compatible with Lispworks' CLIM.
-  ())
-
-(defgeneric gadget-range (range-gadget)
-  (:documentation
-   "Returns the difference of the maximum and minimum value of RANGE-GADGET."))
-
-(defmethod gadget-range ((gadget range-gadget))
-  (- (gadget-max-value gadget)
-     (gadget-min-value gadget)))
-
-(defgeneric gadget-range* (range-gadget)
-  (:documentation
-   "Returns the minimum and maximum value of RANGE-GADGET as two values."))
-
-(defmethod gadget-range* ((gadget range-gadget))
-  (values (gadget-min-value gadget)
-          (gadget-max-value gadget)))
-
-
-;;;; ------------------------------------------------------------------------------------------
-;;;;
-;;;;  30.4 Abstract Gadget Classes
-;;;;
-
-;;; 30.4.1 The abstract push-button Gadget
-
-(defclass push-button (labelled-gadget-mixin action-gadget)
-  ())
-
-;;; 30.4.2 The abstract toggle-button Gadget
-
-(defclass toggle-button (labelled-gadget-mixin value-gadget)
-  ()
-  (:documentation "The value is either t either nil"))
-
-;;; 30.4.3 The abstract menu-button Gadget
-
-(defclass menu-button (labelled-gadget-mixin value-gadget)
-  ()
-  (:documentation "The value is a button"))
-
-;;; 30.4.4 The abstract scroll-bar Gadget
-
-(defgeneric drag-callback (pane client gadget-id value)
-  (:argument-precedence-order client gadget-id value pane))
-
-(defgeneric scroll-to-top-callback (scroll-bar client gadget-id)
-  (:argument-precedence-order client gadget-id scroll-bar))
-
-(defgeneric scroll-to-bottom-callback (scroll-bar client gadget-id)
-  (:argument-precedence-order client gadget-id scroll-bar))
-
-(defgeneric scroll-up-line-callback (scroll-bar client gadget-id)
-  (:argument-precedence-order client gadget-id scroll-bar))
-
-(defgeneric scroll-up-page-callback (scroll-bar client gadget-id)
-  (:argument-precedence-order client gadget-id scroll-bar))
-
-(defgeneric scroll-down-line-callback (scroll-bar client gadget-id)
-  (:argument-precedence-order client gadget-id scroll-bar))
-
-(defgeneric scroll-down-page-callback (scroll-bar client gadget-id)
-  (:argument-precedence-order client gadget-id scroll-bar))
-
-(defclass scroll-bar (value-gadget oriented-gadget-mixin range-gadget-mixin)
-  ((drag-callback :initarg :drag-callback
-                  :initform nil
-                  :reader scroll-bar-drag-callback)
-   (scroll-to-bottom-callback :initarg :scroll-to-bottom-callback
-                              :initform nil
-                              :reader scroll-bar-scroll-to-bottom-callback)
-   (scroll-to-top-callback :initarg :scroll-to-top-callback
-                           :initform nil
-                           :reader scroll-bar-scroll-to-top-callback)
-   (scroll-down-line-callback :initarg :scroll-down-line-callback
-                              :initform nil
-                              :reader scroll-bar-scroll-down-line-callback)
-   (scroll-up-line-callback :initarg :scroll-up-line-callback
-                            :initform nil
-                            :reader scroll-bar-scroll-up-line-callback)
-   (scroll-down-page-callback :initarg :scroll-down-page-callback
-                              :initform nil
-                              :reader scroll-bar-scroll-down-page-callback)
-   (scroll-up-page-callback :initarg :scroll-up-page-callback
-                            :initform nil
-                            :reader scroll-bar-scroll-up-page-callback)
-   (thumb-size :initarg :thumb-size :initform 1/4
-               :accessor scroll-bar-thumb-size
-               :documentation "The size of the scroll bar thumb (slug) in the
-  units of the gadget value. When the scroll bar is drawn the empty region of
-  the scroll bar and the thumb are drawn in proportion  to the values of the
-  gadget range and thumb size."))
-  (:default-initargs :value 0
-                     :min-value 0
-                     :max-value 1
-                     :orientation :vertical))
-
-(defmethod drag-callback ((pane scroll-bar) client gadget-id value)
-  (declare (ignore client gadget-id))
-  (invoke-callback pane (scroll-bar-drag-callback pane) value))
-
-(defmethod scroll-to-top-callback ((pane scroll-bar) client gadget-id)
-  (declare (ignore client gadget-id))
-  (invoke-callback pane (scroll-bar-scroll-to-top-callback pane)))
-
-(defmethod scroll-to-bottom-callback ((pane scroll-bar) client gadget-id)
-  (declare (ignore client gadget-id))
-  (invoke-callback pane (scroll-bar-scroll-to-bottom-callback pane)))
-
-(defmethod scroll-up-line-callback ((pane scroll-bar) client gadget-id)
-  (declare (ignore client gadget-id))
-  (invoke-callback pane (scroll-bar-scroll-up-line-callback pane)))
-
-(defmethod scroll-up-page-callback ((pane scroll-bar) client gadget-id)
-  (declare (ignore client gadget-id))
-  (invoke-callback pane (scroll-bar-scroll-up-page-callback pane)))
-
-(defmethod scroll-down-line-callback ((pane scroll-bar) client gadget-id)
-  (declare (ignore client gadget-id))
-  (invoke-callback pane (scroll-bar-scroll-down-line-callback pane)))
-
-(defmethod scroll-down-page-callback ((pane scroll-bar) client gadget-id)
-  (declare (ignore client gadget-id))
-  (invoke-callback pane (scroll-bar-scroll-down-page-callback pane)))
-
-;;; 30.4.5 The abstract slider Gadget
-
-(defclass slider (labelled-gadget-mixin
-		  value-gadget
-		  oriented-gadget-mixin
-		  range-gadget-mixin)
-  ((drag-callback  :initform nil
-                   :initarg :drag-callback
-                   :reader slider-drag-callback)
-   (show-value-p   :type boolean
-                   :initform nil
-                   :initarg :show-value-p
-                   :accessor gadget-show-value-p)
-   (decimal-places :initform 0
-                   :initarg :decimal-places
-                   :reader slider-decimal-places)
-   (number-of-quanta :initform nil
-                     :initarg :number-of-quanta
-                     :reader slider-number-of-quanta))
-  (:documentation "The value is a real number, and default value for orientation is :vertical,
-and must never be nil.")
-  (:default-initargs :orientation :vertical))
-
-(defmethod drag-callback ((pane slider) client gadget-id value)
-  (declare (ignore client gadget-id))
-  (when (slider-drag-callback pane)
-    (funcall (slider-drag-callback pane) pane value)))
-
-;;; 30.4.6 The abstract radio-box and check-box Gadgets
-
-;; The only real difference between a RADIO-BOX and a CHECK-BOX is the
-;; number of allowed selections.
-
-(defclass radio-box (value-gadget oriented-gadget-mixin)
-  ()
-  (:documentation "The value is a button")
-  (:default-initargs
-   :value nil))
-
-;; RADIO-BOX-CURRENT-SELECTION is just a synonym for GADGET-VALUE:
-
-(defgeneric radio-box-current-selection (radio-box))
-
-(defmethod radio-box-current-selection ((radio-box radio-box))
-  (gadget-value radio-box))
-
-(defgeneric (setf radio-box-current-selection) (new-value radio-box))
-
-(defmethod (setf radio-box-current-selection) (new-value (radio-box radio-box))
-  (setf (gadget-value radio-box) new-value))
-
-(defgeneric radio-box-selections (radio-box))
-
-(defmethod radio-box-selections ((pane radio-box))
-  (loop for child in (sheet-children pane)
-        when (typep child 'toggle-button)
-        collect child))
-
-(defmethod value-changed-callback :before (value-gadget (client radio-box) gadget-id value)
-  (declare (ignorable value-gadget gadget-id value))
-  ;; Note that we ignore 'value', this is because if value is non-NIL,
-  ;; then the toggle button was turned off, which would make no
-  ;; toggle-button turned on => constraint "always exactly one
-  ;; selected" missed. So simply turning this toggle button on again
-  ;; fixes it.
-  (unless (or (and (not value)
-                   (not (eq (gadget-value client) value-gadget)))
-              (and value
-                   (eq (gadget-value client) value-gadget)))
-    (setf (gadget-value client :invoke-callback t) value-gadget)))
-
-;;;; CHECK-BOX
-
-(defclass check-box (value-gadget oriented-gadget-mixin)
-  ()
-  (:documentation "The value is a list of buttons")
-  (:default-initargs
-   :value nil
-   :orientation :vertical))
-
-;; CHECK-BOX-CURRENT-SELECTION is just a synonym for GADGET-VALUE:
-
-(defgeneric check-box-current-selection (check-box))
-
-(defmethod check-box-current-selection ((check-box check-box))
-  (gadget-value check-box))
-
-(defgeneric (setf check-box-current-selection) (new-value check-box))
-
-(defmethod (setf check-box-current-selection) (new-value (check-box check-box))
-  (setf (gadget-value check-box) new-value))
-
-(defmethod check-box-selections ((pane check-box))
-  (loop for child in (sheet-children pane)
-        when (typep child 'toggle-button)
-        collect child))
-
-(defmethod value-changed-callback :before (value-gadget (client check-box) gadget-id value)
-  (declare (ignorable gadget-id))
-  (if value
-      (setf (gadget-value client :invoke-callback t)
-            (adjoin value-gadget (gadget-value client)))
-      (setf (gadget-value client :invoke-callback t)
-            (remove value-gadget (gadget-value client)))))
-
-(defmethod (setf gadget-value) :after (buttons (check-box check-box) &key invoke-callback)
-  ;; this is silly, but works ...
-  (dolist (c (sheet-children check-box))
-    (unless (eq (not (null (member c buttons)))
-                (not (null (gadget-value c))))
-      (setf (gadget-value c :invoke-callback invoke-callback) (member c buttons)) )))
-
-(defmacro with-radio-box ((&rest options
-                           &key (type :one-of) (orientation :vertical) &allow-other-keys)
-                          &body body)
-  (let ((contents (gensym "CONTENTS-"))
-        (selected-p (gensym "SELECTED-P-"))
-        (initial-selection (gensym "INITIAL-SELECTION-")))
-    `(let ((,contents nil)
-           (,selected-p nil)
-           (,initial-selection nil))
-       (declare (special ,selected-p))
-       (flet ((make-pane (type &rest options)
-                (cond ((eq type 'toggle-button)
-                       (let ((pane (apply #'make-pane type
-                                          :value ,selected-p
-                                          :indicator-type ',type
-                                          options)))
-                         (push pane ,contents)
-                         (when ,selected-p
-                           (push pane ,initial-selection))))
-                      (t
-                       (error "oops")))))
-         (macrolet ((radio-box-current-selection (subform)
-                      `(let ((,',selected-p t))
-                         (declare (special ,',selected-p))
-                         ,(cond ((stringp subform)
-                                 `(make-pane 'toggle-button :label ,subform))
-                                (t
-                                 subform)))))
-           ,@(mapcar (lambda (form)
-                       (cond ((stringp form)
-                              `(make-pane 'toggle-button :label ,form))
-                             (t
-                              form)))
-                     body)))
-       (make-pane ',(if (eq type :one-of)
-                            'radio-box
-                            'check-box)
-                  :orientation ',orientation
-                  :current-selection ,(if (eq type :one-of)
-                                          `(or (first ,initial-selection)
-                                               (first ,contents))
-                                        `,initial-selection)
-                  :choices (reverse ,contents)
-                  ,@options))))
-
-;;; 30.4.7 The abstract list-pane and option-pane Gadgets
-
-(defclass meta-list-pane ()
-  ((mode        :initarg :mode
-                :initform :exclusive
-                :reader list-pane-mode
-                :type (member :one-of :some-of :exclusive :nonexclusive))
-   (items       :initarg :items
-                :initform nil
-                :reader list-pane-items
-                :type sequence)
-   (name-key    :initarg :name-key
-                :initform #'princ-to-string
-                :reader list-pane-name-key
-                :documentation "A function to be applied to items to gain a printable representation")
-   (value-key   :initarg :value-key
-                :initform #'identity
-                :reader list-pane-value-key
-                :documentation "A function to be applied to items to gain its value
-                                for the purpose of GADGET-VALUE.")
-   (presentation-type-key :initarg :presentation-type-key
-                          :initform (constantly nil)
-                          :reader list-pane-presentation-type-key
-                          :documentation "A function to be applied to items to find the presentation types for their values, or NIL.")
-   (test        :initarg :test
-                :initform #'eql
-                :reader list-pane-test
-                :documentation "A function to compare two items for equality.")))
-
-(defclass list-pane (meta-list-pane value-gadget)
-  ((visible-items :initarg :visible-items ; Clim 2.2 compatibility
-                  :initform nil
-                  :documentation "Maximum number of visible items in list"))
-  (:documentation
-   "The instantiable class that implements an abstract list pane, that is, a gadget
-    whose semantics are similar to a radio box or check box, but whose visual
-    appearance is a list of buttons.")
-  (:default-initargs :value nil))
-
-(defclass option-pane (meta-list-pane value-gadget)
-  ()
-  (:documentation
-   "The instantiable class that implements an abstract option pane, that is, a
-    gadget whose semantics are identical to a list pane, but whose visual
-    appearance is a single push button which, when pressed, pops up a menu of
-    selections."))
-
-;;; 30.4.8 The abstract text-field Gadget
-
-(defclass text-field (value-gadget action-gadget)
-  ((editable-p :accessor editable-p :initarg editable-p :initform t))
-  (:documentation "The value is a string")
-  (:default-initargs :value ""))
-
-(defmethod initialize-instance :after ((gadget text-field) &rest rest)
-  (unless (getf rest :normal)
-    (setf (slot-value gadget 'current-color) +white+
-          (slot-value gadget 'normal) +white+)))
-
-;;; 30.4.9 The abstract text-editor Gadget
-
-(defclass text-editor (text-field)
-  ((ncolumns :reader text-editor-ncolumns
-             :initarg :ncolumns
-             :initform nil
-             :type (or null integer))
-   (nlines :reader text-editor-nlines
-           :initarg :nlines
-           :initform nil
-           :type (or null integer)))
-  (:documentation "The value is a string"))
-
-;;;; ------------------------------------------------------------------------------------------
-;;;;
-;;;;  Mixin Classes for Concrete Gadgets
-;;;;
-
-;;;; Redrawing mixins
-
-(defclass arm/disarm-repaint-mixin ()
-  ()
-  (:documentation
-   "Mixin class for gadgets, whose appearence depends on its armed state."))
-
-(defmethod armed-callback :after ((gadget arm/disarm-repaint-mixin) client id)
-  (declare (ignore client id))
-  (dispatch-repaint gadget (or (pane-viewport-region gadget)
-                               (sheet-region gadget))))
-
-(defmethod disarmed-callback :after ((gadget arm/disarm-repaint-mixin) client id)
-  (declare (ignore client id))
-  (dispatch-repaint gadget (or (pane-viewport-region gadget)
-                               (sheet-region gadget))))
-
-(defclass activate/deactivate-repaint-mixin ()
-  ()
-  (:documentation
-   "Mixin class for gadgets, whose appearence depends on its activatated state."))
-
-(defmethod activate-gadget :after ((gadget activate/deactivate-repaint-mixin))
-  (dispatch-repaint gadget (or (pane-viewport-region gadget)
-                               (sheet-region gadget))))
-
-(defmethod deactivate-gadget :after ((gadget activate/deactivate-repaint-mixin))
-  (dispatch-repaint gadget (or (pane-viewport-region gadget)
-                               (sheet-region gadget))))
-
-(defclass value-changed-repaint-mixin ()
-  ()
-  (:documentation
-   "Mixin class for gadgets, whose appearence depends on its value."))
-
-(defmethod (setf gadget-value) :after (new-value (gadget value-changed-repaint-mixin)
-                                       &key &allow-other-keys)
-  (declare (ignore new-value))
-  (dispatch-repaint gadget (or (pane-viewport-region gadget)
-                               (sheet-region gadget))))
-
-;;;; Event handling mixins
-
-(defclass enter/exit-arms/disarms-mixin ()
-  ()
-  (:documentation
-   "Mixin class for gadgets which are armed when the mouse enters and
-    disarmed when the mouse leaves."))
-
-(defmethod handle-event :before ((pane enter/exit-arms/disarms-mixin) (event pointer-enter-event))
-  (declare (ignorable event))
-  (arm-gadget pane))
-
-(defmethod handle-event :after ((pane enter/exit-arms/disarms-mixin) (event pointer-exit-event))
-  (declare (ignorable event))
-  (disarm-gadget pane))
-
-;;;; changing-label-invokes-layout-protocol-mixin
-
-(defclass changing-label-invokes-layout-protocol-mixin ()
-  ()
-  (:documentation
-   "Mixin class for gadgets, which want invoke the layout protocol, if the label changes."))
-
-;;;; Common behavior on `basic-gadget'
-
-;;
-;; When a gadget is not activated, it receives no device events.
-;;
-(defmethod handle-event :around ((pane basic-gadget) (event device-event))
-  (when (gadget-active-p pane)
-    (call-next-method)))
-
-;; When a gadget is deactivated, it cannot be armed.
-
-;; Glitch: upon re-activation the mouse might happen to be in the
-;; gadget and thus re-arm it immediately, that is not implemented.
-
-(defmethod note-gadget-deactivated :after (client (gadget basic-gadget))
-  (declare (ignorable client))
-  (disarm-gadget gadget))
-
-;;;; ------------------------------------------------------------------------------------------
-;;;;
-;;;;  Drawing Utilities for Concrete Gadgets
-;;;;
-
-;;; Labels
-
-(defgeneric compose-label-space (gadget &key wider higher))
-
-(defmethod compose-label-space ((gadget labelled-gadget-mixin) &key (wider 0) (higher 0))
-  (with-slots (label align-x align-y) gadget
-    (let* ((text-style (pane-text-style gadget))
-           (as (text-style-ascent text-style gadget))
-           (ds (text-style-descent text-style gadget))
-           (w  (+ (text-size gadget label :text-style text-style) wider))
-           (h  (+ as ds higher)))
-      (make-space-requirement :width w  :min-width w  :max-width  +fill+
-                              :height h :min-height h :max-height +fill+))))
-
-(defgeneric draw-label* (pane x1 y1 x2 y2 &key ink))
-
-(defmethod draw-label* ((pane labelled-gadget-mixin) x1 y1 x2 y2
-                        &key (ink +foreground-ink+))
-  (with-slots (align-x align-y label) pane
-    (let* ((text-style (pane-text-style pane))
-           (as (text-style-ascent text-style pane))
-           (ds (text-style-descent text-style pane))
-           (w  (text-size pane label :text-style text-style)))
-      (draw-text* pane label
-                  (case align-x
-                    ((:left) x1)
-                    ((:right) (- x2 w))
-                    ((:center) (/ (+ x1 x2 (- w)) 2))
-                    (otherwise x1))     ;defensive programming
-                  (case align-y
-                    ((:top) (+ y1 as))
-                    ((:center) (/ (+ y1 y2 (- as ds)) 2))
-                    ((:bottom) (- y2 ds))
-                    (otherwise (/ (+ y1 y2 (- as ds)) 2))) ;defensive programming
-                  ;; Giving the text-style here shouldn't be neccessary --GB
-                  :text-style text-style
-                  :ink ink))))
-
-;;; 3D-ish Look
-
-;; DRAW-BORDERED-POLYGON medium point-seq &key border-width style
-;;
-;; -GB
-
-(labels ((line-hnf (x1 y1 x2 y2)
-           (values (- y2 y1) (- x1 x2) (- (* x1 y2) (* y1 x2))))
-
-         (line-line-intersection (x1 y1 x2 y2 x3 y3 x4 y4)
-           (multiple-value-bind (a1 b1 c1) (line-hnf x1 y1 x2 y2)
-             (multiple-value-bind (a2 b2 c2) (line-hnf x3 y3 x4 y4)
-               (let ((d (- (* a1 b2) (* b1 a2))))
-                 (cond ((< (abs d) 1e-6)
-                        nil)
-                       (t
-                        (values (/ (- (* b2 c1) (* b1 c2)) d)
-                                (/ (- (* a1 c2) (* a2 c1)) d))))))))
-
-         (polygon-orientation (point-seq)
-           "Determines the polygon's orientation.
-            Returns:  +1 = counter-clock-wise
-                      -1 = clock-wise
-
-            The polygon should be clean from duplicate points or co-linear points.
-            If the polygon self intersects, the orientation may not be defined, this
-            function does not try to detect this situation and happily returns some
-            value."
-           ;;
-           (let ((n (length point-seq)))
-             (let* ((min-i 0)
-                    (min-val (point-x (elt point-seq min-i))))
-               ;;
-               (loop for i from 1 below n do
-                     (when (< (point-x (elt point-seq i)) min-val)
-                       (setf min-val (point-x (elt point-seq i))
-                             min-i i)))
-               ;;
-               (let ((p0 (elt point-seq (mod (+ min-i -1) n)))
-                     (p1 (elt point-seq (mod (+ min-i 0) n)))
-                     (p2 (elt point-seq (mod (+ min-i +1) n))))
-                 (signum (- (* (- (point-x p2) (point-x p0)) (- (point-y p1) (point-y p0)))
-                            (* (- (point-x p1) (point-x p0)) (- (point-y p2) (point-y p0)))))))))
-
-         (clean-polygon (point-seq)
-           "Cleans a polygon from duplicate points and co-linear points. Furthermore
-            tries to bring it into counter-clock-wise orientation."
-           ;; first step: remove duplicates
-           (setf point-seq
-                 (let ((n (length point-seq)))
-                   (loop for i from 0 below n
-                         for p0 = (elt point-seq (mod (+ i -1) n))
-                         for p1 = (elt point-seq (mod (+ i 0) n))
-                         unless (and (< (abs (- (point-x p0) (point-x p1))) 10e-8)
-                                     (< (abs (- (point-y p0) (point-y p1))) 10e-8))
-                         collect p1)))
-           ;; second step: remove colinear points
-           (setf point-seq
-                 (let ((n (length point-seq)))
-                   (loop for i from 0 below n
-                         for p0 = (elt point-seq (mod (+ i -1) n))
-                         for p1 = (elt point-seq (mod (+ i 0) n))
-                         for p2 = (elt point-seq (mod (+ i +1) n))
-                         unless (< (abs (- (* (- (point-x p1) (point-x p0)) (- (point-y p2) (point-y p0)))
-                                           (* (- (point-x p2) (point-x p0)) (- (point-y p1) (point-y p0)))))
-                                   10e-8)
-                         collect p1)))
-           ;; third step: care for the orientation
-           (if (and (not (null point-seq))
-                    (minusp (polygon-orientation point-seq)))
-               (reverse point-seq)
-               point-seq) ))
-
-  (defun shrink-polygon (point-seq width)
-    (let ((point-seq (clean-polygon point-seq)))
-      (let ((n (length point-seq)))
-        (values
-         point-seq
-         (loop for i from 0 below n
-               for p0 = (elt point-seq (mod (+ i -1) n))
-               for p1 = (elt point-seq (mod (+ i  0) n))
-               for p2 = (elt point-seq (mod (+ i +1) n))
-               collect
-               (let* ((dx1 (- (point-x p1) (point-x p0))) (dy1 (- (point-y p1) (point-y p0)))
-                      (dx2 (- (point-x p2) (point-x p1))) (dy2 (- (point-y p2) (point-y p1)))
-                      ;;
-                      (m1  (/ width (sqrt (+ (* dx1 dx1) (* dy1 dy1)))))
-                      (m2  (/ width (sqrt (+ (* dx2 dx2) (* dy2 dy2)))))
-                      ;;
-                      (q0  (make-point (+ (point-x p0) (* m1 dy1)) (- (point-y p0) (* m1 dx1))))
-                      (q1  (make-point (+ (point-x p1) (* m1 dy1)) (- (point-y p1) (* m1 dx1))))
-                      (q2  (make-point (+ (point-x p1) (* m2 dy2)) (- (point-y p1) (* m2 dx2))))
-                      (q3  (make-point (+ (point-x p2) (* m2 dy2)) (- (point-y p2) (* m2 dx2)))) )
-                 ;;
-                 (multiple-value-bind (x y)
-                     (multiple-value-call #'line-line-intersection
-                       (point-position q0) (point-position q1)
-                       (point-position q2) (point-position q3))
-                   (if x
-                       (make-point x y)
-                       (make-point 0 0)))))))))
-
-  (defun draw-bordered-polygon (medium point-seq
-                                       &key (border-width 2)
-                                            (style        :inset))
-    (labels ((draw-pieces (outer-points inner-points dark light)
-               (let ((n (length outer-points)))
-                 (dotimes (i n)
-                   (let* ((p1 (elt outer-points (mod (+ i  0) n)))
-                          (p2 (elt outer-points (mod (+ i +1) n)))
-                          (q1 (elt inner-points (mod (+ i  0) n)))
-                          (q2 (elt inner-points (mod (+ i +1) n)))
-                          (p1* (transform-region +identity-transformation+  p1))
-                          (p2* (transform-region +identity-transformation+  p2))
-                          (a (mod (atan (- (point-y p2*) (point-y p1*))
-                                        (- (point-x p2*) (point-x p1*)))
-                                  (* 2 pi))))
-                     (draw-polygon medium (list p1 q1 q2 p2)
-                                   :ink
-                                   (if (<= (* 1/4 pi) a (* 5/4 pi))
-                                       dark light)))))))
-      (let ((light  *3d-light-color*)
-            (dark   *3d-dark-color*))
-      ;;
-      (ecase style
-        (:solid
-         (multiple-value-call #'draw-pieces (shrink-polygon point-seq border-width)
-                              +black+ +black+))
-        (:inset
-         (multiple-value-call #'draw-pieces (shrink-polygon point-seq border-width)
-                              dark light))
-        (:outset
-         (multiple-value-call #'draw-pieces (shrink-polygon point-seq border-width)
-                              light dark))
-        ;;
-        ;; Mickey Mouse is the trademark of the Walt Disney Company.
-        ;;
-        (:mickey-mouse-outset
-         (multiple-value-bind (outer-points inner-points) (shrink-polygon point-seq border-width)
-           (declare (ignore outer-points))
-           (multiple-value-bind (outer-points middle-points) (shrink-polygon point-seq (/ border-width 2))
-             (draw-pieces outer-points middle-points +white+ +black+)
-             (draw-pieces middle-points inner-points light dark))))
-        (:mickey-mouse-inset
-         (multiple-value-bind (outer-points inner-points) (shrink-polygon point-seq border-width)
-           (declare (ignore outer-points))
-           (multiple-value-bind (outer-points middle-points) (shrink-polygon point-seq (/ border-width 2))
-             (draw-pieces outer-points middle-points dark light)
-             (draw-pieces middle-points inner-points +black+ +white+))))
-        ;;
-        (:ridge
-         (multiple-value-bind (outer-points inner-points) (shrink-polygon point-seq border-width)
-           (declare (ignore outer-points))
-           (multiple-value-bind (outer-points middle-points) (shrink-polygon point-seq (/ border-width 2))
-             (draw-pieces outer-points middle-points light dark)
-             (draw-pieces middle-points inner-points dark light))))
-        (:groove
-         (multiple-value-bind (outer-points inner-points) (shrink-polygon point-seq border-width)
-           (declare (ignore outer-points))
-           (multiple-value-bind (outer-points middle-points) (shrink-polygon point-seq (/ border-width 2))
-             (draw-pieces outer-points middle-points dark light)
-             (draw-pieces middle-points inner-points light dark))))
-        (:double
-         (multiple-value-bind (outer-points inner-points) (shrink-polygon point-seq border-width)
-           (declare (ignore outer-points))
-           (multiple-value-bind (outer-points imiddle-points) (shrink-polygon point-seq (* 2/3 border-width))
-             (declare (ignore outer-points))
-             (multiple-value-bind (outer-points omiddle-points) (shrink-polygon point-seq (* 1/3 border-width))
-               (draw-pieces outer-points omiddle-points +black+ +black+)
-               (draw-pieces imiddle-points inner-points +black+ +black+))))))))) )
-
-(defun draw-bordered-rectangle* (medium x1 y1 x2 y2 &rest options)
-  (apply #'draw-bordered-polygon
-         medium
-         (polygon-points (make-rectangle* x1 y1 x2 y2))
-         options))
-
-(defun draw-engraved-label* (pane x1 y1 x2 y2)
-  (draw-label* pane (1+ x1) (1+ y1) (1+ x2) (1+ y2) :ink *3d-light-color*)
-  (draw-label* pane x1 y1 x2 y2 :ink *3d-dark-color*))
-
-;;;;
-;;;; 3D-BORDER-MIXIN Class
-;;;;
-
-;; 3D-BORDER-MIXIN class can be used to add a 3D-ish border to
-;; panes. There are three new options:
-;;
-;;  :border-width       The width of the border
-;;  :border-style       The border's style one of :inset, :outset, :groove, :ridge, :solid,
-;;                      :double, :dotted, :dashed
-;;                      [:dotted and :dashed are not yet implemented]
-;;
-;;  :border-color       The border's color
-;;                      [Not implemented yet]
-;;
-;; [These options are modelled after CSS].
-;;
-;; When using 3D-BORDER-MIXIN, one should query the pane's inner
-;; region, where drawing should take place, by PANE-INNER-REGION.
-;;
-;; --GB
-
-(defclass 3D-border-mixin ()
-  ((border-width :initarg :border-width :initform 2)
-   (border-style :initarg :border-style :initform :outset)
-   (border-color :initarg :border-color :initform "???")))
-
-(defgeneric pane-inner-region (pane))
-
-(defmethod pane-inner-region ((pane 3D-border-mixin))
-  (with-slots (border-width) pane
-    (with-bounding-rectangle* (x1 y1 x2 y2) (sheet-region pane)
-      (make-rectangle* (+ x1 border-width) (+ y1 border-width)
-                       (- x2 border-width) (- y2 border-width)))))
-
-(defmethod handle-repaint :after ((pane 3D-border-mixin) region)
-  (declare (ignore region))
-  (with-slots (border-width border-style) pane
-    (draw-bordered-polygon pane (polygon-points (bounding-rectangle (sheet-region pane)))
-                           :border-width border-width
-                           :style border-style)))
-
-;;;; ------------------------------------------------------------------------------------------
 ;;;;
 ;;;;  30.4a Concrete Gadget Classes
 ;;;;
-
-;; xxx move these!
-
-(defparameter *3d-border-thickness* 2)
-
-;;; Common colors:
-
-(defgeneric gadget-highlight-background (gadget))
-
-(defmethod gadget-highlight-background ((gadget basic-gadget))
-  (compose-over (compose-in #|+paleturquoise+|# +white+ (make-opacity .5))
-                (pane-background gadget)))
-
-(defgeneric effective-gadget-foreground (gadget))
-
-(defmethod effective-gadget-foreground ((gadget basic-gadget))
-  (if (gadget-active-p gadget)
-      +foreground-ink+
-      (compose-over (compose-in (pane-foreground gadget)
-                                (make-opacity .5))
-                    (pane-background gadget))))
-
-(defgeneric effective-gadget-background (gadget))
-
-(defmethod effective-gadget-background ((gadget basic-gadget))
-  (if (slot-value gadget 'armed)
-      (gadget-highlight-background gadget)
-      (pane-background gadget)))
-
-(defgeneric effective-gadget-input-area-color (gadget))
-
-(defmethod effective-gadget-input-area-color ((gadget basic-gadget))
-  (if (gadget-active-p gadget)
-      +lemonchiffon+
-      (compose-over (compose-in +lemonchiffon+ (make-opacity .5))
-                    (pane-background gadget))))
 
 ;;; ------------------------------------------------------------------------------------------
 ;;; 30.4.1 The concrete push-button Gadget
@@ -1154,11 +20,11 @@ and must never be nil.")
                       :initarg :show-as-default-p
                       :accessor push-button-show-as-default-p))
   (:default-initargs
-    :background *3d-normal-color*
-    :align-x :center
-    :align-y :center
-    :x-spacing 4
-    :y-spacing 4))
+   :background *3d-normal-color*
+   :align-x :center
+   :align-y :center
+   :x-spacing 4
+   :y-spacing 4))
 
 (defmethod compose-space ((gadget push-button-pane) &key width height)
   (declare (ignore width height))
@@ -1229,13 +95,12 @@ and must never be nil.")
                    :initarg :indicator-type
                    :reader toggle-button-indicator-type
                    :initform :some-of) )
-  (:default-initargs
-    :value nil
-    :align-x :left
-    :align-y :center
-    :x-spacing 2
-    :y-spacing 2
-    :background *3d-normal-color*))
+  (:default-initargs :value nil
+                     :align-x :left
+                     :align-y :center
+                     :x-spacing 2
+                     :y-spacing 2
+                     :background *3d-normal-color*))
 
 (defmethod compose-space ((pane toggle-button-pane) &key width height)
   (declare (ignore width height))
@@ -1259,15 +124,15 @@ and must never be nil.")
   (multiple-value-bind (cx cy) (values (/ (+ x1 x2) 2) (/ (+ y1 y2) 2))
     (let ((radius (/ (- y2 y1) 2)))
       (draw-circle* gadget cx cy radius
-                     :start-angle (* 1/4 pi)
-                     :end-angle (* 5/4 pi)
-                     :ink *3d-dark-color*)
+                    :start-angle (* 1/4 pi)
+                    :end-angle (* 5/4 pi)
+                    :ink *3d-dark-color*)
       (draw-circle* gadget cx cy radius
-                     :start-angle (* 5/4 pi)
-                     :end-angle (* 9/4 pi)
-                     :ink *3d-light-color*)
+                    :start-angle (* 5/4 pi)
+                    :end-angle (* 9/4 pi)
+                    :ink *3d-light-color*)
       (draw-circle* gadget cx cy (max 1 (- radius 2))
-                     :ink (effective-gadget-input-area-color gadget))
+                    :ink (effective-gadget-input-area-color gadget))
       (when value
         (draw-circle* gadget cx cy (max 1 (- radius 4))
                       :ink (effective-gadget-foreground gadget))))))
@@ -1315,12 +180,11 @@ and must never be nil.")
                             activate/deactivate-repaint-mixin
                             sheet-leaf-mixin)
   ()
-  (:default-initargs
-    :background *3d-normal-color*
-    :x-spacing 3
-    :y-spacing 2
-    :align-x :left
-    :align-y :center))
+  (:default-initargs :background *3d-normal-color*
+                     :x-spacing 3
+                     :y-spacing 2
+                     :align-x :left
+                     :align-y :center))
 
 (defmethod handle-repaint ((pane menu-button-pane) region)
   (declare (ignore region))
@@ -1466,32 +330,32 @@ and must never be nil.")
                        (if (< oy1 ny1)
                            (draw-rectangle* medium ox1 oy1 ox2 ny1 :ink *3d-inner-color*)
                            (draw-rectangle* medium ox1 oy2 ox2 ny2 :ink *3d-inner-color*)))) ))))
-             (t
-              ;; redraw whole thumb bed and thumb all anew
-              (with-drawing-options (scroll-bar :transformation (scroll-bar-transformation scroll-bar))
-                  (with-bounding-rectangle* (bx1 by1 bx2 by2) (scroll-bar-thumb-bed-region scroll-bar)
-                    (with-bounding-rectangle* (x1 y1 x2 y2) (scroll-bar-thumb-region scroll-bar value)
-                      (draw-rectangle* scroll-bar bx1 by1 bx2 y1 :ink *3d-inner-color*)
-                      (draw-rectangle* scroll-bar bx1 y2 bx2 by2 :ink *3d-inner-color*)
-                      (draw-rectangle* scroll-bar x1 y1 x2 y2 :ink *3d-normal-color*)
-                      (draw-bordered-polygon scroll-bar
-                                             (polygon-points (make-rectangle* x1 y1 x2 y2))
-                                             :style :outset
-                                             :border-width 2)
+            (t
+             ;; redraw whole thumb bed and thumb all anew
+             (with-drawing-options (scroll-bar :transformation (scroll-bar-transformation scroll-bar))
+               (with-bounding-rectangle* (bx1 by1 bx2 by2) (scroll-bar-thumb-bed-region scroll-bar)
+                 (with-bounding-rectangle* (x1 y1 x2 y2) (scroll-bar-thumb-region scroll-bar value)
+                   (draw-rectangle* scroll-bar bx1 by1 bx2 y1 :ink *3d-inner-color*)
+                   (draw-rectangle* scroll-bar bx1 y2 bx2 by2 :ink *3d-inner-color*)
+                   (draw-rectangle* scroll-bar x1 y1 x2 y2 :ink *3d-normal-color*)
+                   (draw-bordered-polygon scroll-bar
+                                          (polygon-points (make-rectangle* x1 y1 x2 y2))
+                                          :style :outset
+                                          :border-width 2)
                     ;;;;;;
-                      (let ((y (/ (+ y1 y2) 2)))
-                        (draw-bordered-polygon scroll-bar
-                                               (polygon-points (make-rectangle* (+ x1 3) (- y 1) (- x2 3) (+ y 1)))
-                                               :style :inset
-                                               :border-width 1)
-                        (draw-bordered-polygon scroll-bar
-                                               (polygon-points (make-rectangle* (+ x1 3) (- y 4) (- x2 3) (- y 2)))
-                                               :style :inset
-                                               :border-width 1)
-                        (draw-bordered-polygon scroll-bar
-                                               (polygon-points (make-rectangle* (+ x1 3) (+ y 4) (- x2 3) (+ y 2)))
-                                               :style :inset
-                                               :border-width 1))))))))
+                   (let ((y (/ (+ y1 y2) 2)))
+                     (draw-bordered-polygon scroll-bar
+                                            (polygon-points (make-rectangle* (+ x1 3) (- y 1) (- x2 3) (+ y 1)))
+                                            :style :inset
+                                            :border-width 1)
+                     (draw-bordered-polygon scroll-bar
+                                            (polygon-points (make-rectangle* (+ x1 3) (- y 4) (- x2 3) (- y 2)))
+                                            :style :inset
+                                            :border-width 1)
+                     (draw-bordered-polygon scroll-bar
+                                            (polygon-points (make-rectangle* (+ x1 3) (+ y 4) (- x2 3) (+ y 2)))
+                                            :style :inset
+                                            :border-width 1))))))))
     (setf old-up-state up-state
           old-dn-state dn-state
           old-tb-state tb-state
@@ -1501,7 +365,7 @@ and must never be nil.")
 
 (defun scroll-bar/compute-display (scroll-bar value)
   (with-slots (up-state dn-state tb-state tb-y1 tb-y2
-                        event-state) scroll-bar
+               event-state) scroll-bar
     (setf up-state (if (eq event-state :up-armed) :armed nil))
     (setf dn-state (if (eq event-state :dn-armed) :armed nil))
     (setf tb-state nil)                 ;we have no armed display yet
@@ -1657,9 +521,9 @@ and must never be nil.")
         (:dragging
          (let* ((y-new-thumb-top (- y drag-dy))
                 (new-value
-                 (min (gadget-max-value sb)
-                      (max (gadget-min-value sb)
-                           (scroll-bar/map-coordinate-to-value sb y-new-thumb-top)))) )
+                  (min (gadget-max-value sb)
+                       (max (gadget-min-value sb)
+                            (scroll-bar/map-coordinate-to-value sb y-new-thumb-top)))) )
            (scroll-bar/update-display sb new-value)
            (drag-callback sb (gadget-client sb) (gadget-id sb) new-value)) )))))
 
@@ -1677,9 +541,9 @@ and must never be nil.")
          (with-slots (drag-dy) sb
            (let* ((y-new-thumb-top (- y drag-dy))
                   (new-value
-                   (min (gadget-max-value sb)
-                        (max (gadget-min-value sb)
-                             (scroll-bar/map-coordinate-to-value sb y-new-thumb-top)))) )
+                    (min (gadget-max-value sb)
+                         (max (gadget-min-value sb)
+                              (scroll-bar/map-coordinate-to-value sb y-new-thumb-top)))) )
              (setf (gadget-value sb :invoke-callback t) new-value)))))
       (otherwise
        (setf event-state nil))))
@@ -1770,8 +634,8 @@ and must never be nil.")
 
 (defmethod handle-event ((pane slider-pane) (event pointer-button-press-event))
   (with-slots (armed) pane
-     (when armed
-       (setf armed ':button-press))))
+    (when armed
+      (setf armed ':button-press))))
 
 (defmethod handle-event ((pane slider-pane) (event pointer-motion-event))
   (with-slots (armed) pane
@@ -1869,8 +733,7 @@ and must never be nil.")
                (draw-value (+ x1 slider-button-short-dim)
                            (- middle 10.0))))))))))
 
-
-#|
+#+ (or)
 (defmethod handle-repaint ((pane slider-pane) region)
   (declare (ignore region))
   (let ((position (convert-value-to-position pane))
@@ -1879,47 +742,54 @@ and must never be nil.")
     (multiple-value-bind (x1 y1 x2 y2) (bounding-rectangle* (sheet-region pane))
       (display-gadget-background pane (gadget-current-color pane) 0 0 (- x2 x1) (- y2 y1))
       (if (eq (gadget-orientation pane) :vertical)
-            ; vertical case             ;
+          ;; vertical case
           (let ((middle (round (- x2 x1) 2)))
             (draw-line* pane
                         middle (+ y1 slider-button-half-short-dim)
                         middle (- y2 slider-button-half-short-dim)
                         :ink +black+
                         (draw-rectangle* pane
-                                         (- middle slider-button-half-long-dim) (- position slider-button-half-short-dim)
-                                         (+ middle slider-button-half-long-dim) (+ position slider-button-half-short-dim)
+                                         (- middle slider-button-half-long-dim)
+                                         (- position slider-button-half-short-dim)
+                                         (+ middle slider-button-half-long-dim)
+                                         (+ position slider-button-half-short-dim)
                                          :ink +gray85+ :filled t)
                         (draw-edges-lines* pane
                                            +white+
-                                           (- middle slider-button-half-long-dim) (- position slider-button-half-short-dim)
+                                           (- middle slider-button-half-long-dim)
+                                           (- position slider-button-half-short-dim)
                                            +black+
-                                           (+ middle slider-button-half-long-dim) (+ position slider-button-half-short-dim))
+                                           (+ middle slider-button-half-long-dim)
+                                           (+ position slider-button-half-short-dim))
                         (when (gadget-show-value-p pane)
                           (draw-text* pane (format-value (gadget-value pane)
                                                          (slider-decimal-places pane))
                                       5 ;(- middle slider-button-half-short-dim)
                                       10))) ;(- position slider-button-half-long-dim)
-            ; horizontal case           ;
+            ;; horizontal case
             (let ((middle (round (- y2 y1) 2)))
               (draw-line* pane
                           (+ x1 slider-button-half-short-dim) middle
                           (- x2 slider-button-half-short-dim) middle
                           :ink +black+)
               (draw-rectangle* pane
-                               (- position slider-button-half-short-dim) (- middle slider-button-half-long-dim)
-                               (+ position slider-button-half-short-dim) (+ middle slider-button-half-long-dim)
+                               (- position slider-button-half-short-dim)
+                               (- middle slider-button-half-long-dim)
+                               (+ position slider-button-half-short-dim)
+                               (+ middle slider-button-half-long-dim)
                                :ink +gray85+ :filled t)
               (draw-edges-lines* pane
                                  +white+
-                                 (- position slider-button-half-short-dim) (- middle slider-button-half-long-dim)
+                                 (- position slider-button-half-short-dim)
+                                 (- middle slider-button-half-long-dim)
                                  +black+
-                                 (+ position slider-button-half-short-dim) (+ middle slider-button-half-long-dim))
+                                 (+ position slider-button-half-short-dim)
+                                 (+ middle slider-button-half-long-dim))
               (when (gadget-show-value-p pane)
                 (draw-text* pane (format-value (gadget-value pane)
                                                (slider-decimal-places pane))
-                            5 ;(- position slider-button-half-short-dim)
+                            5 ;; (- position slider-button-half-short-dim)
                             (- middle slider-button-half-long-dim)))))))))
-|#
 
 (flet ((compute-dims (slider)
          (multiple-value-bind (x1 y1 x2 y2) (bounding-rectangle* (sheet-region slider))
@@ -1962,22 +832,21 @@ and must never be nil.")
                           sheet-multiple-child-mixin
                           basic-pane)
   ()
-  (:default-initargs
-   :background *3d-normal-color*))
+  (:default-initargs :background *3d-normal-color*))
 
 (defmethod initialize-instance :after ((pane radio-box-pane)
                                        &key choices current-selection orientation (active t) &allow-other-keys)
   (setf (box-layout-orientation pane) orientation)
   (setf (gadget-value pane) current-selection)
   (let ((children
-         (mapcar (lambda (c)
-                   (let ((c (if (stringp c)
-                                (make-pane 'toggle-button-pane :label c :value nil)
-                                c)))
-                     (setf (gadget-value c) (if (eq c (radio-box-current-selection pane)) t nil))
-                     (setf (gadget-client c) pane)
-                     c))
-                 choices)))
+          (mapcar (lambda (c)
+                    (let ((c (if (stringp c)
+                                 (make-pane 'toggle-button-pane :label c :value nil)
+                                 c)))
+                      (setf (gadget-value c) (if (eq c (radio-box-current-selection pane)) t nil))
+                      (setf (gadget-client c) pane)
+                      c))
+                  choices)))
     (mapc (curry #'sheet-adopt-child pane) children))
   (unless active
     (deactivate-gadget pane)))
@@ -2007,22 +876,21 @@ and must never be nil.")
                           sheet-multiple-child-mixin
                           basic-pane)
   ()
-  (:default-initargs
-   :background *3d-normal-color*))
+  (:default-initargs :background *3d-normal-color*))
 
 (defmethod initialize-instance :after ((pane check-box-pane)
                                        &key choices current-selection orientation (active t) &allow-other-keys)
   (setf (box-layout-orientation pane) orientation)
   (setf (gadget-value pane) current-selection)
   (let ((children
-         (mapcar (lambda (c)
-                   (let ((c (if (stringp c)
-                                (make-pane 'toggle-button-pane :label c :value nil)
-                                c)))
-                     (setf (gadget-value c) (if (member c current-selection) t nil))
-                     (setf (gadget-client c) pane)
-                     c))
-                 choices)))
+          (mapcar (lambda (c)
+                    (let ((c (if (stringp c)
+                                 (make-pane 'toggle-button-pane :label c :value nil)
+                                 c)))
+                      (setf (gadget-value c) (if (member c current-selection) t nil))
+                      (setf (gadget-client c) pane)
+                      c))
+                  choices)))
     (mapc (curry #'sheet-adopt-child pane) children))
   (unless active
     (deactivate-gadget pane)))
@@ -2085,26 +953,27 @@ and must never be nil.")
                   :initarg :highlight-ink
                   :reader list-pane-highlight-ink)
    (item-strings :initform nil
-     :documentation "Vector of item strings.")
+                 :documentation "Vector of item strings.")
    (item-values :initform nil
-     :documentation "Vector of item values.")
+                :documentation "Vector of item values.")
    (items-width  :initform nil
-     :documentation "Width sufficient to contain all items")
+                 :documentation "Width sufficient to contain all items")
    (last-action  :initform nil
-     :documentation "Last action performed on items in the pane, either
+                 :documentation "Last action performed on items in the pane, either
 :select, :deselect, or NIL if none has been performed yet.")
    (last-index   :initform nil
-     :documentation "Index of last item clicked, for extending selections.")
+                 :documentation "Index of last item clicked, for extending selections.")
    (prefer-single-selection :initform nil :initarg :prefer-single-selection
-     :documentation "For nonexclusive menus, emulate the common behavior of
+                            :documentation "For nonexclusive menus, emulate the common behavior of
 preferring selection of a single item, but allowing extension of the
 selection via the control modifier.")
    (items-length :initform nil
                  :documentation "Number of items")
    (items-origin :initform 0 :accessor items-origin
-     :documentation "Index of the first item to be rendered. This changes in
+                 :documentation "Index of the first item to be rendered. This changes in
 response to scroll wheel events."))
-  (:default-initargs :background +white+ :foreground +black+))
+  (:default-initargs :background +white+
+                     :foreground +black+))
 
 (defmethod initialize-instance :after ((gadget meta-list-pane) &rest rest)
   (declare (ignorable rest))
@@ -2163,12 +1032,12 @@ response to scroll wheel events."))
   (with-slots (item-strings) pane
     (or item-strings
         (setf item-strings
-          (map 'vector (lambda (item)
-                         (let ((s (funcall (list-pane-name-key pane) item)))
-                           (if (stringp s)
-                               s
-                             (princ-to-string s)))) ;defensive programming!
-                (list-pane-items pane))))))
+              (map 'vector (lambda (item)
+                             (let ((s (funcall (list-pane-name-key pane) item)))
+                               (if (stringp s)
+                                   s
+                                   (princ-to-string s)))) ;defensive programming!
+                   (list-pane-items pane))))))
 
 (defgeneric generic-list-pane-item-values (generic-list-pane))
 
@@ -2176,7 +1045,7 @@ response to scroll wheel events."))
   (with-slots (item-values) pane
     (or item-values
         (setf item-values
-          (map 'vector (list-pane-value-key pane) (list-pane-items pane))))))
+              (map 'vector (list-pane-value-key pane) (list-pane-items pane))))))
 
 (defgeneric generic-list-pane-items-width (generic-list-pane))
 
@@ -2229,17 +1098,17 @@ response to scroll wheel events."))
   (with-bounding-rectangle* (sx0 sy0 sx1 sy1) (sheet-region pane)
     (declare (ignore sx1 sy1))
     (with-bounding-rectangle* (rx0 ry0 rx1 ry1)
-      (if (bounding-rectangle-p region)
-          region
-          (or (pane-viewport-region pane)   ; workaround for +everywhere+
-              (sheet-region pane)))
+        (if (bounding-rectangle-p region)
+            region
+            (or (pane-viewport-region pane)   ; workaround for +everywhere+
+                (sheet-region pane)))
       (let ((item-height (generic-list-pane-item-height pane))
             (highlight-ink (list-pane-highlight-ink pane)))
         (do* ((index (floor (- ry0 sy0) item-height) (1+ index))
               (elt-index (+ index (items-origin pane)) (1+ elt-index)))
-            ((or (> (+ sy0 (* item-height index)) ry1)
-                 (>= elt-index (generic-list-pane-items-length pane))
-                 (>= elt-index (+ (items-origin pane) (visible-items pane)))))
+             ((or (> (+ sy0 (* item-height index)) ry1)
+                  (>= elt-index (generic-list-pane-items-length pane))
+                  (>= elt-index (+ (items-origin pane) (visible-items pane)))))
           (let ((y0 (+ sy0 (* index item-height)))
                 (y1 (+ sy0 (* (1+ index) item-height))))
             (multiple-value-bind (background foreground)
@@ -2253,7 +1122,7 @@ response to scroll wheel events."))
                            (member (elt (generic-list-pane-item-values pane)
                                         elt-index)
                                    (gadget-value pane)
-                                :test (list-pane-test pane)))
+                                   :test (list-pane-test pane)))
                        (values highlight-ink (pane-background pane)))
                       (t (values (pane-background pane) (pane-foreground pane))))
               (draw-rectangle* pane rx0 y0 rx1 y1 :filled t :ink background)
@@ -2316,15 +1185,15 @@ Returns two values, the item itself, and the index within the item list."
   (declare (ignore mx))
   (with-bounding-rectangle* (sx0 sy0 sx1 sy1)  (sheet-region pane)
     (declare (ignorable sx0 sx1 sy1))
-      (with-slots (items) pane
-        (let* ((item-height (generic-list-pane-item-height pane))
-               (number-of-items (generic-list-pane-items-length pane))
-               (n (+ (items-origin pane) (floor (- my sy0) item-height)))
-               (index (and (>= n 0)
-                           (< n number-of-items)
-                           n))
-               (item-value (and index (elt (generic-list-pane-item-values pane) index))))
-          (values item-value index)))))
+    (with-slots (items) pane
+      (let* ((item-height (generic-list-pane-item-height pane))
+             (number-of-items (generic-list-pane-items-length pane))
+             (n (+ (items-origin pane) (floor (- my sy0) item-height)))
+             (index (and (>= n 0)
+                         (< n number-of-items)
+                         n))
+             (item-value (and index (elt (generic-list-pane-item-values pane) index))))
+        (values item-value index)))))
 
 (defun generic-list-pane-handle-click (pane x y modifier)
   (multiple-value-bind (item-value index)
@@ -2393,10 +1262,10 @@ Returns two values, the item itself, and the index within the item list."
   (let ((ptype (funcall (list-pane-presentation-type-key pane) item)))
     (when ptype
       (let ((presentation
-             (make-instance 'ad-hoc-presentation
-               :object (funcall (list-pane-value-key pane) item)
-               :single-box t
-               :type ptype)))
+              (make-instance 'ad-hoc-presentation
+                             :object (funcall (list-pane-value-key pane) item)
+                             :single-box t
+                             :type ptype)))
         (call-presentation-menu
          presentation
          *input-context*
@@ -2440,7 +1309,7 @@ if INVOKE-CALLBACK is given."))
     (newval (pane meta-list-pane) &key invoke-callback)
   (when (slot-boundp pane 'value)
     (let ((new-values
-           (coerce (climi::generic-list-pane-item-values pane) 'list))
+            (coerce (climi::generic-list-pane-item-values pane) 'list))
           (test (list-pane-test pane)))
       (setf (gadget-value pane :invoke-callback invoke-callback)
             (if (list-pane-exclusive-p pane)
@@ -2497,9 +1366,9 @@ if INVOKE-CALLBACK is given."))
   (flet ((label (value) (funcall (list-pane-name-key pane) (option-pane-evil-backward-map pane value))))
     (if (list-pane-exclusive-p pane)
         (if (or value
-              (member nil (list-pane-items pane) ;; Kludge in case NIL is part of the item set..
-                      :key (list-pane-value-key pane)
-                      :test (list-pane-test pane)))
+                (member nil (list-pane-items pane) ;; Kludge in case NIL is part of the item set..
+                        :key (list-pane-value-key pane)
+                        :test (list-pane-test pane)))
             (label value)
             "")
         (cond ((= 0 (length value)) "")
@@ -2546,13 +1415,13 @@ if INVOKE-CALLBACK is given."))
   (let* ((dx -4)
          (dy 4)
          (shape
-          (if (eq direction :up)  ;; Hack-p?
-              (list x0 y0
-                    (+ x0 dx) (+ 1 y0 dy)
-                    (- x0 dx) (+ 1 y0 dy))
-              (list x0 y0
-                    (+ 1 x0 dx) (+ y0 (- dy))
-                    (- x0 dx)   (+ y0 (- dy))))))
+           (if (eq direction :up)  ;; Hack-p?
+               (list x0 y0
+                     (+ x0 dx) (+ 1 y0 dy)
+                     (- x0 dx) (+ 1 y0 dy))
+               (list x0 y0
+                     (+ 1 x0 dx) (+ y0 (- dy))
+                     (- x0 dx)   (+ y0 (- dy))))))
     (draw-polygon* sheet shape :ink +black+)))
 
 (defun generic-option-pane-compute-max-label-width (pane)
@@ -2594,7 +1463,7 @@ if INVOKE-CALLBACK is given."))
       (let ((center (floor (/ (- y1 y0) 2)))
             (height/2 (/ widget-height 2))
             (highlight-color (compose-over (compose-in +white+ (make-opacity 0.85))
-                                        (pane-background pane)))
+                                           (pane-background pane)))
             (shadow-color (compose-over (compose-in +black+ (make-opacity 0.3))
                                         (pane-background pane))))
         (draw-engraved-vertical-separator pane
@@ -2645,21 +1514,21 @@ if INVOKE-CALLBACK is given."))
         (cond ((and (<= polite-ts height)
                     (<= polite-bs height))
                (multiple-value-call #'values t
-                                    (if (> top-space bottom-space)
-                                        (values :above (* 0.7 top-space))
-                                        (values :below (* 0.7 bottom-space)))))
+                 (if (> top-space bottom-space)
+                     (values :above (* 0.7 top-space))
+                     (values :below (* 0.7 bottom-space)))))
               ((> polite-bs height) (values nil :below height))
               (t (values nil :above height)))))))
 
 (defun popup-init (parent manager frame)
   (let ((list-pane (apply #'make-pane-1 manager frame 'generic-list-pane
-                                :items (list-pane-items parent)
-                                :mode  (list-pane-mode parent)
-                                :name-key (list-pane-name-key parent)
-                                :value-key (list-pane-value-key parent)
-                                :test (list-pane-test parent)
-                                (and (slot-boundp parent 'value)
-                                     (list :value (gadget-value parent))))))
+                          :items (list-pane-items parent)
+                          :mode  (list-pane-mode parent)
+                          :name-key (list-pane-name-key parent)
+                          :value-key (list-pane-value-key parent)
+                          :test (list-pane-test parent)
+                          (and (slot-boundp parent 'value)
+                               (list :value (gadget-value parent))))))
     (multiple-value-bind (scroll-p position height)
         (popup-compute-height parent list-pane)
       (with-bounding-rectangle* (cx0 cy0 cx1 cy1) parent
@@ -2676,7 +1545,7 @@ if INVOKE-CALLBACK is given."))
                                                :suggested-height height
                                                :suggested-width (if scroll-p (+ 30 (bounding-rectangle-width list-pane))))
                                      list-pane)
-                                  list-pane))
+                                   list-pane))
                  (topmost-pane    (outlining (:thickness 1) topmost-pane))
                  (composed-height (space-requirement-height (compose-space topmost-pane :width (- x1 x0) :height height)))
                  (menu-frame      (make-menu-frame topmost-pane
@@ -2693,7 +1562,7 @@ if INVOKE-CALLBACK is given."))
          ;; Popup state
          (final-change nil) ;; Menu should exit after next value change
          (inner-grab nil)    ;; Gadget is grabbing the pointer, used to simulate
-                             ;; X implicit pointer grabbing (for the scrollbar)
+         ;; X implicit pointer grabbing (for the scrollbar)
          (retain-value nil)
          (consume-and-exit nil) ;; If true, wait until a button release then exit
          (last-click-time nil)
@@ -2703,7 +1572,7 @@ if INVOKE-CALLBACK is given."))
           (popup-init parent manager frame)
         (setf (slot-value list-pane 'armed) t)
         (adopt-frame manager menu-frame)
-	(enable-frame menu-frame)
+        (enable-frame menu-frame)
         (labels ((in-window (window child x y)
                    (and window
                         (sheet-ancestor-p child window)
@@ -2732,50 +1601,50 @@ if INVOKE-CALLBACK is given."))
 
             (tracking-pointer (list-pane :multiple-window t :highlight nil)
               (:pointer-motion (&key event window x y)
-                 (cond (inner-grab (handle-event inner-grab (rewrite-event-for-grab inner-grab event)))
-                       ((and (list-pane-exclusive-p parent)
-                             (in-list window x y))
-                        (generic-list-pane-handle-click list-pane x y 0))
-                       ((in-menu window x y)
-                        (handle-event window event))))
+                               (cond (inner-grab (handle-event inner-grab (rewrite-event-for-grab inner-grab event)))
+                                     ((and (list-pane-exclusive-p parent)
+                                           (in-list window x y))
+                                      (generic-list-pane-handle-click list-pane x y 0))
+                                     ((in-menu window x y)
+                                      (handle-event window event))))
 
               (:pointer-button-press (&key event x y)
-                 (if inner-grab
-                     (handle-event inner-grab event)
-                     (cond ((in-list (event-sheet event) x y)
-                            (multiple-value-bind (item current-index)
-                                (generic-list-pane-item-from-x-y list-pane x y)
-                              (declare (ignore item))
-                              (let ((double-clicked (and (compute-double-clicked)
-                                                         (= (or last-item-index -1)
-                                                            (or current-index -2))))
-                                    (exclusive (list-pane-exclusive-p parent)))
-                                (setf retain-value t
-                                      final-change   (or exclusive double-clicked)
-                                      last-item-index current-index
-                                      consume-and-exit (or exclusive
-                                                           (and (not exclusive)
-                                                                double-clicked)))
-                                (unless (and (not exclusive)
-                                             double-clicked)
-                                    (handle-event list-pane event)))))
-                           ((in-menu (event-sheet event) x  y)
-                            (handle-event (event-sheet event) event)
-                            (setf inner-grab (event-sheet event)))
-                           (t (setf consume-and-exit t)))))
+                                     (if inner-grab
+                                         (handle-event inner-grab event)
+                                         (cond ((in-list (event-sheet event) x y)
+                                                (multiple-value-bind (item current-index)
+                                                    (generic-list-pane-item-from-x-y list-pane x y)
+                                                  (declare (ignore item))
+                                                  (let ((double-clicked (and (compute-double-clicked)
+                                                                             (= (or last-item-index -1)
+                                                                                (or current-index -2))))
+                                                        (exclusive (list-pane-exclusive-p parent)))
+                                                    (setf retain-value t
+                                                          final-change   (or exclusive double-clicked)
+                                                          last-item-index current-index
+                                                          consume-and-exit (or exclusive
+                                                                               (and (not exclusive)
+                                                                                    double-clicked)))
+                                                    (unless (and (not exclusive)
+                                                                 double-clicked)
+                                                      (handle-event list-pane event)))))
+                                               ((in-menu (event-sheet event) x  y)
+                                                (handle-event (event-sheet event) event)
+                                                (setf inner-grab (event-sheet event)))
+                                               (t (setf consume-and-exit t)))))
 
               (:pointer-button-release (&key event x y)
-                (when consume-and-exit (end-it))
-                (cond (inner-grab
-                       (handle-event inner-grab event)
-                       (setf inner-grab nil))
-                      ((in-list (event-sheet event) x y)
-                       (when (list-pane-exclusive-p parent)
-                         (setf retain-value t
-                               final-change t)
-                         (handle-event list-pane event)))
-                      ((in-menu (event-sheet event) x y)
-                       (handle-event (event-sheet event) event)))))))
+                                       (when consume-and-exit (end-it))
+                                       (cond (inner-grab
+                                              (handle-event inner-grab event)
+                                              (setf inner-grab nil))
+                                             ((in-list (event-sheet event) x y)
+                                              (when (list-pane-exclusive-p parent)
+                                                (setf retain-value t
+                                                      final-change t)
+                                                (handle-event list-pane event)))
+                                             ((in-menu (event-sheet event) x y)
+                                              (handle-event (event-sheet event) event)))))))
         ;; Cleanup and exit
         (when retain-value
           (setf (gadget-value parent :invoke-callback t)
@@ -2867,14 +1736,14 @@ if INVOKE-CALLBACK is given."))
          (sr (compose-space child))
          (width  (space-requirement-width sr))
          (height (space-requirement-height sr)))
-    (multiple-value-bind (x y)(output-record-position record)
+    (multiple-value-bind (x y) (output-record-position record)
       (setf (rectangle-edges* record) (values x y (+ x width) (+ y height)))
-    (when t ; :move-cursor t
-      ;; Almost like LWW, except baseline of text should align with bottom
-      ;; of gadget? FIXME
-      (setf (stream-cursor-position sheet)
-            (values (+ x (bounding-rectangle-width record))
-                    (+ y (bounding-rectangle-height record))))))))
+      (when t ; :move-cursor t
+        ;; Almost like LWW, except baseline of text should align with bottom
+        ;; of gadget? FIXME
+        (setf (stream-cursor-position sheet)
+              (values (+ x (bounding-rectangle-width record))
+                      (+ y (bounding-rectangle-height record))))))))
 
 ;; The CLIM 2.0 spec does not really say what this macro should return.
 ;; Existing code written for "Real CLIM" assumes it returns the gadget pane
@@ -2901,10 +1770,10 @@ if INVOKE-CALLBACK is given."))
                         (with-output-as-gadget-body ,stream)))))
          (declare (dynamic-extent #'with-output-as-gadget-continuation))
          (let ((,gadget-output-record
-                (invoke-with-output-to-output-record
-                 ,stream
-                 #'with-output-as-gadget-continuation
-                 'gadget-output-record ,@options :x ,x :y ,y)))
+                 (invoke-with-output-to-output-record
+                  ,stream
+                  #'with-output-as-gadget-continuation
+                  'gadget-output-record ,@options :x ,x :y ,y)))
            (setup-gadget-record ,stream ,gadget-output-record)
            (stream-add-output-record ,stream ,gadget-output-record)
            (values (gadget ,gadget-output-record) ,gadget-output-record))))))
@@ -2968,7 +1837,7 @@ it in a layout between two panes that are to be resizeable.  E.g.:
     (multiple-value-bind (left right)
         (loop for (first second third) on (box-layout-mixin-clients parent)
               when (eq gadget (box-client-pane second))
-              do (return (values first third)))
+                do (return (values first third)))
       (labels ((sheet-size (sheet)
                  (ecase orientation
                    (:vertical (bounding-rectangle-width sheet))

--- a/Core/clim-core/gadgets/drawing-utilities.lisp
+++ b/Core/clim-core/gadgets/drawing-utilities.lisp
@@ -1,0 +1,340 @@
+(in-package #:climi)
+
+;;;;
+;;;;  Drawing Utilities for Concrete Gadgets
+;;;;
+
+;;; Labels
+
+(defgeneric compose-label-space (gadget &key wider higher)
+  (:method  ((gadget labelled-gadget-mixin) &key (wider 0) (higher 0))
+    (with-slots (label align-x align-y) gadget
+      (let* ((text-style (pane-text-style gadget))
+             (as (text-style-ascent text-style gadget))
+             (ds (text-style-descent text-style gadget))
+             (w  (+ (text-size gadget label :text-style text-style) wider))
+             (h  (+ as ds higher)))
+        (make-space-requirement :width w  :min-width w  :max-width  +fill+
+                                :height h :min-height h :max-height +fill+)))))
+
+(defgeneric draw-label* (pane x1 y1 x2 y2 &key ink)
+  (:method ((pane labelled-gadget-mixin) x1 y1 x2 y2
+            &key (ink +foreground-ink+))
+    (with-slots (align-x align-y label) pane
+      (let* ((text-style (pane-text-style pane))
+             (as (text-style-ascent text-style pane))
+             (ds (text-style-descent text-style pane))
+             (w  (text-size pane label :text-style text-style)))
+        (draw-text* pane label
+                    (case align-x
+                      ((:left) x1)
+                      ((:right) (- x2 w))
+                      ((:center) (/ (+ x1 x2 (- w)) 2))
+                      (otherwise x1))  ;defensive programming
+                    (case align-y
+                      ((:top) (+ y1 as))
+                      ((:center) (/ (+ y1 y2 (- as ds)) 2))
+                      ((:bottom) (- y2 ds))
+                      (otherwise (/ (+ y1 y2 (- as ds)) 2))) ;defensive programming
+                    ;; Giving the text-style here shouldn't be neccessary --GB
+                    :text-style text-style
+                    :ink ink)))))
+
+;;; 3D-ish Look
+
+;; DRAW-BORDERED-POLYGON medium point-seq &key border-width style
+;;
+;; -GB
+
+(labels ((line-hnf (x1 y1 x2 y2)
+           (values (- y2 y1) (- x1 x2) (- (* x1 y2) (* y1 x2))))
+
+         (line-line-intersection (x1 y1 x2 y2 x3 y3 x4 y4)
+           (multiple-value-bind (a1 b1 c1) (line-hnf x1 y1 x2 y2)
+             (multiple-value-bind (a2 b2 c2) (line-hnf x3 y3 x4 y4)
+               (let ((d (- (* a1 b2) (* b1 a2))))
+                 (cond ((< (abs d) 1e-6)
+                        nil)
+                       (t
+                        (values (/ (- (* b2 c1) (* b1 c2)) d)
+                                (/ (- (* a1 c2) (* a2 c1)) d))))))))
+
+         (polygon-orientation (point-seq)
+           "Determines the polygon's orientation.
+            Returns:  +1 = counter-clock-wise
+                      -1 = clock-wise
+
+            The polygon should be clean from duplicate points or co-linear points.
+            If the polygon self intersects, the orientation may not be defined, this
+            function does not try to detect this situation and happily returns some
+            value."
+           ;;
+           (let ((n (length point-seq)))
+             (let* ((min-i 0)
+                    (min-val (point-x (elt point-seq min-i))))
+               ;;
+               (loop for i from 1 below n do
+                 (when (< (point-x (elt point-seq i)) min-val)
+                   (setf min-val (point-x (elt point-seq i))
+                         min-i i)))
+               ;;
+               (let ((p0 (elt point-seq (mod (+ min-i -1) n)))
+                     (p1 (elt point-seq (mod (+ min-i 0) n)))
+                     (p2 (elt point-seq (mod (+ min-i +1) n))))
+                 (signum (- (* (- (point-x p2) (point-x p0)) (- (point-y p1) (point-y p0)))
+                            (* (- (point-x p1) (point-x p0)) (- (point-y p2) (point-y p0)))))))))
+
+         (clean-polygon (point-seq)
+           "Cleans a polygon from duplicate points and co-linear points. Furthermore
+            tries to bring it into counter-clock-wise orientation."
+           ;; first step: remove duplicates
+           (setf point-seq
+                 (let ((n (length point-seq)))
+                   (loop for i from 0 below n
+                         for p0 = (elt point-seq (mod (+ i -1) n))
+                         for p1 = (elt point-seq (mod (+ i 0) n))
+                         unless (and (< (abs (- (point-x p0) (point-x p1))) 10e-8)
+                                     (< (abs (- (point-y p0) (point-y p1))) 10e-8))
+                           collect p1)))
+           ;; second step: remove colinear points
+           (setf point-seq
+                 (let ((n (length point-seq)))
+                   (loop for i from 0 below n
+                         for p0 = (elt point-seq (mod (+ i -1) n))
+                         for p1 = (elt point-seq (mod (+ i 0) n))
+                         for p2 = (elt point-seq (mod (+ i +1) n))
+                         unless (< (abs (- (* (- (point-x p1) (point-x p0)) (- (point-y p2) (point-y p0)))
+                                           (* (- (point-x p2) (point-x p0)) (- (point-y p1) (point-y p0)))))
+                                   10e-8)
+                           collect p1)))
+           ;; third step: care for the orientation
+           (if (and (not (null point-seq))
+                    (minusp (polygon-orientation point-seq)))
+               (reverse point-seq)
+               point-seq) ))
+
+  (defun shrink-polygon (point-seq width)
+    (let ((point-seq (clean-polygon point-seq)))
+      (let ((n (length point-seq)))
+        (values
+         point-seq
+         (loop for i from 0 below n
+               for p0 = (elt point-seq (mod (+ i -1) n))
+               for p1 = (elt point-seq (mod (+ i  0) n))
+               for p2 = (elt point-seq (mod (+ i +1) n))
+               collect
+               (let* ((dx1 (- (point-x p1) (point-x p0)))
+                      (dy1 (- (point-y p1) (point-y p0)))
+                      (dx2 (- (point-x p2) (point-x p1)))
+                      (dy2 (- (point-y p2) (point-y p1)))
+                      ;;
+                      (m1  (/ width (sqrt (+ (* dx1 dx1) (* dy1 dy1)))))
+                      (m2  (/ width (sqrt (+ (* dx2 dx2) (* dy2 dy2)))))
+                      ;;
+                      (q0  (make-point (+ (point-x p0) (* m1 dy1))
+                                       (- (point-y p0) (* m1 dx1))))
+                      (q1  (make-point (+ (point-x p1) (* m1 dy1))
+                                       (- (point-y p1) (* m1 dx1))))
+                      (q2  (make-point (+ (point-x p1) (* m2 dy2))
+                                       (- (point-y p1) (* m2 dx2))))
+                      (q3  (make-point (+ (point-x p2) (* m2 dy2))
+                                       (- (point-y p2) (* m2 dx2)))) )
+                 ;;
+                 (multiple-value-bind (x y)
+                     (multiple-value-call #'line-line-intersection
+                       (point-position q0) (point-position q1)
+                       (point-position q2) (point-position q3))
+                   (if x
+                       (make-point x y)
+                       (make-point 0 0)))))))))
+
+  (defun draw-bordered-polygon (medium point-seq
+                                &key (border-width 2)
+                                  (style        :inset))
+    (labels ((draw-pieces (outer-points inner-points dark light)
+               (let ((n (length outer-points)))
+                 (dotimes (i n)
+                   (let* ((p1 (elt outer-points (mod (+ i  0) n)))
+                          (p2 (elt outer-points (mod (+ i +1) n)))
+                          (q1 (elt inner-points (mod (+ i  0) n)))
+                          (q2 (elt inner-points (mod (+ i +1) n)))
+                          (p1* (transform-region +identity-transformation+  p1))
+                          (p2* (transform-region +identity-transformation+  p2))
+                          (a (mod (atan (- (point-y p2*) (point-y p1*))
+                                        (- (point-x p2*) (point-x p1*)))
+                                  (* 2 pi))))
+                     (draw-polygon medium (list p1 q1 q2 p2)
+                                   :ink
+                                   (if (<= (* 1/4 pi) a (* 5/4 pi))
+                                       dark light)))))))
+      (let ((light  *3d-light-color*)
+            (dark   *3d-dark-color*))
+        ;;
+        (ecase style
+          (:solid
+           (multiple-value-call #'draw-pieces (shrink-polygon point-seq border-width)
+             +black+ +black+))
+          (:inset
+           (multiple-value-call #'draw-pieces (shrink-polygon point-seq border-width)
+             dark light))
+          (:outset
+           (multiple-value-call #'draw-pieces (shrink-polygon point-seq border-width)
+             light dark))
+          ;;
+          ;; Mickey Mouse is the trademark of the Walt Disney Company.
+          ;;
+          (:mickey-mouse-outset
+           (multiple-value-bind (outer-points inner-points)
+               (shrink-polygon point-seq border-width)
+             (declare (ignore outer-points))
+             (multiple-value-bind (outer-points middle-points)
+                 (shrink-polygon point-seq (/ border-width 2))
+               (draw-pieces outer-points middle-points +white+ +black+)
+               (draw-pieces middle-points inner-points light dark))))
+          (:mickey-mouse-inset
+           (multiple-value-bind (outer-points inner-points)
+               (shrink-polygon point-seq border-width)
+             (declare (ignore outer-points))
+             (multiple-value-bind (outer-points middle-points)
+                 (shrink-polygon point-seq (/ border-width 2))
+               (draw-pieces outer-points middle-points dark light)
+               (draw-pieces middle-points inner-points +black+ +white+))))
+          ;;
+          (:ridge
+           (multiple-value-bind (outer-points inner-points)
+               (shrink-polygon point-seq border-width)
+             (declare (ignore outer-points))
+             (multiple-value-bind (outer-points middle-points)
+                 (shrink-polygon point-seq (/ border-width 2))
+               (draw-pieces outer-points middle-points light dark)
+               (draw-pieces middle-points inner-points dark light))))
+          (:groove
+           (multiple-value-bind (outer-points inner-points)
+               (shrink-polygon point-seq border-width)
+             (declare (ignore outer-points))
+             (multiple-value-bind (outer-points middle-points)
+                 (shrink-polygon point-seq (/ border-width 2))
+               (draw-pieces outer-points middle-points dark light)
+               (draw-pieces middle-points inner-points light dark))))
+          (:double
+           (multiple-value-bind (outer-points inner-points)
+               (shrink-polygon point-seq border-width)
+             (declare (ignore outer-points))
+             (multiple-value-bind (outer-points imiddle-points)
+                 (shrink-polygon point-seq (* 2/3 border-width))
+               (declare (ignore outer-points))
+               (multiple-value-bind (outer-points omiddle-points)
+                   (shrink-polygon point-seq (* 1/3 border-width))
+                 (draw-pieces outer-points omiddle-points +black+ +black+)
+                 (draw-pieces imiddle-points inner-points +black+ +black+))))))))) )
+
+(defun draw-bordered-rectangle* (medium x1 y1 x2 y2 &rest options)
+  (apply #'draw-bordered-polygon
+         medium
+         (polygon-points (make-rectangle* x1 y1 x2 y2))
+         options))
+
+(defun draw-engraved-label* (pane x1 y1 x2 y2)
+  (draw-label* pane (1+ x1) (1+ y1) (1+ x2) (1+ y2) :ink *3d-light-color*)
+  (draw-label* pane x1 y1 x2 y2 :ink *3d-dark-color*))
+
+;;;;
+;;;; 3D-BORDER-MIXIN Class
+;;;;
+
+;; 3D-BORDER-MIXIN class can be used to add a 3D-ish border to
+;; panes. There are three new options:
+;;
+;;  :border-width       The width of the border
+;;  :border-style       The border's style one of :inset, :outset, :groove, :ridge, :solid,
+;;                      :double, :dotted, :dashed
+;;                      [:dotted and :dashed are not yet implemented]
+;;
+;;  :border-color       The border's color
+;;                      [Not implemented yet]
+;;
+;; [These options are modelled after CSS].
+;;
+;; When using 3D-BORDER-MIXIN, one should query the pane's inner
+;; region, where drawing should take place, by PANE-INNER-REGION.
+;;
+;; --GB
+
+(defclass 3D-border-mixin ()
+  ((border-width :initarg :border-width :initform 2)
+   (border-style :initarg :border-style :initform :outset)
+   (border-color :initarg :border-color :initform "???")))
+
+(defgeneric pane-inner-region (pane)
+  (:method  ((pane 3D-border-mixin))
+    (with-slots (border-width) pane
+      (with-bounding-rectangle* (x1 y1 x2 y2) (sheet-region pane)
+        (make-rectangle* (+ x1 border-width) (+ y1 border-width)
+                         (- x2 border-width) (- y2 border-width))))))
+
+(defmethod handle-repaint :after ((pane 3D-border-mixin) region)
+  (declare (ignore region))
+  (with-slots (border-width border-style) pane
+    (draw-bordered-polygon pane (polygon-points (bounding-rectangle (sheet-region pane)))
+                           :border-width border-width
+                           :style border-style)))
+
+(defparameter *3d-border-thickness* 2)
+
+;;; Common colors:
+
+(defgeneric gadget-highlight-background (gadget)
+  (:method ((gadget basic-gadget))
+    (compose-over (compose-in #|+paleturquoise+|# +white+ (make-opacity .5))
+                  (pane-background gadget))))
+
+(defgeneric effective-gadget-foreground (gadget)
+  (:method  ((gadget basic-gadget))
+    (if (gadget-active-p gadget)
+        +foreground-ink+
+        (compose-over (compose-in (pane-foreground gadget)
+                                  (make-opacity .5))
+                      (pane-background gadget)))))
+
+(defgeneric effective-gadget-background (gadget)
+  (:method  ((gadget basic-gadget))
+    (if (slot-value gadget 'armed)
+        (gadget-highlight-background gadget)
+        (pane-background gadget))))
+
+(defgeneric effective-gadget-input-area-color (gadget)
+  (:method  ((gadget basic-gadget))
+    (if (gadget-active-p gadget)
+        +lemonchiffon+
+        (compose-over (compose-in +lemonchiffon+ (make-opacity .5))
+                      (pane-background gadget)))))
+
+(defparameter *3d-border-thickness* 2)
+
+;;; Common colors:
+
+(defgeneric gadget-highlight-background (gadget)
+  (:method ((gadget basic-gadget))
+    (compose-over (compose-in #|+paleturquoise+|# +white+ (make-opacity .5))
+                  (pane-background gadget))))
+
+(defgeneric effective-gadget-foreground (gadget)
+  (:method  ((gadget basic-gadget))
+    (if (gadget-active-p gadget)
+        +foreground-ink+
+        (compose-over (compose-in (pane-foreground gadget)
+                                  (make-opacity .5))
+                      (pane-background gadget)))))
+
+(defgeneric effective-gadget-background (gadget)
+  (:method  ((gadget basic-gadget))
+    (if (slot-value gadget 'armed)
+        (gadget-highlight-background gadget)
+        (pane-background gadget))))
+
+(defgeneric effective-gadget-input-area-color (gadget)
+  (:method  ((gadget basic-gadget))
+    (if (gadget-active-p gadget)
+        +lemonchiffon+
+        (compose-over (compose-in +lemonchiffon+ (make-opacity .5))
+                      (pane-background gadget)))))

--- a/Core/clim-core/gadgets/mixins.lisp
+++ b/Core/clim-core/gadgets/mixins.lisp
@@ -1,0 +1,87 @@
+(in-package #:climi)
+
+;;;;
+;;;;  Mixin Classes for Concrete Gadgets
+;;;;
+
+;;;; Redrawing mixins
+
+(defclass arm/disarm-repaint-mixin ()
+  ()
+  (:documentation
+   "Mixin class for gadgets, whose appearence depends on its armed state."))
+
+(defmethod armed-callback :after ((gadget arm/disarm-repaint-mixin) client id)
+  (declare (ignore client id))
+  (dispatch-repaint gadget (or (pane-viewport-region gadget)
+                               (sheet-region gadget))))
+
+(defmethod disarmed-callback :after ((gadget arm/disarm-repaint-mixin) client id)
+  (declare (ignore client id))
+  (dispatch-repaint gadget (or (pane-viewport-region gadget)
+                               (sheet-region gadget))))
+
+(defclass activate/deactivate-repaint-mixin ()
+  ()
+  (:documentation
+   "Mixin class for gadgets, whose appearence depends on its activatated state."))
+
+(defmethod activate-gadget :after ((gadget activate/deactivate-repaint-mixin))
+  (dispatch-repaint gadget (or (pane-viewport-region gadget)
+                               (sheet-region gadget))))
+
+(defmethod deactivate-gadget :after ((gadget activate/deactivate-repaint-mixin))
+  (dispatch-repaint gadget (or (pane-viewport-region gadget)
+                               (sheet-region gadget))))
+
+(defclass value-changed-repaint-mixin ()
+  ()
+  (:documentation
+   "Mixin class for gadgets, whose appearence depends on its value."))
+
+(defmethod (setf gadget-value) :after (new-value (gadget value-changed-repaint-mixin)
+                                       &key &allow-other-keys)
+  (declare (ignore new-value))
+  (dispatch-repaint gadget (or (pane-viewport-region gadget)
+                               (sheet-region gadget))))
+
+;;;; Event handling mixins
+
+(defclass enter/exit-arms/disarms-mixin ()
+  ()
+  (:documentation
+   "Mixin class for gadgets which are armed when the mouse enters and
+    disarmed when the mouse leaves."))
+
+(defmethod handle-event :before ((pane enter/exit-arms/disarms-mixin) (event pointer-enter-event))
+  (declare (ignorable event))
+  (arm-gadget pane))
+
+(defmethod handle-event :after ((pane enter/exit-arms/disarms-mixin) (event pointer-exit-event))
+  (declare (ignorable event))
+  (disarm-gadget pane))
+
+;;;; changing-label-invokes-layout-protocol-mixin
+
+(defclass changing-label-invokes-layout-protocol-mixin ()
+  ()
+  (:documentation
+   "Mixin class for gadgets, which want invoke the layout protocol, if the label changes."))
+
+;;;; Common behavior on `basic-gadget'
+
+;;
+;; When a gadget is not activated, it receives no device events.
+;;
+(defmethod handle-event :around ((pane basic-gadget) (event device-event))
+  (when (gadget-active-p pane)
+    (call-next-method)))
+
+;; When a gadget is deactivated, it cannot be armed.
+
+;; Glitch: upon re-activation the mouse might happen to be in the
+;; gadget and thus re-arm it immediately, that is not implemented.
+
+(defmethod note-gadget-deactivated :after (client (gadget basic-gadget))
+  (declare (ignorable client))
+  (disarm-gadget gadget))


### PR DESCRIPTION
Put gadgets in a separate module. It is a self-contained changed factored out from a local branch for adding themes to frame managers. No functional change is expected – all changes were a typical cleanup without adding or removing interfaces. Only slots from the protocol class gadget has been moved to a basic-gadget.