### PR TITLE
Fix bug in presentation-type-history that causes infinite loop if the…

### DIFF
--- a/Core/clim-core/presentation-defs.lisp
+++ b/Core/clim-core/presentation-defs.lisp
@@ -548,8 +548,6 @@ a specific type."))
                        (gethash name history-table)
                        history-object))
                history-object))
-	    ;; This used to be just nil, which in SBCL and Allegro (at least)
-	    ;; never matches.  You have to put it inside parens
             ((nil)
              nil)
             (otherwise

--- a/Core/clim-core/presentation-defs.lisp
+++ b/Core/clim-core/presentation-defs.lisp
@@ -548,7 +548,9 @@ a specific type."))
                        (gethash name history-table)
                        history-object))
                history-object))
-            (nil
+	    ;; This used to be just nil, which in SBCL and Allegro (at least)
+	    ;; never matches.  You have to put it inside parens
+            ((nil)
              nil)
             (otherwise
              (funcall-presentation-generic-function presentation-type-history


### PR DESCRIPTION
In define-default-presentation-method presentation-type-history (type)

If the type doesn't have a history then this method will go into an infinite loop.  The reason is that in the original of this case statement, in 2nd clause was (nil not ((nil) ; that never matches and so you go onto the otherwise clause which is a recursive call.

 (case history
            ((t)
             ...
	    ;; This used to be just nil, which in SBCL and Allegro (at least)
	    ;; never matches.  You have to put it inside parens
            ((nil)
             nil)
            (otherwise
             (funcall-presentation-generic-function presentation-type-history
                                                    type)))
