### PR TITLE
Fix command menu bug

### DIFF
--- a/Core/clim-core/commands.lisp
+++ b/Core/clim-core/commands.lisp
@@ -1300,55 +1300,29 @@ examine the type of the command menu item to see if it is
 (define-presentation-method accept ((type command) stream
 				    (view textual-view)
 				    &key)
-  (let ((command (funcall *command-parser* command-table stream)))
-    (cond ((null command)
-	   (simple-parse-error "Empty command"))
-          ((partial-command-p command)
-           (funcall *partial-command-parser*
-            command-table stream command
-            (position *unsupplied-argument-marker* command)))
-	  (t (values command type)))))
-
-(define-presentation-method accept ((type command) stream
-				    (view textual-view)
-				    &key)
   (setq command-table (find-command-table command-table))
   (let ((start-position (and (input-editing-stream-p stream)
                              (stream-scan-pointer stream)))
-        ;; this also requires some thought, but I suspect that
-        ;; we can just kludge it this way in this presentation type,
-        ;; because we can't think of any other presentation types
-        ;; that would establish a shadowing context within the one
-        ;; established by ACCEPT-1.
         (replace-input-p nil))
     (multiple-value-bind (object new-type)
         ;; We establish a new input context so that clicks throw to us
-        ;; rather than to the input context established in ACCEPT-1.
         ;; This will let's us handle "partial commands" below.
-        ;; The "partial" notion could be extended to apply to all
-        ;; presentation-types, but there are so few which need this
-        ;; treatment, that it does not seem worthwhile.
         (with-input-context (type :override nil)
 	    (object presentation-type event options)
 	    (funcall *command-parser* command-table stream)
 	  (t 
 	     (when (getf options :echo t)
 	       (setq replace-input-p t))
-	     (values object type)))
-      (declare (ignore new-type))
+	     (values object presentation-type)))
       (cond ((partial-command-p object)
-	     ;; (command-table stream partial-command start-position)
              (values (funcall *partial-command-parser*
                               command-table stream object start-position)
                      type))
             (t (when replace-input-p
                  (presentation-replace-input stream object type view
                                              :buffer-start start-position
-                                             ;;--- We really need to pass the
-                                             ;;--- query-identifier to the parser.
-					; :query-identifier query-identifier
                                              ))
-               (values object type))))))
+               (values object new-type))))))
 
 
 ;;; A presentation type for empty input at the command line; something for

--- a/Core/clim-core/commands.lisp
+++ b/Core/clim-core/commands.lisp
@@ -49,7 +49,7 @@
   ((menu-name :reader command-menu-item-name :initarg :menu-name)
    (type :initarg :type :reader command-menu-item-type)
    (value :initarg :value :reader command-menu-item-value)
-   (documentation :initarg :documentation)
+   (documentation :initarg :documentation :initform nil)
    (text-style :initarg :text-style :initform nil)
    (keystroke :initarg :keystroke)))
 

--- a/Core/clim-core/gadgets/menu.lisp
+++ b/Core/clim-core/gadgets/menu.lisp
@@ -421,7 +421,9 @@ account, and create a list of menu buttons."
 	       (with-presentation-type-parameters (command context-type)
 		 (present (list command-name) `command :stream stream)))))))
     (object)
-  (command-menu-item-value object))
+  (values (command-menu-item-value object)
+	  `(command :command-table ,(frame-command-table *application-frame*))
+  	  ))
 
 
 


### PR DESCRIPTION
Context: an application frame with both a command menu pane and a pointer-documentation pane and where some command in the menu has arguments.  This happens specifically when one of the arguments is expected to be a data-structure (other than a symbol).

1) If the mouse just moves over this menu item can cause an error.  The reason is that the menu items are presented as commands; when the mouse moves over the menu-item the pointer-documentation is updated by calling present on this command.  This recursively calls present on each of the arguments.  One of these (sub) presentation methods might attempt to perform an operation on its argument; but in fact it is passed the symbol for undefined arguments, even though the presentation type is the one appropriate for the command.

2) Even if moving the mouse over the menu item doesn't cause an error, you get a message saying that you've provided an incomplete command, rather than calling the partial-command completer.

The fix involves:
1) Defining a new presentation-type: command-menu-item
2) Changing display-command-table-menu to present the menu elements as command-manu-item
3) Providing a presentation-translator for this presentation-type whose documentation function returns just the name of the command
(all these are in /core/clim-code/gadgets/menu

4) Changing the accept method for comand so that the body is wrapped in an with-input-context so that if a menu-item is clicked on, it can br handled specially; in particular so that the partial command parser is called.
