### PR TITLE
text-style-mapping: do not cache partially specified text styles

### DIFF
--- a/Backends/common/fonts.lisp
+++ b/Backends/common/fonts.lisp
@@ -179,10 +179,6 @@ of letters specified in a separate kerning-table."))
 
 
 ;; clim:make-device-font-text-style
-(defvar +font-sizes+
-  '(:normal 14 :tiny 8 :very-small 10 :small 12 :large 18 :very-large 20 :huge 24)
-  "Mapping between keyword and a font size.")
-
 (declaim (inline climb:normalize-font-size))
 (defun climb:normalize-font-size (size)
   (cond ((numberp size)

--- a/Backends/common/mcclim-backend-common.asd
+++ b/Backends/common/mcclim-backend-common.asd
@@ -1,8 +1,18 @@
 (cl:in-package #:asdf-user)
 
-(defsystem #:mcclim-backend-common
-  :depends-on (#:clim)
-  :components
-  ((:file "ports")
-   (:file "fonts")
-   (:file "medium" :depends-on ("fonts"))))
+(defsystem "mcclim-backend-common"
+  :depends-on ("clim")
+  :components ((:file "ports")
+               (:file "fonts")
+               (:file "medium" :depends-on ("fonts")))
+  :in-order-to ((test-op (test-op "mcclim-backend-common/test"))))
+
+(defsystem "mcclim-backend-common/test"
+  :depends-on ("mcclim-backend-common"
+               "fiveam")
+  :components ((:module "test"
+                :serial t
+                :components ((:file "package")
+                             (:file "fonts"))))
+  :perform (test-op (operation component)
+             (uiop:symbol-call '#:mcclim-backend-common.test '#:run-tests)))

--- a/Backends/common/test/fonts.lisp
+++ b/Backends/common/test/fonts.lisp
@@ -1,0 +1,50 @@
+;;;;  (c) copyright 2020 Jan Moringen
+;;;;
+;;;; This library is free software; you can redistribute it and/or
+;;;; modify it under the terms of the GNU Library General Public
+;;;; License as published by the Free Software Foundation; either
+;;;; version 2 of the License, or (at your option) any later version.
+;;;;
+;;;; This library is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;;;; Library General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU Library General Public
+;;;; License along with this library; if not, write to the
+;;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;;;; Boston, MA  02111-1307  USA.
+
+(in-package #:mcclim-backend-common.test)
+
+(in-suite :mcclim-backend-common)
+
+(test parse-text-style*.smoke
+  "Smoke test for the `parse-text-style*' function."
+
+  (mapc (lambda (input-and-expected)
+          (destructuring-bind (input &optional (expected t))
+              input-and-expected
+            (case expected
+              ((t :no-op)
+               (let ((result (climi::parse-text-style* input)))
+                 (is-true (text-style-p result))
+                 (is-true (climi::text-style-fully-specified-p result))
+                 (when (eq expected :no-op)
+                   (is (eq input result)))))
+              (error
+               (signals error (climi::parse-text-style* input))))))
+        `(;; Invalid text style specifications
+          (1                 error)
+          ((nil nil)         error)
+          ((nil nil nil nil) error)
+          ;; Valid ones
+          (nil)
+          ((nil nil nil))
+          (,(make-text-style nil nil nil))
+          (,(make-text-style :fix nil nil))
+          (,(make-text-style :fix :roman :small))
+          (,(make-text-style nil nil :smaller))
+          (,(make-text-style nil nil :larger))
+          ;; Must be returned as-is
+          (,(make-text-style :fix :roman 10) :no-op))))

--- a/Backends/common/test/package.lisp
+++ b/Backends/common/test/package.lisp
@@ -1,0 +1,32 @@
+;;;;  (c) copyright 2020 Jan Moringen
+;;;;
+;;;; This library is free software; you can redistribute it and/or
+;;;; modify it under the terms of the GNU Library General Public
+;;;; License as published by the Free Software Foundation; either
+;;;; version 2 of the License, or (at your option) any later version.
+;;;;
+;;;; This library is distributed in the hope that it will be useful,
+;;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;;;; Library General Public License for more details.
+;;;;
+;;;; You should have received a copy of the GNU Library General Public
+;;;; License along with this library; if not, write to the
+;;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;;;; Boston, MA  02111-1307  USA.
+
+(defpackage #:mcclim-backend-common.test
+  (:use
+   #:clim-lisp
+   #:clim
+   #:fiveam)
+
+  (:export
+   #:run-tests))
+
+(in-package #:mcclim-backend-common.test)
+
+(def-suite* :mcclim-backend-common)
+
+(defun run-tests ()
+  (run! :mcclim-backend-common))

--- a/Core/clim-basic/drawing/medium.lisp
+++ b/Core/clim-basic/drawing/medium.lisp
@@ -167,17 +167,21 @@
   (defconstant *smaller-sizes* '(:huge :very-large :large :normal
                                  :small :very-small :tiny :tiny))
 
+  (defconstant *larger-sizes* '(:tiny :very-small :small :normal
+                                :large :very-large :huge :huge))
+
   (defconstant *font-scaling-factor* 4/3)
   (defconstant *font-min-size* 6)
-  (defconstant *font-max-size* 48))
+  (defconstant *font-max-size* 48)
+
+  (defconstant +font-sizes+
+    '(:normal 14 :tiny 8 :very-small 10 :small 12 :large 18 :very-large 20 :huge 24)
+    "Mapping between keyword and a font size."))
 
 (defun find-smaller-size (size)
   (if (numberp size)
       (max (round (/ size *font-scaling-factor*)) *font-min-size*)
       (cadr (member size *smaller-sizes*))))
-
-(defconstant *larger-sizes* '(:tiny :very-small :small :normal
-                              :large :very-large :huge :huge))
 
 (defun find-larger-size (size)
   (if (numberp size)


### PR DESCRIPTION
*DEFAULT-TEXT-STYLE* may change and then mapping would be invalid.

Also:

- add a method to the function TEXT-STYLE-COMPONENTS specialized on
  DEVICE-FONT-TEXT-STYLE returning (values :device :device :device);
  method must be defined for all subclasses of text-style

- be more robust in parse-text-style* by returning
  DEVICE-FONT-TEXT-STYLE as is; this text style is always considered
  to be fully specified.