### PR TITLE
text-style-mapping: specialize on cons only in core

### DIFF
--- a/Backends/CLX/fonts.lisp
+++ b/Backends/CLX/fonts.lisp
@@ -41,7 +41,7 @@
     (when fonts
       (xlib:open-font display (first fonts)))))
 
-(defmethod text-style-mapping ((port clx-port) text-style &optional character-set
+(defmethod text-style-mapping ((port clx-port) (text-style text-style) &optional character-set
                                &aux (text-style (climb:parse-text-style* text-style)))
   (declare (ignore character-set))
   (labels

--- a/Backends/Null/port.lisp
+++ b/Backends/Null/port.lisp
@@ -100,13 +100,14 @@
   (make-instance 'null-medium :sheet sheet))
 
 (defmethod text-style-mapping
-    ((port null-port) text-style &optional character-set)
-  (declare (ignore text-style character-set))
+    ((port null-port) (text-style text-style) &optional character-set)
+  (declare (ignore port text-style character-set))
   nil)
 
-(defmethod (setf text-style-mapping)
-    (font-name (port null-port)
-    (text-style text-style) &optional character-set)
+(defmethod (setf text-style-mapping) (font-name
+                                      (port null-port)
+                                      (text-style text-style)
+                                      &optional character-set)
   (declare (ignore font-name text-style character-set))
   nil)
 

--- a/Backends/PostScript/font/font.lisp
+++ b/Backends/PostScript/font/font.lisp
@@ -131,7 +131,8 @@
                  (:italic . "Helvetica-Oblique")
                  ((:bold :italic) . "Helvetica-BoldOblique"))))
 
-(defmethod text-style-mapping ((port postscript-font-port) text-style
+(defmethod text-style-mapping ((port postscript-font-port)
+                               (text-style text-style)
                                &optional character-set)
   (declare (ignore character-set))
   (multiple-value-bind (family face size) (text-style-components text-style)

--- a/Core/clim-basic/drawing/medium.lisp
+++ b/Core/clim-basic/drawing/medium.lisp
@@ -230,6 +230,11 @@
   ;; text-style like other methods. -- jd 2020-01-15
   text-style)
 
+(defmethod text-style-mapping ((port basic-port)
+                               text-style
+                               &optional character-set)
+  (text-style-mapping port (parse-text-style text-style) character-set))
+
 (defmethod text-style-mapping :around ((port basic-port)
                                        (text-style text-style)
                                        &optional character-set)
@@ -295,8 +300,9 @@
 (defun parse-text-style (style)
   (cond ((text-style-p style) style)
         ((null style) (make-text-style nil nil nil)) ; ?
-        ((and (listp style) (<= 3 (length style) 4))
-         (apply #'make-text-style style))
+        ((and (listp style) (alexandria:length= 3 style))
+         (destructuring-bind (family face size) style
+           (make-text-style family face size)))
         (t (error "Invalid text style specification ~S." style))))
 
 (defmacro with-text-style ((medium text-style) &body body)

--- a/Extensions/render/backend/port.lisp
+++ b/Extensions/render/backend/port.lisp
@@ -55,10 +55,6 @@
     (or (find-truetype-font port text-style)
         (invoke-with-truetype-path-restart #'find-font))))
 
-(defmethod text-style-mapping ((port render-port-mixin) (gs-text-style cons) &optional character-set)
-  (declare (ignore character-set))
-  (text-style-mapping port (apply #'make-text-style gs-text-style)))
-
 (defmethod clim-internals::text-style-size ((gs-text-style cons))
   (caddr gs-text-style))
 


### PR DESCRIPTION
Method specialized on cons parses the text style and calls
text-style-mapping on the parsed text style. Fixes a regression in a
demo "German Towns".