### PR TITLE
Fix problems with command-menu items that take commands

### DIFF
--- a/Core/clim-core/commands.lisp
+++ b/Core/clim-core/commands.lisp
@@ -49,7 +49,7 @@
   ((menu-name :reader command-menu-item-name :initarg :menu-name)
    (type :initarg :type :reader command-menu-item-type)
    (value :initarg :value :reader command-menu-item-value)
-   (documentation :initarg :documentation)
+   (documentation :initarg :documentation :initform nil)
    (text-style :initarg :text-style :initform nil)
    (keystroke :initarg :keystroke)))
 
@@ -1297,17 +1297,35 @@ examine the type of the command menu item to see if it is
   (declare (ignore acceptably for-context-type))
   (funcall *command-unparser* command-table stream object))
 
+
 (define-presentation-method accept ((type command) stream
 				    (view textual-view)
 				    &key)
-  (let ((command (funcall *command-parser* command-table stream)))
-    (cond ((null command)
-	   (simple-parse-error "Empty command"))
-          ((partial-command-p command)
-           (funcall *partial-command-parser*
-            command-table stream command
-            (position *unsupplied-argument-marker* command)))
-	  (t (values command type)))))
+  (setq command-table (find-command-table command-table))
+  (let ((start-position (and (input-editing-stream-p stream)
+                             (stream-scan-pointer stream)))
+        (replace-input-p nil))
+    (multiple-value-bind (object new-type)
+        ;; We establish a new input context so that clicks throw to us
+        ;; This will let's us handle "partial commands" below.
+        (with-input-context (type :override nil)
+	    (object presentation-type event options)
+	    (funcall *command-parser* command-table stream)
+	  (t
+	     (when (getf options :echo t)
+	       (setq replace-input-p t))
+	     (values object presentation-type)))
+      (cond ((partial-command-p object)
+             (values (funcall *partial-command-parser*
+                              command-table stream object start-position)
+                     type))
+            (t (when replace-input-p
+                 (presentation-replace-input stream object type view
+                                             :buffer-start start-position
+                                             ))
+               (values object new-type))))))
+
+
 
 ;;; A presentation type for empty input at the command line; something for
 ;;; read-command to supply as a default.  The command is defined in

--- a/Core/clim-core/gadgets/menu.lisp
+++ b/Core/clim-core/gadgets/menu.lisp
@@ -394,6 +394,38 @@ account, and create a list of menu buttons."
                (incf x width)
                (incf x x-spacing)))))
 
+(define-presentation-type command-menu-item ())
+
+(define-presentation-translator command-menu-item-to-command
+    (command-menu-item command global-command-table
+    :tester
+    ((object event)
+     (declare (ignore event))
+     (let* ((menu-item (command-menu-item-value object))
+	    (command-name (first menu-item))
+	    (type (command-menu-item-type object)))
+       (and (or (eq type ':command)
+		(eq type ':function))
+	    (command-enabled
+	     command-name
+	     *application-frame*))))
+      :tester-definitive t
+      ;; The pointer-documentation uses this, too
+      :documentation
+      ((object presentation context-type frame event window x y stream)
+       (declare (ignore presentation frame x y event window))
+       (let ((documentation (getf (command-menu-item-options object) :documentation)))
+	 (if documentation
+	     (write-string documentation stream)
+	     (let ((command-name (first (command-menu-item-value object))))
+	       (with-presentation-type-parameters (command context-type)
+		 (present (list command-name) `command :stream stream)))))))
+    (object)
+  (values (command-menu-item-value object)
+	  `(command :command-table ,(frame-command-table *application-frame*))
+  	  ))
+
+
 (defmethod display-command-table-menu ((command-table standard-command-table)
                                        (stream fundamental-output-stream)
                                        &rest args
@@ -419,7 +451,7 @@ account, and create a list of menu buttons."
                            stream args)))
                  ((eq (command-menu-item-type item) :command)
                   (let ((name (command-menu-item-name item)))
-                    (with-output-as-presentation (stream (command-menu-item-value item) 'command)
+                    (with-output-as-presentation (stream item 'command-menu-item)
                       (write-string name stream)))))))
      command-table)))
 


### PR DESCRIPTION
…In file clim-core/commands.lisp add an :initform nil for the docuemtation field of %menu-item.  This is necessary to avoid an error if the mouse moves over a command menu item
In file clim-core/gadgets/menu.lisp

- Introduce a new presentation type command-menu-item to be used in command menus diplayed in appllication-frames.
- add a translator from the command-menu-item to command
- use the new presentation-type when displaying command table menu

The problem is that if a command-menu-item takes arguments, when the mouse moves over the item an error will signaled rather than querying for the rest of the arguments;  this is because the documentation was not being
initialized.  

The  approach is to change the object (to the full command-menu-item rather than just a field of it) and the presentation type used to present items in the command menu, and then to provide a presentation-translator to command.  This causes the documentation in the pointer-documentation pane to just show the command name.

The second change is to the accept method for command.   It wraps the call to the command-processor in a with-input-context form, allowing it to distingish between a menu-click and a typed command.  This then lets it invoke the partial-command-parser for a menu item with arguments that was clicked on.

These changes are necessary to fix a bug describbed  in #955, and followed up with pull request #957.  Both #955 and #957 can be closed

