### PR TITLE
filling-output: better default for fill-width

### DIFF
--- a/Core/clim-basic/extended-streams/recording.lisp
+++ b/Core/clim-basic/extended-streams/recording.lisp
@@ -1938,8 +1938,7 @@ add output recording facilities. It is not instantiable."))
                                     width height baseline))
 
 ;;; Text output catching methods
-(defmethod stream-write-output ((stream standard-output-recording-stream)
-                                line string-width
+(defmethod stream-write-output ((stream standard-output-recording-stream) line
                                 &optional (start 0) end)
   (unless (stream-recording-p stream)
     (return-from stream-write-output
@@ -1959,10 +1958,9 @@ add output recording facilities. It is not instantiable."))
                                      height
                                      ascent)
         (stream-add-string-output stream line start end text-style
-                                  (or string-width
-                                      (stream-string-width stream line
-                                                           :start start :end end
-                                                           :text-style text-style))
+                                  (stream-string-width stream line
+                                                       :start start :end end
+                                                       :text-style text-style)
                                   height
                                   ascent))))
 

--- a/Core/clim-basic/extended-streams/text-formatting.lisp
+++ b/Core/clim-basic/extended-streams/text-formatting.lisp
@@ -179,10 +179,10 @@
                             (etypecase ,after-line-break
                               (string   (write-string ,after-line-break ,stream))
                               (function (funcall ,after-line-break ,stream soft-newline-p))))))
-                      ;; When after-line-break goes beyond the previous
-                      ;; position we advance the cursor.
-                      (maxf cx (stream-cursor-position ,stream))
-                      (setf (stream-cursor-position ,stream) (values cx cy)))))
+                      ;; When after-line-break goes beyond the
+                      ;; previous position we advance the cursor.
+                      (multiple-value-bind (nx ny) (stream-cursor-position ,stream)
+                        (stream-set-cursor-position ,stream (max cx nx) (max cy ny))))))
              (declare (dynamic-extent #',continuation #',fresh-line-fn))
              (invoke-with-filling-output ,stream #',continuation #',fresh-line-fn ,@args)))))))
 

--- a/Core/clim-basic/extended-streams/text-formatting.lisp
+++ b/Core/clim-basic/extended-streams/text-formatting.lisp
@@ -127,7 +127,9 @@
 (defgeneric invoke-with-filling-output (stream continuation fresh-line-fn
                                         &key fill-width break-characters)
   (:method ((stream filling-output-mixin) continuation fresh-line-fn
-            &key (fill-width '(80 :character)) break-characters)
+            &key
+              (fill-width (bounding-rectangle-max-x (stream-page-region stream)))
+              break-characters)
     (with-temporary-margins (stream :right `(:absolute ,fill-width))
       (letf (((stream-end-of-line-action stream) :wrap*)
              ((line-break-strategy stream) break-characters)

--- a/Examples/misc-tests.lisp
+++ b/Examples/misc-tests.lisp
@@ -383,7 +383,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed venenatis volutpat 
 Second case uses FILLING-OUTPUT,
 Third case uses INDENTING-OUTPUT over FILLING-OUTPUT,
 Fourth case FILLING-OUTPUT over INDENTING-OUTPUT,
-Fifth case is a nested mix of two above."
+Fifth case is a nested mix of two above,
+Sixth case exhibits vertical gap between paragraphs and margins."
   (indenting-output (stream 20)
     (fresh-line stream)
     (format stream *lorem-ipsum*))
@@ -431,15 +432,15 @@ Fifth case is a nested mix of two above."
           (format stream *lorem-ipsum*))
         (indenting-output (stream 20)
           (with-drawing-options (stream :ink +dark-red+)
-           (filling-output (stream :fill-width '(80 :character)
-                                   :break-characters '(#\space)
-                                   :after-line-break "| "
-                                   :after-line-break-composed nil
-                                   :after-line-break-initially t
-                                   :after-line-break-subsequent t)
-             (fresh-line stream)
-             (with-drawing-options (stream :text-style *default-text-style* :ink +dark-blue+)
-               (format stream *lorem-ipsum*)))))
+            (filling-output (stream :fill-width '(80 :character)
+                                    :break-characters '(#\space)
+                                    :after-line-break "| "
+                                    :after-line-break-composed nil
+                                    :after-line-break-initially t
+                                    :after-line-break-subsequent t)
+              (fresh-line stream)
+              (with-drawing-options (stream :text-style *default-text-style* :ink +dark-blue+)
+                (format stream *lorem-ipsum*)))))
         (fresh-line stream)
         (with-drawing-options (stream :text-style *default-text-style* :ink +black+)
           (format stream *lorem-ipsum*))
@@ -455,7 +456,29 @@ Fifth case is a nested mix of two above."
               (with-drawing-options (stream :text-style *default-text-style* :ink +dark-blue+)
                 (format stream *lorem-ipsum*)))))
         (with-drawing-options (stream :text-style *default-text-style* :ink +black+)
-          (format stream *lorem-ipsum*))))))
+          (format stream *lorem-ipsum*)))))
+  (terpri stream)
+  (clime:with-temporary-margins (stream :left 50 :right 50)
+    (terpri stream)
+    (clim:with-bounding-rectangle* (x1 y1 x2 y2)
+        (clime:stream-page-region *standard-output*)
+      (declare (ignore y1 y2))
+      (let ((cy (nth-value 1 (stream-cursor-position stream))))
+        (clim:draw-rectangle* *standard-output* x1 cy x2 (+ cy 100)
+                              :filled nil
+                              :ink clim:+grey+)))
+    (filling-output (stream
+                     :after-line-break
+                     (lambda (stream soft-p)
+                       (if (null soft-p)
+                           (with-drawing-options (stream :ink +red+)
+                             (stream-increment-cursor-position stream 40 10)
+                             (format stream "hard: "))
+                           (with-drawing-options (stream :ink +blue+)
+                             (stream-increment-cursor-position stream 20 0)
+                             (format stream "soft newline: "))))
+                     :after-line-break-initially t)
+      (format stream *lorem-ipsum*))))
 
 (defun misc-tests ()
   (let ((frame (make-application-frame 'misc-tests)))

--- a/Examples/misc-tests.lisp
+++ b/Examples/misc-tests.lisp
@@ -323,11 +323,14 @@
 
 (define-misc-test "Line centering" (stream)
     "Test focuses on a fact that line should be centered around its underlying coordinate (so if it has big thickness it extends in both directions) for regions composed of lines."
+  #+ (or)
+  ;; We are not ready for rectangular-tile background yet
+  ;; (medium-clear-area in CLX backend assumes acolor).
   (let ((array (make-array '(10 10) :initial-element 0)))
     (dotimes (i 10) (setf (aref array 0 i) 1
                           (aref array i 0) 1))
-    (setf (pane-background stream) (make-rectangular-tile
-                                      (make-pattern array (list +white+ +gray+)) 10 10))
+    (setf (pane-background stream)
+          (make-rectangular-tile (make-pattern array (list +white+ +gray+)) 10 10))
     (repaint-sheet stream +everywhere+))
   (flet ((single-lines ()
            (draw-line* stream 20 0 100 0)

--- a/Tests/utils.lisp
+++ b/Tests/utils.lisp
@@ -17,149 +17,41 @@
 
 ;;; Line splitting utility
 ;;; ============================================================================
-
-;;; orthogonal dimensions:
-;;; - string is lesser, equal or greater than first margin
-;;; - after first split string is lesser, equal or greater than {1,2,3} margin
-;;; - initial-offset is negative, zero or positive number
-;;; - final margin is a negative number, zero , lesser than initial-offset, equal, grater
-;;; - width-fn is a number or a fixed width function
-;;; - start boundary is 0, is first split, is last split
-;;; - end boundary is first split, is last split
-;;; - width/margin dimensions are scaled by 1/2, 1, 3 multiplier
-;;;
-;;; Not tested here (see demos with wrapping):
-;;; - width-fn is a function with a not fixed character size (not tested here)
-;;; - start boundary is right before/after {1,2,...,n-1,n} split
-;;; - end boundary is just before/after {1,2,3,..,n-1,n} split
-(test %line-breaks-1.smoke
-  "Smoke test for the %LINE-BREAKS-1 function."
-  (flet ((tbl (len off mar &rest splits)
-           (let* ((str (make-string len))
-                  (fix-fn (lambda (string start end)
-                            (declare (ignore string))
-                            (- end start)))
-                  (f/2-fn (lambda (string start end)
-                            (/ (funcall fix-fn string start end) 2)))
-                  (3*f-fn (lambda (string start end)
-                            (* (funcall fix-fn string start end) 3))))
-             (is (equal (climi::%line-breaks-1 str 1      off mar 0 len) splits) nil)
-             (is (equal (climi::%line-breaks-1 str fix-fn off mar 0 len) splits) nil)
-             (is (equal (climi::%line-breaks-1 str 1/2    (/ off 2) (/ mar 2) 0 len) splits))
-             (is (equal (climi::%line-breaks-1 str f/2-fn (/ off 2) (/ mar 2) 0 len) splits))
-             (is (equal (climi::%line-breaks-1 str 3      (* off 3) (* mar 3) 0 len) splits))
-             (is (equal (climi::%line-breaks-1 str 3*f-fn (* off 3) (* mar 3) 0 len) splits))
-             (alexandria:when-let ((first-split (car splits)))
-               (let ((start* first-split)
-                     (end* len)
-                     (splits* (cdr splits)))
-                 ;; after the first split there are no offsets
-                 (is (equal (climi::%line-breaks-1 str 1      0 mar       start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str fix-fn 0 mar       start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 1/2    0 (/ mar 2) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str f/2-fn 0 (/ mar 2) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 3      0 (* mar 3) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 3*f-fn 0 (* mar 3) start* end*) splits*))))
-             (alexandria:when-let ((last-split (car (last splits))))
-               (let ((start* last-split)
-                     (end* len)
-                     (splits* nil))
-                 ;; after the first split there are no offsets
-                 (is (equal (climi::%line-breaks-1 str 1      0 mar       start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str fix-fn 0 mar       start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 1/2    0 (/ mar 2) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str f/2-fn 0 (/ mar 2) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 3      0 (* mar 3) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 3*f-fn 0 (* mar 3) start* end*) splits*))))
-             (alexandria:when-let ((last-split (car (last splits))))
-               (let ((start* 0)
-                     (end* last-split)
-                     (splits* (butlast splits)))
-                 (is (equal (climi::%line-breaks-1 str 1      off       mar       start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str fix-fn off       mar       start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 1/2    (/ off 2) (/ mar 2) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str f/2-fn (/ off 2) (/ mar 2) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 3      (* off 3) (* mar 3) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 3*f-fn (* off 3) (* mar 3) start* end*) splits*))))
-             (alexandria:when-let ((start* (car splits))
-                                   (end* (car (last splits))))
-               (let ((splits* (cdr (butlast splits))))
-                 (is (equal (climi::%line-breaks-1 str 1      0 mar       start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str fix-fn 0 mar       start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 1/2    0 (/ mar 2) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str f/2-fn 0 (/ mar 2) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 3      0 (* mar 3) start* end*) splits*))
-                 (is (equal (climi::%line-breaks-1 str 3*f-fn 0 (* mar 3) start* end*) splits*)))))))
-    (tbl 0     0   -3)
-    (tbl 1     0   -3)
-    (tbl 2     0   -3    1)
-    (tbl 2    -5   -3)
-    (tbl 2    -4   -3    1)
-    (tbl 2    -3   -3    1)
-    (tbl 2    -2   -3    1)
-    (tbl 4    -2   -3    1 2 3)
-    (tbl 4    -2    1    3)
-    (tbl 4    -1    1    2 3)
-    (tbl 4     0    0    1 2 3)
-    (tbl 4     1    0    0 1 2 3)
-    (tbl 4     1    1    0 1 2 3)
-    (tbl 4     1    2    1 3)
-    (tbl 0     0   80)
-    (tbl 10    0   80)
-    (tbl 10    1   80)
-    (tbl 10   -1   80)
-    (tbl 10   70   80)
-    (tbl 10   71   80    9)
-    (tbl 90    0   80    80)
-    (tbl 90    1   80    79)
-    (tbl 90  -10   80)
-    (tbl 90   -9   80    89)
-    (tbl 90   79   80    1 81)
-    (tbl 90   80   80    0 80)
-    (tbl 90   81   80    0 80)
-    (tbl 800  -20  80    100 180 260 340 420 500 580 660 740)
-    (tbl 800  20   80    60 140 220 300 380 460 540 620 700 780)
-    (tbl 800  40   80    40 120 200 280 360 440 520 600 680 760)
-    (tbl 800  60   80    20 100 180 260 340 420 500 580 660 740)))
-
-(defun list-lines (string start breaks)
+(defun list-lines (string start end breaks)
   (climi::collect (line)
     (do ((start start (car breaks))
          (breaks breaks (rest breaks)))
         ((null breaks)
-         (line (string-trim '(#\space) (subseq string start))))
-      (line (string-trim '(#\space) (subseq string start (car breaks)))))))
+         (line))
+      (line (subseq string start (car breaks))))))
 
-(defun lines (string start margin &optional (offset 0))
-  (list-lines string start
-              (climi::line-breaks string 1 :margin margin :initial-offset offset :start start)))
+(defun lines (string &key (start 0) end margin (offset 0))
+  (list-lines string start end
+              (climi::line-breaks string 1 :margin margin :initial-offset offset :start start :end end)))
 
 (test line-breaks.smoke
-  (let ((string "ala ma kota a kot ma alę")
-        (string2 "Xala ma kota a kot ma alę"))
-    ;; We skip #\space at the line end (lines after break start with a character
-    ;; which is not a space). LINES trims spaces from the right.
-    (is (equal '("ala" "m" "a" "k" "o" "t" "a" "a" "k" "o" "t" "m" "a" "a" "l" "ę") (lines string 0 0 -3)))
-    (is (equal '("a" "l" "a" "m" "a" "k" "o" "t" "a" "a" "k" "o" "t" "m" "a" "a" "l" "ę") (lines string 0 0)))
-    (is (equal '("a" "l" "a" "m" "a" "k" "o" "t" "a" "a" "k" "o" "t" "m" "a" "a" "l" "ę") (lines string 0 1)))
-    (is (equal '("al" "a" "ma" "ko" "ta" "a" "ko" "t" "ma" "al" "ę") (lines string 0 2)))
-    (is (equal '("ala" "ma" "kot" "a a" "kot" "ma" "alę") (lines string 0 3)))
-    (is (equal '("ala" "ma" "kota" "a" "kot" "ma" "alę") (lines string 0 4)))
-    (is (equal '("ala" "ma" "kota" "a kot" "ma" "alę") (lines string 0 5)))
-    (is (equal '("ala ma" "kota a" "kot ma" "alę") (lines string 0 6)))
-    (is (equal '("ala" "ma" "kota a" "kot ma" "alę") (lines string 0 6 3)))
-    (is (equal (list string) (lines string 0 64)))
-    (is (equal (list string) (lines string 0 64 3)))
-    ;; ignore first character
-    (is (equal '("ala" "m" "a" "k" "o" "t" "a" "a" "k" "o" "t" "m" "a" "a" "l" "ę") (lines string2 1 0 -3)))
-    (is (equal '("a" "l" "a" "m" "a" "k" "o" "t" "a" "a" "k" "o" "t" "m" "a" "a" "l" "ę") (lines string2 1 0)))
-    (is (equal '("a" "l" "a" "m" "a" "k" "o" "t" "a" "a" "k" "o" "t" "m" "a" "a" "l" "ę") (lines string2 1 1)))
-    (is (equal '("al" "a" "ma" "ko" "ta" "a" "ko" "t" "ma" "al" "ę") (lines string2 1 2)))
-    (is (equal '("ala" "ma" "kot" "a a" "kot" "ma" "alę") (lines string2 1 3)))
-    (is (equal '("ala" "ma" "kota" "a" "kot" "ma" "alę") (lines string2 1 4)))
-    (is (equal '("ala" "ma" "kota" "a kot" "ma" "alę") (lines string2 1 5)))
-    (is (equal '("ala ma" "kota a" "kot ma" "alę") (lines string2 1 6)))
-    (is (equal '("ala" "ma" "kota a" "kot ma" "alę") (lines string2 1 6 3)))))
+  (let* ((string "ala ma kota a kot ma alę")
+         (prefix "XXX XXX ")
+         (suffix "XXX XXX ")
+         (string1 (concatenate 'string prefix string suffix))
+         (string2 (concatenate 'string prefix string))
+         (string3 (concatenate 'string        string suffix))
+         ;;
+         (start1 (length prefix))
+         (start2 start1)
+         (end1 (- (length string1) (length suffix)))
+         (end3 (- (length string3) (length suffix))))
+    (flet ((check (margin offset result)
+             (is (equal result (lines string  :margin margin :offset offset                        )))
+             (is (equal result (lines string1 :margin margin :offset offset :start start1 :end end1)))
+             (is (equal result (lines string2 :margin margin :offset offset :start start2          )))
+             (is (equal result (lines string3 :margin margin :offset offset               :end end3)))))
+      ;; Test emergency breaks with negative initial offset.
+      (check 0 -3 '("ala" " " "m" "a" " " "k" "o" "t" "a" " " "a" " " "k" "o" "t" " " "m" "a" " " "a" "l" "ę"))
+      ;; Similar to above but does not trigger a degenarte case where we violate the layout.
+      (check 1 -2 '("ala" " " "m" "a" " " "k" "o" "t" "a" " " "a" " " "k" "o" "t" " " "m" "a" " " "a" "l" "ę"))
+      ;; Usual case where each word may fit in a line.
+      (check 5  1 '("ala " "ma " "kota " "a " "kot " "ma " "alę")))))
 
 ;;; for interactive testing
 (defun print-lines (string start margin &optional (offset 0) bstr
@@ -171,7 +63,7 @@
   (dotimes (i margin)
     (princ "-"))
   (princ "|")
-  (let ((lines (list-lines string start
+  (let ((lines (list-lines string start (length string)
                            (climi::line-breaks string 1 :margin margin
                                                         :initial-offset offset
                                                         :start start
@@ -184,7 +76,7 @@
              (princ line)
              (dotimes (i (- margin (length line) off))
                (incf counter)
-               (princ #\space))
+               (princ #\_))
              (princ "|")
              (format t "~16tRemaining space: ~s" counter)
              (setf last-score (expt counter 2))

--- a/Tests/utils.lisp
+++ b/Tests/utils.lisp
@@ -18,6 +18,7 @@
 ;;; Line splitting utility
 ;;; ============================================================================
 (defun list-lines (string start end breaks)
+  (declare (ignore end))
   (climi::collect (line)
     (do ((start start (car breaks))
          (breaks breaks (rest breaks)))
@@ -130,7 +131,7 @@
             (is-true (alexandria:starts-with-subseq string text))
             (is (string= text string)))
         (loop for line in lines
-              do (is (null (find #\Newline line))
+              do (is (null (find #\Newline (string-right-trim '(#\newline #\Linefeed #\return) line)))
                      "For input~@
                       ~2@T~S~@
                       ~S ~S ~S ~S ~S ~S ~S ~S, breaking into~@


### PR DESCRIPTION
Previous default value was 80 characters wide, while stream has its
own line width. It is better default, because when text-margins are
specified then filling-width does not ignore them unless explicitly
told to.