### PR TITLE
medium-drawable method for basic-medium

### DIFF
--- a/Backends/PDF/sheet.lisp
+++ b/Backends/PDF/sheet.lisp
@@ -96,9 +96,6 @@
 
 ;;; Output Protocol
 
-(defmethod medium-drawable ((medium pdf-medium))
-  (sheet-mirror (medium-sheet medium)))
-
 (defmethod make-medium ((port pdf-port) (sheet clim-pdf-stream))
   (make-instance 'pdf-medium :sheet sheet))
 

--- a/Backends/PostScript/sheet.lisp
+++ b/Backends/PostScript/sheet.lisp
@@ -166,9 +166,6 @@
 
 ;;; Output Protocol
 
-(defmethod medium-drawable ((medium postscript-medium))
-  (sheet-mirror (medium-sheet medium)))
-
 (defmethod make-medium ((port postscript-port) (sheet postscript-stream))
   (make-instance 'postscript-medium :sheet sheet))
 

--- a/Core/clim-basic/drawing/medium.lisp
+++ b/Core/clim-basic/drawing/medium.lisp
@@ -519,6 +519,10 @@
           :writer (setf %medium-sheet) ))
   (:documentation "The basic class, on which all CLIM mediums are built."))
 
+(defmethod medium-drawable ((medium basic-medium))
+  (when-let ((sheet (medium-sheet medium)))
+    (sheet-mirror sheet)))
+
 (defclass ungrafted-medium (basic-medium) ())
 
 (defmethod initialize-instance :after ((medium basic-medium) &rest args)


### PR DESCRIPTION
This commit implements a method for the generic function defined in
the CLIM specification MEDIUM-DRAWABLE specialized on BASIC-MEDIUM.

The methods of MEDIUM-DRAWABLE specialized on POSTSCRIPT-MEDIUM and
PDF-MEDIUM are removed because they are no more necessary.