### PR TITLE
Clouseau Improvements

### DIFF
--- a/Apps/Clouseau/src/application.lisp
+++ b/Apps/Clouseau/src/application.lisp
@@ -38,7 +38,10 @@
 ;;; Application frame
 
 (define-application-frame inspector ()
-  ((%state :accessor %state))
+  ((%state          :accessor %state
+                    :initform nil)
+   (%change-handler :accessor %change-handler
+                    :initform nil))
   (:panes
    (history    history-pane   :state (%state *application-frame*))
    (inspector  inspector-pane :state (%state *application-frame*))
@@ -67,16 +70,24 @@
 (defmethod initialize-instance :after ((instance inspector)
                                        &key object
                                             (handle-errors t))
-  (setf (%state instance) (make-instance 'inspector-state
+  (setf (%change-handler instance)
+        (lambda (old-root-place new-root-place)
+          (declare (ignore old-root-place))
+          (setf (clim:frame-pretty-name instance)
+                (inspector-name (value new-root-place))))
+        (%state instance) (make-instance 'inspector-state
                                          :root-object   object
                                          :handle-errors handle-errors)))
 
-(defmethod (setf %state) :after ((new-value t) (inspector inspector))
-  (push (lambda (old-root-place new-root-place)
-          (declare (ignore old-root-place))
-          (setf (clim:frame-pretty-name inspector)
-                (inspector-name (value new-root-place))))
-        (change-hook new-value)))
+(defmethod (setf %state) :around ((new-value t) (object inspector))
+  (let ((old-value (%state object)))
+    (prog1
+        (call-next-method)
+      (unless (eq new-value old-value)
+        (let ((handler (%change-handler object)))
+          (when old-value
+            (removef (change-hook old-value) handler))
+          (push handler (change-hook new-value)))))))
 
 (defmethod root-place ((inspector-state inspector) &key run-hook-p)
   (declare (ignore run-hook-p))

--- a/Apps/Clouseau/src/application.lisp
+++ b/Apps/Clouseau/src/application.lisp
@@ -1,4 +1,4 @@
-;;;; Copyright (C) 2018, 2019 Jan Moringen
+;;;; Copyright (C) 2018, 2019, 2020 Jan Moringen
 ;;;;
 ;;;; This library is free software; you can redistribute it and/or
 ;;;; modify it under the terms of the GNU Library General Public
@@ -49,14 +49,14 @@
   (:layouts
    (with-interactor
     (vertically ()
-      (scrolling (:scroll-bars :horizontal :suggested-height 40)
+      (scrolling (:scroll-bars :horizontal :suggested-height 48)
         history)
       (:fill (scrolling (:width 920 :height 480) inspector))
       (make-pane 'clime:box-adjuster-gadget)
       (1/16 interactor :height 200)))
    (without-interactor
     (vertically ()
-      (scrolling (:scroll-bars :horizontal :suggested-height 40)
+      (scrolling (:scroll-bars :horizontal :suggested-height 48)
         history)
       (:fill (scrolling (:width 920 :height 800) inspector)))))
   (:command-table (application :inherit-from (inspector-pane-command-table

--- a/Apps/Clouseau/src/formatting.lisp
+++ b/Apps/Clouseau/src/formatting.lisp
@@ -1,4 +1,4 @@
-;;;; Copyright (C) 2018, 2019 Jan Moringen
+;;;; Copyright (C) 2018, 2019, 2020 Jan Moringen
 ;;;;
 ;;;; This library is free software; you can redistribute it and/or
 ;;;; modify it under the terms of the GNU Library General Public
@@ -76,6 +76,8 @@
        (:error                       . (:ink ,+dark-red+                                    :text-face :italic))
 
        (:identity                    . (:ink ,+dark-slate-blue+                                                :text-size :smaller))
+
+       (:package-note                . (:ink ,+dark-gray+                                                      :text-size :smaller))
 
        (:float-sign                  . (:ink ,(make-contrasting-inks 8 0)))
        (:float-significand           . (:ink ,(make-contrasting-inks 8 1)))
@@ -255,6 +257,16 @@ the :UNBOUND style."
   (when delimitersp
     (write-char #\" stream))
   string)
+
+;;; Symbols
+
+(defun print-symbol-in-context (symbol context-package stream)
+  (write-string (symbol-name symbol) stream)
+  (let ((symbol-package (symbol-package symbol)))
+    (unless (eq context-package symbol-package)
+      (write-char #\Space stream)
+      (with-style (stream :package-note)
+        (write-string (or (package-name symbol-package) "unnamed") stream)))))
 
 ;;; Safety
 

--- a/Apps/Clouseau/src/objects/array.lisp
+++ b/Apps/Clouseau/src/objects/array.lisp
@@ -203,7 +203,6 @@
         (when fill-pointer
           (format-place-row stream object 'vector-fill-pointer-place nil
                             :label "Fill pointer"))))
-
     (with-section (stream) "Elements"
       (with-placeholder-if-empty (stream)
         ((zerop length)

--- a/Apps/Clouseau/src/objects/instance.lisp
+++ b/Apps/Clouseau/src/objects/instance.lisp
@@ -22,7 +22,7 @@
 
 ;;; `slot-place'
 
-(defclass slot-place (key-value-place)
+(defclass slot-place (key-value-place) ; read-only-place
   ())
 
 (defmethod object-state-class ((object null) (place slot-place))
@@ -143,7 +143,7 @@
             (write-char #\Space stream)
             (badge stream "~A-allocated" allocation)))
         (formatting-cell (stream :align-x :center :align-y :center)
-          (present stream))
+          (with-style (stream :slot-like) (present stream)))
         (formatting-cell (stream :align-y :center)
           (with-error-handling (stream "Error accessing slot")
             (inspect stream)))))))

--- a/Apps/Clouseau/src/objects/instance.lisp
+++ b/Apps/Clouseau/src/objects/instance.lisp
@@ -1,4 +1,4 @@
-;;;; Copyright (C) 2018, 2019 Jan Moringen
+;;;; Copyright (C) 2018, 2019, 2020 Jan Moringen
 ;;;;
 ;;;; This library is free software; you can redistribute it and/or
 ;;;; modify it under the terms of the GNU Library General Public
@@ -95,8 +95,10 @@
   ())
 
 (defmethod make-object-state ((object t) (place slot-definition-of-place))
-  (make-instance (object-state-class object place) :place place
-                                                   :style :name-only))
+  (make-instance (object-state-class object place)
+                 :place place
+                 :class (class-of (container place))
+                 :style :name-only))
 
 (defun inspect-as-slot-name (instance slot-definition stream)
   ;; This presents the name of SLOT-DEFINITION as a collapsed

--- a/Apps/Clouseau/src/package.lisp
+++ b/Apps/Clouseau/src/package.lisp
@@ -1,4 +1,4 @@
-;;;; Copyright (C) 2018, 2019 Jan Moringen
+;;;; Copyright (C) 2018, 2019, 2020 Jan Moringen
 ;;;;
 ;;;; This library is free software; you can redistribute it and/or
 ;;;; modify it under the terms of the GNU Library General Public
@@ -86,7 +86,22 @@
    #:object-state-class
    #:make-object-state
 
-   #:inspected-object)
+   #:inspected-object
+   #:inspected-integer
+   #:inspected-list
+   #:inspected-proper-list
+   #:inspected-plist
+   #:inspected-alist
+   #:inspected-improper-list
+   #:inspected-array
+   #:inspected-vector
+   #:inspected-instance
+   #:inspected-hash-table
+   #:inspected-function
+   #:inspected-class
+   #:inspected-method
+   #:inspected-generic-function
+   #:inspected-sequence)
 
   ;; Object inspection protocol
   (:export

--- a/Apps/Clouseau/src/pane.lisp
+++ b/Apps/Clouseau/src/pane.lisp
@@ -42,43 +42,52 @@
 ;;; Mixin for managing inspector presentations on a pane
 
 (defclass inspector-pane-mixin ()
-  ((%state :reader   state
-           :writer   (setf %state))))
+  ((%state          :reader   state
+                    :writer   (setf %state)
+                    :initform nil)
+   (%change-handler :accessor %change-handler
+                    :initform nil)))
 
 (defmethod shared-initialize :before ((instance   inspector-pane-mixin)
                                       (slot-names t)
-                                      &key
-                                      (state nil state-supplied-p)
-                                      (root  nil root-supplied-p))
+                                      &key (state nil state-supplied-p)
+                                           (root  nil root-supplied-p))
   (declare (ignore state root))
   (when (and state-supplied-p root-supplied-p)
     (error "~@<The initargs ~S and ~S are mutually exclusive.~@:>"
            :state :root)))
 
-(defmethod initialize-instance :after ((instance inspector-pane-mixin)
-                                        &key
-                                        (state nil state-supplied-p)
-                                        (root  nil root-supplied-p))
-  (declare (ignore state root))
-  (unless (or state-supplied-p root-supplied-p)
-    (setf (%state instance) (make-instance 'inspector-state))))
-
 (defmethod shared-initialize :after ((instance   inspector-pane-mixin)
                                      (slot-names t)
-                                     &key
-                                     (state nil state-supplied-p)
-                                     (root  nil root-supplied-p))
+                                     &key (state nil state-supplied-p)
+                                          (root  nil root-supplied-p))
+  (unless (%change-handler instance)
+    (setf (%change-handler instance)
+          (lambda (old-root-place new-root-place)
+            (declare (ignore old-root-place new-root-place))
+            (queue-redisplay instance))))
   (cond (state-supplied-p
          (setf (%state instance) state))
         (root-supplied-p
          (setf (%state instance) (make-instance 'inspector-state
                                                 :root-object root)))))
 
-(defmethod (setf %state) :after ((new-value t) (object inspector-pane-mixin))
-  (push (lambda (old-root-place new-root-place)
-          (declare (ignore old-root-place new-root-place))
-          (queue-redisplay object))
-        (change-hook new-value)))
+(defmethod initialize-instance :after ((instance inspector-pane-mixin)
+                                        &key (state nil state-supplied-p)
+                                             (root  nil root-supplied-p))
+  (declare (ignore state root))
+  (unless (or state-supplied-p root-supplied-p)
+    (setf (%state instance) (make-instance 'inspector-state))))
+
+(defmethod (setf %state) :around ((new-value t) (object inspector-pane-mixin))
+  (let ((old-value (state object)))
+    (prog1
+        (call-next-method)
+      (unless (eq new-value old-value)
+        (let ((handler (%change-handler object)))
+          (when old-value
+            (removef (change-hook old-value) handler))
+          (push handler (change-hook new-value)))))))
 
 (defmethod root-place ((inspector-state inspector-pane-mixin)
                        &key run-hook-p)

--- a/Apps/Clouseau/src/place.lisp
+++ b/Apps/Clouseau/src/place.lisp
@@ -35,6 +35,10 @@
    :parent (error "missing required initarg ~S for class ~S"
                   :parent 'basic-place)))
 
+(defmethod print-object ((object basic-place) stream)
+  (print-unreadable-object (object stream :type t :identity t)
+    (ignore-errors (princ (cell object) stream))))
+
 (defmethod ensure-child ((container t)
                          (cell      t)
                          (class     t)

--- a/Documentation/Manual/Texinfo/chap-inspector.texi
+++ b/Documentation/Manual/Texinfo/chap-inspector.texi
@@ -568,14 +568,14 @@ as we want the simple representation to be, we don't need to define a
 @lisp
 (defmethod @codegenfunref{clouseau:inspect-object-using-state}
     ((object sample)
-     (state  clouseau:inspected-object)
+     (state  clouseau:inspected-instance)
      (style  (eql :expanded-header))
      (stream t))
   (format stream "SAMPLE n=~D" (sample-size object)))
 
 (defmethod @codegenfunref{clouseau:inspect-object-using-state}
     ((object sample)
-     (state  clouseau:inspected-object)
+     (state  clouseau:inspected-instance)
      (style  (eql :expanded-body))
      (stream t))
   (@codemacroref{clouseau:formatting-place} (object 'clouseau:reader-place 'mean
@@ -614,7 +614,7 @@ place class:
 @lisp
 (defmethod @codegenfunref{clouseau:inspect-object-using-state}
     ((object sample)
-     (state  clouseau:inspected-object)
+     (state  clouseau:inspected-instance)
      (style  (eql :expanded-body))
      (stream t))
   (formatting-table (stream)
@@ -651,7 +651,7 @@ over it:
 
 (defmethod @codegenfunref{clouseau:inspect-object-using-state}
     ((object sample)
-     (state  clouseau:inspected-object)
+     (state  clouseau:inspected-instance)
      (style  (eql :expanded-body))
      (stream t))
   (formatting-table (stream)
@@ -671,7 +671,7 @@ easily:
 @lisp
 (defmethod @codegenfunref{clouseau:inspect-object-using-state}
     ((object sample)
-     (state  clouseau:inspected-object)
+     (state  clouseau:inspected-instance)
      (style  (eql :expanded-header))
      (stream t))
   (clouseau::inspect-class-as-name (class-of object) stream)

--- a/Documentation/Manual/Texinfo/inspector-example.lisp
+++ b/Documentation/Manual/Texinfo/inspector-example.lisp
@@ -1,0 +1,144 @@
+(in-package :clim-user)
+
+(defclass sample ()
+  ((data :initarg :data
+         :accessor data
+         :type list
+         :initform '()))
+  (:documentation "A statistical sample"))
+
+(defgeneric sample-size (sample)
+  (:documentation "Return the size of a statistical sample"))
+
+(defmethod sample-size ((sample sample))
+  (length (data sample)))
+
+(defmethod print-object ((object sample) stream)
+  (print-unreadable-object (object stream :type t)
+    (format stream "n=~D" (sample-size object))))
+
+(defparameter *my-sample*
+  (make-instance 'sample
+                 :data (map-into (make-list 1000) (lambda () (random 100.f0)))))
+
+(defgeneric sum (sample)
+  (:documentation "The sum of all numbers in a statistical
+sample"))
+
+(defmethod sum ((sample sample))
+  (reduce #'+ (data sample)))
+
+(defgeneric mean (sample)
+  (:documentation "The mean of the numbers in a statistical
+sample"))
+
+(defmethod mean ((sample sample))
+  (/ (sum sample)
+     (sample-size sample)))
+
+(defgeneric standard-deviation (sample)
+  (:documentation "Find the standard deviation of the numbers
+in a sample. This measures how spread out they are."))
+
+(defmethod standard-deviation ((sample sample))
+  (let ((mean (mean sample)))
+    (sqrt (/ (loop for x in (data sample)
+                   sum (expt (- x mean) 2))
+             (1- (sample-size sample))))))
+
+;;;; 1
+
+(defmethod clouseau:inspect-object-using-state ((object sample)
+                                                (state  clouseau:inspected-instance)
+                                                (style  (eql :expanded-header))
+                                                (stream t))
+  (format stream "SAMPLE n=~D" (sample-size object)))
+
+(defmethod clouseau:inspect-object-using-state ((object sample)
+                                                (state  clouseau:inspected-instance)
+                                                (style  (eql :expanded-body))
+                                                (stream t))
+  (clouseau:formatting-place (object 'clouseau:reader-place 'mean
+                                     present-place present-object)
+    (write-string "mean" stream) ; label
+    (present-place stream)       ; place indicator for the "slot"
+    (present-object stream))     ; the value of the "slot" is the object
+  (fresh-line stream)
+  (clouseau:formatting-place (object 'clouseau:reader-place 'standard-deviation
+                                     present-place present-object)
+    (write-string "std. dev." stream)
+    (present-place stream)
+    (present-object stream)))
+
+;;;; 2
+
+(defmethod clouseau:inspect-object-using-state ((object sample)
+                                                (state  clouseau:inspected-instance)
+                                                (style  (eql :expanded-body))
+                                                (stream t))
+  (formatting-table (stream)
+    (clouseau:format-place-row stream object 'clouseau:reader-place 'mean
+                                :label "mean")
+    (clouseau:format-place-row stream object 'clouseau:reader-place 'standard-deviation
+                                :label "std. dev.")))
+
+;;;; 3
+
+(defun xbar (stream)
+  "Draw an x with a bar over it"
+  (with-room-for-graphics (stream)
+    (with-text-face (stream :italic)
+      (princ #\x stream)
+      (draw-line* stream 0 0 (text-size stream #\x) 0))))
+
+(defmethod clouseau:inspect-object-using-state ((object sample)
+                                                (state  clouseau:inspected-instance)
+                                                (style  (eql :expanded-body))
+                                                (stream t))
+  (formatting-table (stream)
+    (clouseau:format-place-row stream object 'clouseau:reader-place 'mean
+                                :label #'xbar)
+    (clouseau:format-place-row stream object 'clouseau:reader-place 'standard-deviation
+                                :label #\S)))
+
+;;;; 4
+
+(defmethod clouseau:inspect-object-using-state ((object sample)
+                                                (state  clouseau:inspected-instance)
+                                                (style  (eql :expanded-header))
+                                                (stream t))
+  (clouseau::inspect-class-as-name (class-of object) stream)
+  (write-char #\Space stream)
+  (with-drawing-options (stream :text-family :serif :text-face :italic)
+    (write-char #\n stream))
+  (format stream "=~D" (sample-size object)))
+
+;;;; 5
+
+(defmethod clouseau:inspect-object-using-state ((object sample)
+                                                (state  clouseau:inspected-instance)
+                                                (style  (eql :expanded-body))
+                                                (stream t))
+  (formatting-table (stream)
+    (clouseau:format-place-row stream object 'clouseau:reader-place 'mean
+                               :label #'xbar)
+    (clouseau:format-place-row stream object 'clouseau:reader-place 'standard-deviation
+                               :label #\S :label-style '(:text-face :italic)))
+  (fresh-line stream)
+  (clouseau:inspect-object-using-state object state :histogram stream))
+
+(defmethod clouseau:inspect-object-using-state ((object sample)
+                                                (state  clouseau:inspected-instance)
+                                                (style  (eql :histogram))
+                                                (stream t))
+  (let* ((data (data object))
+         (buckets (make-array 10 :initial-element 0))
+         (max (reduce #'max data)))
+    (loop for x in data
+          do (incf (aref buckets (floor x (/ (1+ max) (length buckets))))))
+    (with-room-for-graphics (stream)
+      (loop for i below (length buckets)
+            for x = (* 20 i)
+            for y = (* 1 (aref buckets i))
+            do (draw-rectangle* stream x 0 (+ x 19) y
+                                :ink (make-contrasting-inks 1 0))))))


### PR DESCRIPTION
1. Export classes and adjust documentation so that the Clouseau tutorial works again

2. Cleanup inconsistencies between `ensure-place` and `formatting-place` (as pointed out by @robert-strandh )

3. When printing slot names, omit package if it is the same as the "context package"

4. Better support for reinitialization of Clouseau structures

5. Prettier and more readable history