### PR TITLE
presentations: use information from the patched defclass on ecl

### DIFF
--- a/Core/clim-core/presentations.lisp
+++ b/Core/clim-core/presentations.lisp
@@ -601,13 +601,13 @@ supertypes of TYPE that are presentation types"))
 ;;; that if a CLOS class exists at compile time, it will exist at
 ;;; load/run time too.
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  #-(or excl cmu sbcl openmcl)
+  #-(or excl cmu sbcl openmcl ecl)
   (defun compile-time-clos-p (name)
     (let ((meta (find-class name nil)))
       (and meta
            (typep meta 'standard-class))))
 
-  #+(or excl cmu sbcl openmcl)
+  #+(or excl cmu sbcl openmcl ecl)
   (defun compile-time-clos-p (name)
     (let ((metaclass (find-class name nil)))
       (or (and metaclass


### PR DESCRIPTION
It is allowed for define-presentation-type to assume, that class has
been already defined (that is -- defclass must be evaluated before the
matching define-presentation-type). McCLIM patches defclass to store
information about defined classes at compilation time to allow them to
be defined both as top-level forms in the same file without additional
eval-when by some implementations which use that information; add ECL
to this set.