### PR TITLE
clx-medium: inherit from font-rendering-medium-mixin

### DIFF
--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -47,7 +47,9 @@
 
 ;;; CLX-MEDIUM class
 
-(defclass clx-medium (basic-medium climb:multiline-text-medium-mixin)
+(defclass clx-medium (basic-medium
+                      climb:multiline-text-medium-mixin
+                      climb:font-rendering-medium-mixin)
   ((gc :initform nil)
    (last-medium-device-region :initform nil
                               :accessor last-medium-device-region)


### PR DESCRIPTION
clx-medium implements font renderer protocols and that's where it gets
text-style* methods from. 76dd65c27756d introduced a regression which
may these methods not applicable. Closes #984.