### PR TITLE
Fix two problems with recent commits

### DIFF
--- a/Core/clim-basic/protocol-classes.lisp
+++ b/Core/clim-basic/protocol-classes.lisp
@@ -234,6 +234,11 @@
   ((port :initarg :port :reader port)
    (frames :initform nil :reader frame-manager-frames)))
 
+;;; 29.2 Basic Pane Construction
+
+(define-protocol-class pane (sheet)
+  ())
+
 ;;; 30.3 Basic Gadget Classes
 ;;; XXX Slots definitions should be banished.
 (define-protocol-class gadget (pane)

--- a/Core/clim-basic/windowing/ports.lisp
+++ b/Core/clim-basic/windowing/ports.lisp
@@ -458,15 +458,14 @@
 
 (defmethod make-graft
     ((port basic-port) &key (orientation :default) (units :device))
-  (let ((graft (make-instance 'graft
-		              :port port :mirror nil
-		              :orientation orientation :units units)))
+  (make-instance 'graft :port port :mirror nil
+                        :orientation orientation :units units))
+
+(defmethod make-graft :around ((port basic-port) &key orientation units)
+  (declare (ignore orientation units))
+  (let ((graft (call-next-method)))
     (push graft (port-grafts port))
     graft))
-
-(defmethod make-graft :around
-    ((port basic-port) &key (orientation :default) (units :device))
-  (first (push (call-next-method) (port-grafts port))))
 
 (defmethod map-over-grafts (function (port basic-port))
   (mapc function (port-grafts port)))


### PR DESCRIPTION
1. Fix handling of unused keyword parameters and registration of created grafts in new `make-graft` methods

2. Fix use-before-definition problem with `panep` by defining the `pane` protocol class in `protocol-class.lisp` (and in basic instead of core)