### PR TITLE
Correctly parse defgeneric* lambda list

### DIFF
--- a/Core/clim-basic/clim-basic.asd
+++ b/Core/clim-basic/clim-basic.asd
@@ -2,6 +2,7 @@
 
 (defsystem #:clim-basic
   :depends-on ("clim-lisp"
+               "alexandria"
                "spatial-trees"
                (:version "flexichain" "1.5.1")
                "bordeaux-threads"

--- a/Core/clim-basic/setf-star.lisp
+++ b/Core/clim-basic/setf-star.lisp
@@ -1,6 +1,6 @@
 ;;; -*- Mode: Lisp; Package: CLIM-INTERNALS -*-
 
-;;;  (c) copyright 2001 by 
+;;;  (c) copyright 2001 by
 ;;;           Tim Moore (moore@bricoworks.com)
 
 ;;; This library is free software; you can redistribute it and/or
@@ -14,8 +14,8 @@
 ;;; Library General Public License for more details.
 ;;;
 ;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the 
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330, 
+;;; License along with this library; if not, write to the
+;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;;; Boston, MA  02111-1307  USA.
 
 (in-package :clim-internals)
@@ -33,21 +33,38 @@
 			    (symbol-name '#:star))
 		    (symbol-package name-sym)))))
 
+(defun make-arglist (args)
+  "Convert the list ARGS to a list of arguments in the form (var
+init-form supplied-p-parameter)."
+  (mapcar (lambda (a) `(,a nil ,(gensym))) args))
+
 (defmacro defgeneric* (fun-name lambda-list &body options)
   "Defines a SETF* generic function.  FUN-NAME is a SETF function
-name.  The last argument is the single argument to the function in a
+name.  The last required argument is the single argument to the function in a
 SETF place form; the other arguments are values collected from the
 SETF new value form."
   (unless (setf-name-p fun-name)
     (error "~S is not a valid name for a SETF* generic function." fun-name))
   (let ((setf-name (cadr fun-name))
-	(args (butlast lambda-list))
-	(place (car (last lambda-list)))
-	(gf (make-setf*-gfn-name fun-name)))
-    `(progn
-       (defsetf ,setf-name (,place) ,args
-	 `(funcall #',',gf ,,@args ,,place))
-       (defgeneric ,gf ,lambda-list ,@options))))
+        (gf (make-setf*-gfn-name fun-name)))
+    (multiple-value-bind (required optional rest keys allow-other-keys aux keyp)
+        (alexandria:parse-ordinary-lambda-list lambda-list)
+      (when aux
+        (error "The use of &aux is not allowed in generic function lambda list."))
+      (let ((optional (make-arglist (mapcar #'car optional)))
+            (keys (make-arglist (mapcar #'cadar keys))))
+        `(progn
+           (defsetf ,setf-name
+               (,(car (last required))
+                ,@(and optional `(&optional ,@optional))
+                ,@(and rest `(&rest ,rest))
+                ,@(and keyp `(&key ,@keys))
+                ,@(and allow-other-keys `(&allow-other-keys)))
+               ,(butlast required)
+             `(funcall #',',gf ,,@required
+                ,,@(mapcar (lambda (x) `(and ,(third x) ,(car x))) optional)
+                ,@,@(mapcar (lambda (x) `(and ,(third x) `(,,(make-keyword (car x)) ,,(car x)))) keys)))
+           (defgeneric ,gf ,lambda-list ,@options))))))
 
 (defmacro defmethod* (name lambda-list &body body)
   "Defines a SETF* method.  NAME is a SETF function name.  Otherwise,

--- a/Tests/setf-star.lisp
+++ b/Tests/setf-star.lisp
@@ -1,0 +1,78 @@
+(cl:in-package #:clim-tests)
+
+(def-suite* :mcclim.setf-star
+  :in :mcclim)
+
+(defclass my-point ()
+  ((x :accessor my-point-x :initarg :x)
+   (y :accessor my-point-y :initarg :y)))
+
+(defgeneric my-point-position (point))
+
+(defmethod my-point-position ((point my-point))
+  (values (my-point-x point) (my-point-y point)))
+
+(climi::defgeneric* (setf my-point-position)
+    (nx ny point &optional return-polar &key coordinates))
+
+(climi::defmethod* (setf my-point-position)
+    (nx ny (point my-point) &optional return-polar &key (coordinates :cartesian))
+  "Set X an Y positions of POINT. If COORDINATES is :CARTESIAN, NX and
+NY are the new cartesian coordinates. If COORDINATES is :POLAR, NX is
+the radial coordinate and NY is the angular coordinate. By default
+cartesian coordinates are returned. When the optional argument
+RETURN-POLAR is true then return the polar coordinates."
+  (with-slots (x y) point
+    (case coordinates
+      (:polar (multiple-value-bind (nx ny)
+                  (polar-to-caresian nx ny)
+                (setf x nx y ny)))
+      (:cartesian (setf x nx y ny))
+      (otherwise
+       (error "Invalid coordinates. Must be one of :cartesian or :polar.")))
+    (if return-polar
+        (cartesian-to-polar x y)
+        (values x y))))
+
+(defun polar-to-caresian (r a)
+  (let ((x (* r (cos a)))
+        (y (* r (sin a))))
+    (values x y)))
+
+(defun cartesian-to-polar (x y)
+  (let ((r (sqrt (+ (expt x 2) (expt y 2))))
+        (a (atan (/ y x))))
+    (values r a)))
+
+(test required-args
+  (let ((point (make-instance 'my-point :x 1 :y 2)))
+    (setf (my-point-position point) (values 3 4))
+    (is (equal (my-point-position point) (values 3 4))
+        "The new coordinates of the point are correct.")))
+
+(test optional-args
+  (let* ((point (make-instance 'my-point :x 1 :y 2))
+         (nx 3)
+         (ny 4)
+         (polar-point-coordinates (cartesian-to-polar nx ny)))
+    (is (equal (setf (my-point-position point t) (values nx ny))
+               polar-point-coordinates)
+        "Return polar coordinates are correct.")
+    (is (equal (my-point-position point) (values nx ny))
+        "The new coordinates of the point are correct.")))
+
+(test key-args
+  (let ((point (make-instance 'my-point :x 1 :y 2)))
+    (setf (my-point-position point nil :coordinates :cartesian) (values 1 pi))
+    (is (equal (my-point-position point) (values 1 pi))
+        "New position values use cartesian coordinates when the keyword argument is passed")
+
+    (setf (my-point-position point nil :coordinates :polar) (values 0 (/ pi 4)))
+    (is (<= 0 (abs (- (my-point-x point) (my-point-y point))) 0.000001)
+        "New position values use polar coordinates when the keyword argument is passed")
+
+    ;; Error is signalled because :angular is not a valid coordinates
+    ;; type
+    (signals error
+      (setf (my-point-position point :coordinates :angular) (values 1 pi)))))
+

--- a/mcclim.asd
+++ b/mcclim.asd
@@ -101,6 +101,7 @@ interface management system."
                              (:file "text-selection")
                              (:file "text-formatting")
                              (:file "text-styles")
+                             (:file "setf-star")
                              (:module "geometry"
                               :depends-on ("package")
                               :serial t


### PR DESCRIPTION
With this change, generic function lambda list is correctly parsed and
is used to construct the correct defsetf lambda list.

Closes #802, #96.