### PR TITLE
tests: fix the package conflict between clim-tests and clim

### DIFF
--- a/Tests/package.lisp
+++ b/Tests/package.lisp
@@ -1,14 +1,8 @@
 (cl:defpackage #:clim-tests
-  (:use
-   #:clim-lisp
-   #:clim
-   #:clime
-   #:fiveam)
-  (:import-from
-   #:climi
-   #:coordinate=)
-  (:export
-   #:run-tests))
+  (:use #:clim-lisp #:clim #:clime #:fiveam)
+  (:shadowing-import-from #:fiveam #:test)
+  (:import-from #:climi #:coordinate=)
+  (:export #:run-tests))
 
 (cl:in-package #:clim-tests)
 


### PR DESCRIPTION
Recently exported symbol clim:test caused a symbol name conflict with
fiveam:test symbol because clim-tests USE both packages. Use
shadowing-import to rectify that.