### PR TITLE
Move FRAME-EXIT check into RUN-FRAME-TOP-LEVEL

### DIFF
--- a/Core/clim-core/frames.lisp
+++ b/Core/clim-core/frames.lisp
@@ -377,20 +377,8 @@ documentation produced by presentations.")
 (define-condition frame-exit (condition)
   ((frame :initarg :frame :reader %frame-exit-frame)))
 
-;; I make the assumption here that the contents of *application-frame* is
-;; the frame the top-level loop is running. With the introduction of
-;; window-stream frames that may be sharing the event queue with the main
-;; application frame, we need to discriminate between them here to avoid
-;; shutting down the application at the wrong time.
-;; ...
-;; A better way to do this would be to make the handler bound in
-;; run-frame-top-level check whether the frame signalled is the one
-;; it was invoked on..                    -- Hefner
-
 (defmethod frame-exit ((frame standard-application-frame))
-  (if (eq *application-frame* frame)
-      (signal 'frame-exit :frame frame)
-      (disown-frame (frame-manager frame) frame)))
+  (signal 'frame-exit :frame frame))
 
 (defmethod frame-exit-frame ((c frame-exit))
   (%frame-exit-frame c))
@@ -470,15 +458,26 @@ documentation produced by presentations.")
       (enable-frame frame))
     (unwind-protect
          (loop
-            for query-io = (frame-query-io frame)
-            for *default-frame-manager* = (frame-manager frame)
-            do (handler-case
-                   (return (if query-io
-                               (with-input-focus (query-io)
-                                 (call-next-method))
-                               (call-next-method)))
-                 (frame-layout-changed () nil)
-                 (frame-exit ()	(return))))
+           named run-frame-loop
+           for query-io = (frame-query-io frame)
+           for *default-frame-manager* = (frame-manager frame)
+           do (block run-frame-iter
+                (handler-bind
+                    ((frame-layout-changed
+                       (lambda (c)
+                         (declare (ignore c))
+                         (return-from run-frame-iter)))
+                     (frame-exit
+                       (lambda (c)
+                         (let ((exiting-frame (frame-exit-frame c)))
+                           (if (eq exiting-frame frame)
+                               (return-from run-frame-loop)
+                               (disown-frame (frame-manager exiting-frame) exiting-frame))))))
+                  (return-from run-frame-loop
+                    (if query-io
+                        (with-input-focus (query-io)
+                          (call-next-method))
+                        (call-next-method))))))
       (case original-state
         (:disabled
          (disable-frame frame))


### PR DESCRIPTION
The comment above the function said it would be a better way of doing things, and I agree. The only thing I'm uncertain about is whether my implementation of the check is as clean as it could be; the named block within the loop that exists only so the `frame-layout-changed` handler can return from it to continue to the next iteration.