### PR TITLE
Refresh FRAME-QUERY-IO and INTERACTORP variables after commands

### DIFF
--- a/Core/clim-core/frames.lisp
+++ b/Core/clim-core/frames.lisp
@@ -535,7 +535,14 @@ documentation produced by presentations.")
                          (write-string prompt frame-query-io)
                          (funcall prompt frame-query-io frame))
                      (force-output frame-query-io))))
-               (execute-command)
+               (unwind-protect (execute-command)
+                 ;; The command may have set the frame's query I/O, in
+                 ;; which case the values of FRAME-QUERY-IO and
+                 ;; INTERACTORP would be outdated; the other stream
+                 ;; variables could be outdated as well, but they are
+                 ;; not used after executing the command
+                 (setf frame-query-io (frame-query-io frame)
+                       interactorp (typep frame-query-io 'interactor-pane)))
                (when interactorp
                  (fresh-line frame-query-io)))
            (abort ()


### PR DESCRIPTION
Without refreshing these variables, if a command updates the frame's query I/O, the fresh line on the query I/O would be output to the wrong stream (possibly leading to the next iteration of the command loop not starting on its own line in the new stream) and the ABORT restart would print its message to the frame's old query I/O stream, which could be surprising to a client who set the query I/O stream and subsequently invoked the ABORT restart.