### PR TITLE
Fix bounding region for degenerate ellipses

### DIFF
--- a/Tests/geometry/bounding-rectangles.lisp
+++ b/Tests/geometry/bounding-rectangles.lisp
@@ -55,9 +55,26 @@
     (has-valid-bounding-rectangle rectangle 0 0 5 5)))
 
 (test bounding-rectangle.ellipse
+  ;; Non-degenerate cases.
   (let ((ellipse1 (make-ellipse* 0 0 10 0 0 15))
         (ellipse2 (make-ellipse* 0 0 10 0 0 15
                                  :start-angle 0
                                  :end-angle (/ pi 2))))
     (has-valid-bounding-rectangle ellipse1 -10 -15 10 15)
-    (has-valid-bounding-rectangle ellipse2 0 -15 10 0)))
+    (has-valid-bounding-rectangle ellipse2 0 -15 10 0))
+
+  ;; Degenerate cases: horizontal and vertical lines.
+  (let ((ellipse1 (make-ellipse* 0 0 10 0 0 0))
+        (ellipse2 (make-ellipse* 0 0 0 0 0 10))
+        (ellipse3 (make-ellipse* 0 0 10 0 0 0
+                                 :end-angle (/ pi 4)))
+        (ellipse4 (make-ellipse* 0 0 0 0 0 10
+                                 :start-angle (/ pi 4))))
+    (has-valid-bounding-rectangle ellipse1 -10 0 10 0)
+    (has-valid-bounding-rectangle ellipse2 0 -10 0 10)
+    (has-valid-bounding-rectangle ellipse3 -10 0 0 0)
+    (has-valid-bounding-rectangle ellipse4 0 0 0 10))
+
+  ;; Degenerate case: point
+  (let ((ellipse (make-ellipse* 0 0 0 0 0 0)))
+    (has-valid-bounding-rectangle ellipse 0 0 0 0)))


### PR DESCRIPTION
Attempting to compute the bounding rectangle for certain degenerate ellipses (non-invertible but non-zero transform) resulted in an error while attempting to invert the transform. Since these ellipses are basically lines, compute the bounding rectangle by computing the end points of the line.