### PR TITLE
presentation-typep: implement missing methods

### DIFF
--- a/Core/clim-core/menu-choose.lisp
+++ b/Core/clim-core/menu-choose.lisp
@@ -215,7 +215,16 @@
           (when deexpose ; Checkme as well.
             (disown-frame fm frame)))))))
 
+;;; MENU-ITEM is used as a default presentation type for displaying
+;;; objects in the menu. Display object is described in the spec of
+;;; the function FRAME-MANAGER-MENU-CHOOSE. From this description it
+;;; seems that anything may be a display object, so we fix the
+;;; predicate PRESENTATION-TYPEP to always return T. -- jd 2020-07-02
 (define-presentation-type menu-item ())
+
+(define-presentation-method presentation-typep (object (type menu-item))
+  (declare (ignore object type))
+  t)
 
 (defmethod menu-choose
     (items &rest args &key associated-window &allow-other-keys)

--- a/Core/clim-core/presentations/presentation-type-functions.lisp
+++ b/Core/clim-core/presentations/presentation-type-functions.lisp
@@ -82,11 +82,9 @@ otherwise return false."
 (define-presentation-generic-function %presentation-typep presentation-typep
   (type-key parameters object type))
 
-;;; FIXME this method should return NIL. There is a problem with
-;;; MENU-ITEM translators which doesn't work without this kludge.
 (define-default-presentation-method presentation-typep (object type)
   (declare (ignore object type))
-  t)
+  nil)
 
 (defun presentation-typep (object type)
   (with-presentation-type-decoded (name parameters)

--- a/Core/clim-core/standard-presentations.lisp
+++ b/Core/clim-core/standard-presentations.lisp
@@ -129,6 +129,13 @@
 (define-presentation-type blank-area ()
   :inherit-from t)
 
+;;; Do other slots of this have to be bound in order for this to be
+;;; useful?  Guess we'll see.
+(defvar *null-presentation* (make-instance 'standard-presentation
+                                           :object nil
+                                           :type 'blank-area
+                                           :view +textual-view+))
+
 (define-presentation-method highlight-presentation ((type blank-area)
                                                     record
                                                     stream
@@ -136,20 +143,14 @@
   (declare (ignore record stream state))
   nil)
 
-;;; Do other slots of this have to be bound in order for this to be useful?
-;;; Guess we'll see.
-(defparameter *null-presentation* (make-instance 'standard-presentation
-                                                 :object nil
-                                                 :type 'blank-area
-                                                 :view +textual-view+))
+(define-presentation-method presentation-typep (object (type blank-area))
+  (eq object *null-presentation*))
 
 (define-presentation-type number ()
   :inherit-from 't)
 
 (define-presentation-method presentation-typep (object (type number))
   (numberp object))
-
-
 
 (define-presentation-type complex (&optional (type 'real))
   :inherit-from 'number)

--- a/Documentation/Specification/presentation-types.tex
+++ b/Documentation/Specification/presentation-types.tex
@@ -2024,7 +2024,7 @@ The type that represents all the places in a window where there is no
 presentation that is applicable in the current input context.  CLIM provides a
 single ``null presentation'' as the object associated with this type.
 
-\Defconst {*null-presentation*}
+\Defvar {*null-presentation*}
 
 The null presentation, which occupies all parts of a window in which there are
 no applicable presentations.  This will have a presentation type of \cl{blank-area}.

--- a/Tests/presentations/presentation-types.lisp
+++ b/Tests/presentations/presentation-types.lisp
@@ -116,4 +116,4 @@
 ;;; type T (and returned incorrectly truth for unknown relations).
 (test presentations.typep.1
   (define-presentation-type foo ())
-  (is (null (presentation-typep 3 'foo))))
+  (signals error (presentation-typep 3 'foo)))


### PR DESCRIPTION
Presentation types BLANK-AREA and MENU-ITEM had no implementation of
the presentation method PRESENTATION-TYPEP. Default method was
returning mistakenly T and recent fix to that revealed that issue.