### PR TITLE
Fix out-of-extend use in DRAW-TEXT-OUTPUT-RECORD

### DIFF
--- a/Core/clim-basic/extended-streams/recording.lisp
+++ b/Core/clim-basic/extended-streams/recording.lisp
@@ -1121,7 +1121,7 @@ were added."
 
 (defmacro generate-medium-recording-body (class-name args)
   (let ((arg-list (loop for arg in args
-                     nconc `(,(intern (symbol-name arg) :keyword) ,arg))))
+                        appending `(,(alexandria:make-keyword arg) ,arg))))
     `(progn
        (when (stream-recording-p stream)
          (let ((record

--- a/Core/clim-basic/extended-streams/recording.lisp
+++ b/Core/clim-basic/extended-streams/recording.lisp
@@ -1577,7 +1577,10 @@ were added."
     finally (return (values min-x min-y max-x max-y))))
 
 (def-grecording (draw-text :replay-fn nil) (gs-text-style-mixin gs-transformation-mixin)
-    (string start end point-x point-y align-x align-y
+    ((string (subseq string (or start 0) (or end (length string))))
+     (start  nil nil)
+     (end    nil nil)
+     point-x point-y align-x align-y
      toward-x toward-y transform-glyphs)
   ;; FIXME!!! Text direction.
   (let* ((transformation (medium-transformation medium))
@@ -1586,7 +1589,6 @@ were added."
     (multiple-value-bind (left top right bottom)
         (text-bounding-rectangle* medium string
                                   :align-x align-x :align-y align-y
-                                  :start start :end end
                                   :text-style text-style)
       (if transform-glyphs
           (enclosing-transform-polygon transformation (list (+ point-x left)  (+ point-y top)
@@ -1611,11 +1613,11 @@ were added."
     ((record draw-text-output-record) stream
      &optional (region +everywhere+) (x-offset 0) (y-offset 0))
   (declare (ignore x-offset y-offset region))
-  (with-slots (string point-x point-y start end align-x align-y toward-x
+  (with-slots (string point-x point-y align-x align-y toward-x
                toward-y transform-glyphs transformation)
       record
     (let ((medium (sheet-medium stream)))
-      (medium-draw-text* medium string point-x point-y start end align-x
+      (medium-draw-text* medium string point-x point-y 0 nil align-x
                          align-y toward-x toward-y transform-glyphs))))
 
 (defrecord-predicate draw-text-output-record

--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -602,6 +602,11 @@ STREAM in the direction DIRECTION."
 	       (values (cdr tail) t)))
     finally (return (values list nil))))
 
+(defun copy-sequence-into-vector (sequence)
+  (typecase sequence
+    (vector (copy-seq sequence))
+    (t (coerce sequence 'vector))))
+
 (defun rebind-arguments (arg-list)
   "Create temporary variables for non keywords in a list of
   arguments. Returns two values: a binding list for let, and a new

--- a/Extensions/bezier/bezier.lisp
+++ b/Extensions/bezier/bezier.lisp
@@ -72,7 +72,7 @@
 	       (values)))
 	  (t
 	   (values (+ -a1/2 (sqrt r)) (- -a1/2 (sqrt r)))))))
-  
+
 (defun dist (v z)
   #.(format nil "Compute the distance between a point and a vector~@
                  represented as a complex number.")
@@ -95,10 +95,11 @@
 (defclass translatable-record-mixin ()
   ((output-record-translation :accessor output-record-translation :initform nil)))
 
-(climi::def-grecording draw-bezier-design ((climi::gs-line-style-mixin translatable-record-mixin)
-                                           design) ()
+(climi::def-grecording draw-bezier-design
+    (climi::gs-line-style-mixin translatable-record-mixin)
+    (design)
   (let ((transformed-design (transform-region (medium-transformation medium) design))
-	(border (climi::graphics-state-line-style-border climi::graphic medium)))
+        (border (climi::graphics-state-line-style-border climi::graphic medium)))
     (declare (ignore border))
     (setf design transformed-design)
     (bounding-rectangle* design)))
@@ -412,7 +413,7 @@ second curve point, yielding (200 50)."
 ;;;
 ;;; Converting a path to a polyline or an area to a polygon
 
-;;; convert a cubic bezier segment to a list of 
+;;; convert a cubic bezier segment to a list of
 ;;; line segments
 (defun %polygonalize (p0 p1 p2 p3 &key (precision 0.01))
   (if (< (- (+ (distance p0 p1)
@@ -607,7 +608,7 @@ second curve point, yielding (200 50)."
 	   (left (reduce (lambda (a b) (if (< (dist a m) (dist b m)) a b))
 			 polygon)))
       (make-instance 'bezier-area
-        :segments 
+        :segments
 	(list (make-bezier-segment (add-points p0 right) (add-points p1 right)
 				   (add-points p2 right) (add-points p3 right))
 	      (make-line-segment (add-points p3 right) (add-points p3 left))
@@ -616,7 +617,7 @@ second curve point, yielding (200 50)."
 	      (make-line-segment (add-points p0 left) (add-points p0 right)))))))
 
 (defun area-at-point (area point)
-  (let ((transformation 
+  (let ((transformation
 	 (make-translation-transformation (point-x point) (point-y point))))
     (transform-region transformation area)))
 
@@ -629,7 +630,7 @@ second curve point, yielding (200 50)."
 	 (segments (split-segment segment split-points)))
     (loop for segment in (coerce segments 'list)
 	  if first collect (area-at-point area (slot-value segment 'p0))
-	  collect (convert-primitive-segment-to-bezier-area 
+	  collect (convert-primitive-segment-to-bezier-area
 		   (polygon-points polygon) segment)
 	  collect (area-at-point area (slot-value segment 'p3)))))
 
@@ -638,7 +639,7 @@ second curve point, yielding (200 50)."
 (defmethod convolve-regions ((area bezier-area) (path bezier-curve))
   (let ((polygon (polygonalize area)))
     (make-instance 'bezier-union
-      :areas 
+      :areas
       (loop for segment in (coerce (%segments path) 'list)
 	    for first = t then nil
 	    append (convolve-polygon-and-segment area polygon segment first)))))
@@ -1058,4 +1059,3 @@ second curve point, yielding (200 50)."
       (postscript-actualize-graphics-state stream medium :color :line-style)
       (dolist (area (negative-areas design))
         (%ps-draw-bezier-area stream medium area)))))
-


### PR DESCRIPTION
It is not generally correct or safe to store the string passed to `medium-draw-text*` in the created `draw-text-output-record` instance:

* The string could be changed after the `medium-draw-text*` call:

  ```common-lisp
  (loop with buffer = (make-string 10)
        do (fill-buffer buffer)
           (draw-text* stream buffer ...))
  ```

* The string could have dynamic extent in which case storing it in the `draw-text-output-record` would lead to out-of-extent accesses:

  ```common-lisp
  (let ((string ...))
    (declare (dynamic-extent string))
    (draw-text* stream string ...))
  ```

  This is an actual problem which leads to bad crashes for seemingly innocent things like `(princ 5 <output-recording-stream>)` in recent SBCL versions.

The fix implemented in this change lets `generate-medium-recording-body` handle an argument called `string` by inserting a call to `subseq` with appropriate start and end positions and rebinding the variables `string`, `start` and `end` with appropriate values.