### PR TITLE
Major performance improvements in `fill-image`

### DIFF
--- a/Backends/CLX-fb/package.lisp
+++ b/Backends/CLX-fb/package.lisp
@@ -1,73 +1,49 @@
-;;; -*- Mode: Lisp; Package: COMMON-LISP-USER -*-
+;;; ---------------------------------------------------------------------------
+;;;   License: LGPL-2.1+ (See file 'Copyright' for details).
+;;; ---------------------------------------------------------------------------
+;;;
+;;;  (c) copyright 2016 Alessandro Serra <gas2serra@gmail.com>
+;;;  (c) copyright 2017-2020 Daniel Kochmański <daniel@turtleware.eu>
+;;;  (c) copyright 2020 Jan Moringen <jmoringe@techfak.uni-bielefeld.de>
+;;;
+;;; ---------------------------------------------------------------------------
+;;;
+;;; Package definition for the clx-fb module.
 
-(in-package :common-lisp-user)
-
-(defpackage :clim-clx-fb
-    (:use :clim :clim-lisp :clim-backend :clim-clx :mcclim-render-extensions)
-  (:import-from :climi
-                #:+alt-key+
-                ;;
-                #:port-text-style-mappings
+(defpackage #:clim-clx-fb
+  (:use #:clim
+        #:clim-lisp
+        #:clim-backend
+        #:clim-clx
+        #:mcclim-render-extensions)
+  (:import-from #:climi
                 #:port-lookup-mirror
                 #:port-register-mirror
-                #:port-event-process
                 #:port-grafts
-                #:%%sheet-native-transformation
-                #:%%set-sheet-native-transformation
-                ;;
-                #:clamp
-                #:get-environment-variable
-                #:pixmap-sheet
-                #:port-lookup-sheet
-                #:port-unregister-mirror
-                #:port-pointer-sheet
-                #:map-repeated-sequence
-                #:pixmap-mirror
-                #:do-sequence
-                #:with-double-buffering
-                #:with-transformed-position
-                #:with-transformed-positions
-                #:with-medium-options
                 ;;
                 #:pixmap
                 #:top-level-sheet-mixin
                 #:unmanaged-sheet-mixin
-                #:top-level-sheet-pane
-                #:unmanaged-top-level-sheet-pane
-                #:menu-frame
                 ;;
-                #:frame-managers        ;used as slot
-                #:top-level-sheet       ;used as slot
-                #:medium-device-region
-                #:draw-image
-                #:height                ;this seems bogus
-                #:width                 ;dito
-                #:coordinate=
-                #:get-transformation
-                ;;
-                #:medium-miter-limit
-                ;; classes:
-                #:mirrored-pixmap
-                #:window-destroy-event
-                #:device-font-text-style
+                #:frame-managers        ; used as slot
+                #:height                ; used to access a slot
+                #:width                 ; ditto
                 ;;
                 #:make-medium)
-   (:import-from :mcclim-render-internals
-                  #:render-medium-mixin
-                  #:render-port-mixin
-                  #:image-mirror-image
-                  #:image-sheet-mixin
-                  #:image-pixmap-mixin
-                  #:image-pixmap-mixin
-                  #:image-mirror-mixin)
-   (:import-from :clim-clx
-                 #:CLX-PORT-DISPLAY
-                 #:clx-medium
-                 #:initialize-clx
-                 #:clx-port-screen
+  (:import-from #:mcclim-render-internals
+                #:render-medium-mixin
+                #:render-port-mixin
+                #:image-mirror-image
+                #:image-sheet-mixin
+                #:image-pixmap-mixin
+                #:image-mirror-mixin)
+  (:import-from #:clim-clx
+                #:clx-port-display
+                #:initialize-clx
+                #:clx-port-screen
                 #:clx-graft
                 #:clx-port-window
                 #:sheet-xmirror
-                #:sheet-direct-xmirror
-                )
-  (:import-from :climi #:standard-port))
+                #:sheet-direct-xmirror)
+  (:import-from #:climi
+                #:standard-port))

--- a/Extensions/render/image.lisp
+++ b/Extensions/render/image.lisp
@@ -116,43 +116,116 @@
                                      (width (pattern-width image))
                                      (height (pattern-height image))
                                      stencil (stencil-dx 0) (stencil-dy 0)
-                                     clip-region
-                                &aux (dst-array (climi::pattern-array image))
-                                     (x2 (+ x width -1))
-                                     (y2 (+ y height -1)))
-  "Blends DESIGN onto IMAGE with STENCIL and CLIP-REGION."
-  (let ((stencil-array (and stencil (climi::pattern-array stencil))))
-    (do-regions ((src-j j y y y2)
-                 (src-i i x x x2))
-      (when (or (null clip-region)
-                (region-contains-position-p clip-region src-i src-j))
-        (let ((alpha (if stencil-array
-                         (let ((stencil-x (+ stencil-dx i))
-                               (stencil-y (+ stencil-dy j)))
-                           (if
-                            (array-in-bounds-p stencil-array stencil-y stencil-x)
-                            (aref stencil-array stencil-y stencil-x)
-                            #xff))
-                         #xff))
-              (ink (clime:design-ink design src-i src-j)))
-          (if (typep ink 'standard-flipping-ink)
-              (let-rgba ((r.fg g.fg b.fg a.fg) (let ((d1 (slot-value ink 'climi::design1))
-                                                     (d2 (slot-value ink 'climi::design2)))
-                                                 (logior (logxor (climi::%rgba-value d1)
-                                                                 (climi::%rgba-value d2))
-                                                         #xff)))
-                (let-rgba ((r.bg g.bg b.bg a.bg) (aref dst-array j i))
-                  (setf (aref dst-array j i)
-                        (octet-blend-function* (color-octet-xor r.fg r.bg)
-                                               (color-octet-xor g.fg g.bg)
-                                               (color-octet-xor b.fg b.bg)
-                                               (octet-mult a.fg alpha)
-                                               r.bg g.bg b.bg a.bg))))
-              (let-rgba ((r.fg g.fg b.fg a.fg) (climi::%rgba-value ink))
-                (let-rgba ((r.bg g.bg b.bg a.bg) (aref dst-array j i))
-                  (setf (aref dst-array j i)
-                        (octet-blend-function* r.fg g.fg b.fg (octet-mult a.fg alpha)
-                                               r.bg g.bg b.bg a.bg)))))))))
+                                     clip-region)
+  "Blends DESIGN onto IMAGE with STENCIL and a CLIP-REGION."
+  (declare (optimize (speed 3))
+           (type image-index x y width height)
+           (type image-index-displacement stencil-dx stencil-dy))
+  ;; Try to do something smart about CLIP-REGION to avoid checking
+  ;; containment for each pixel.
+  (when clip-region
+    (let ((region (make-rectangle* x y (+ x width) (+ y height))))
+      (cond ;; Disregard CLIP-REGION if x,y,width,height is entirely contained.
+            ((region-contains-region-p clip-region region)
+             (setf clip-region nil))
+            ((bounding-rectangle-p clip-region)
+             (with-bounding-rectangle* (x1 y1 x2 y2)
+                 (region-intersection clip-region region)
+               (setf x (floor x1) y (floor y1)
+                     width (ceiling (- x2 x1)) height (ceiling (- y2 y1))
+                     clip-region nil))))))
+  (let* (;; Stencil
+         (stencil-array (and stencil (climi::pattern-array stencil)))
+         (stencil-width (when stencil-array
+                          (array-dimension stencil-array 1)))
+         (stencil-height (when stencil-array
+                           (array-dimension stencil-array 0)))
+         ;; Destination
+         (dst-array (climi::pattern-array image))
+         (x2 (+ x width -1))
+         (y2 (+ y height -1))
+         ;; Current mode and color
+         (old-alpha 255) (alpha 255)
+         old-ink ink
+         mode
+         source-rgba source-r source-g source-b source-a)
+    (declare (type (or null stencil-array) stencil-array)
+             (type argb-pixel-array dst-array)
+             (type octet old-alpha alpha))
+    (flet ((update-alpha (i j)
+             (locally (declare (type stencil-array stencil-array)
+                               (type image-dimension stencil-width stencil-height))
+               (let ((stencil-x (+ stencil-dx i))
+                     (stencil-y (+ stencil-dy j)))
+                 (setf alpha (if (and (<= 0 stencil-y stencil-height)
+                                      (<= 0 stencil-x stencil-width))
+                                 (aref stencil-array stencil-y stencil-x)
+                                 0)))))
+           (update-ink (i j)
+             (setf ink (clime:design-ink design i j))
+             (when (and (eq old-ink ink) (= old-alpha alpha))
+               (return-from update-ink))
+             (setf old-alpha alpha
+                   old-ink ink)
+             (cond ((zerop alpha)
+                    (setf mode nil))
+                   ((typep ink 'standard-flipping-ink)
+                    (setf source-rgba (let ((d1 (slot-value ink 'climi::design1))
+                                            (d2 (slot-value ink 'climi::design2)))
+                                        (logand #x00ffffff
+                                                (logxor (climi::%rgba-value d1)
+                                                        (climi::%rgba-value d2)))))
+                    (if (= alpha 255)
+                        (setf mode :flipping)
+                        (setf source-a alpha
+                              mode :flipping/blend)))
+                   ((= alpha 255)
+                    (let ((ink-rgba (climi::%rgba-value ink)))
+                      (if (= 255 (ldb (byte 8 24) ink-rgba))
+                          (setf source-rgba ink-rgba
+                                mode :copy)
+                          (let-rgba ((r g b a) ink-rgba)
+                            (setf source-r r
+                                  source-g g
+                                  source-b b
+                                  source-a a
+                                  mode :blend)))))
+                   (t ; If we get here, ALPHA is [1, 254].
+                    (locally (declare (type (integer 1 254) alpha))
+                      (let-rgba ((r.fg g.fg b.fg a.fg) (climi::%rgba-value ink))
+                        (setf source-r r.fg
+                              source-g g.fg
+                              source-b b.fg
+                              source-a (octet-mult a.fg alpha)
+                              ;; SOURCE-A is [0, 254], so never :COPY.
+                              mode (if (zerop source-a)
+                                       nil
+                                       :blend))))))))
+      (do-regions ((src-j j y y y2)
+                   (src-i i x x x2))
+        (when (or (null clip-region)
+                  (region-contains-position-p clip-region src-i src-j))
+          (when stencil-array
+            (update-alpha i j))
+          (update-ink i j)
+          (case mode ; do nothing if MODE is NIL
+            (:flipping
+             (setf (aref dst-array j i) (logxor source-rgba
+                                                (aref dst-array j i))))
+            (:flipping/blend
+             (let ((dest-rgba (aref dst-array j i)))
+               (let-rgba ((r.bg g.bg b.bg a.bg) dest-rgba)
+                 (let-rgba ((r g b) (logxor source-rgba dest-rgba))
+                   (setf (aref dst-array j i)
+                         (octet-blend-function* r    g    b    source-a
+                                                r.bg g.bg b.bg a.bg))))))
+            (:copy
+             (setf (aref dst-array j i) source-rgba))
+            (:blend
+             (let-rgba ((r.bg g.bg b.bg a.bg) (aref dst-array j i))
+               (setf (aref dst-array j i)
+                     (octet-blend-function* source-r source-g source-b source-a
+                                            r.bg     g.bg     b.bg     a.bg)))))))))
   ;; XXX These #'1- are fishy. We don't capture correct region (rounding
   ;; issue?). This problem is visible when scrolling.
   (make-rectangle* (1- x) (1- y) (+ x width) (+ y height)))

--- a/Extensions/render/types.lisp
+++ b/Extensions/render/types.lisp
@@ -21,8 +21,15 @@
 
 (cl:defconstant +image-dimension-limit+ (ash 1 30))
 
+(deftype image-dimension ()
+  `(integer 0 ,+image-dimension-limit+))
+
 (deftype image-index ()
   `(integer 0 (,+image-dimension-limit+)))
+
+(deftype image-index-displacement ()
+  `(integer ,(- (floor +image-dimension-limit+ 2))
+            (,(floor +image-dimension-limit+ 2))))
 
 (deftype stencil-array ()
   `(simple-array octet 2))

--- a/Extensions/render/utilities.lisp
+++ b/Extensions/render/utilities.lisp
@@ -43,12 +43,14 @@ top-left. Useful when we iterate over the same array and mutate its state."
 
 ;;; color functions
 
-(defmacro let-rgba (((r g b a) elt) &body body)
-  (alexandria:once-only (elt)
-    `(let ((,a (ldb (byte 8 24) ,elt))
-           (,r (ldb (byte 8 16) ,elt))
-           (,g (ldb (byte 8  8) ,elt))
-           (,b (ldb (byte 8  0) ,elt)))
+(defmacro let-rgba (((r g b &optional (a nil a-supplied-p)) rgba-integer)
+                    &body body)
+  (alexandria:once-only (rgba-integer)
+    `(let (,@(when a-supplied-p
+               `((,a (ldb (byte 8 24) ,rgba-integer))))
+           (,r (ldb (byte 8 16) ,rgba-integer))
+           (,g (ldb (byte 8  8) ,rgba-integer))
+           (,b (ldb (byte 8  0) ,rgba-integer)))
        ,@body)))
 
 (declaim (inline color-value->octet)


### PR DESCRIPTION
This gets the drawing benchmark in "red rectangle" mode to 466 on my machine.

Change details:

* Package cleanup

* New types `image-{dimension,index-displacement}`

* Declare types.

* Disregard `clip-region`, in particular the per-pixel `region-contains-position-p` check, if the image region is entirely contained in it.

* Instead of unconditionally and fully updating the alpha value and the ink-based color values once per pixel, only perform the necessary computations and do not recompute unchanged quantities.

* Depending on the flipping and blending mode, skip unnecessary flipping and blending computations.