### PR TITLE
Refactor input streams new

### DIFF
--- a/Core/clim-basic/windowing/input.lisp
+++ b/Core/clim-basic/windowing/input.lisp
@@ -327,7 +327,8 @@ use condition-variables nor locks."))
   (do-port-force-output queue)
   (check-schedule queue)
   ;; Slurp as many elements as available.
-  (loop until (null (process-next-event (event-queue-port queue) :timeout 0)))
+  (loop with port = (event-queue-port queue)
+        while (process-next-event port :timeout 0))
   (find-if predicate (event-queue-head queue)))
 
 (defmethod event-queue-listen-or-wait ((queue simple-event-queue)

--- a/Core/clim-core/frames.lisp
+++ b/Core/clim-core/frames.lisp
@@ -145,7 +145,12 @@ input focus. This is a McCLIM extension."))
                 :initform nil
                 :accessor frame-event-queue
                 :documentation "The event queue that, by default, will be
-  shared by all panes in the stream")
+                                shared by all panes in the frame")
+   (input-buffer :initarg :frame-input-buffer
+                 :initform (make-instance 'concurrent-event-queue :port nil)
+                 :accessor frame-input-buffer
+                 :documentation "The input buffer queue that, by default, will
+                                 be shared by all input streams in the frame")
    (documentation-state :accessor frame-documentation-state
                         :initform nil
                         :documentation "Used to keep of track of what
@@ -626,7 +631,8 @@ documentation produced by presentations.")
   ;; Default event-queue to the frame event queue.
   (declare (ignore event-queue))
   (if (null evq-p)
-      (let ((evq (frame-event-queue frame)))
+      (let ((evq (frame-event-queue frame))
+            (*input-buffer* (frame-input-buffer frame)))
         (apply #'call-next-method fm frame type :event-queue evq args))
       (call-next-method)))
 

--- a/Core/clim-core/presentations/translators.lisp
+++ b/Core/clim-core/presentations/translators.lisp
@@ -735,16 +735,13 @@ a presentation"
 
 (defun highlight-applicable-presentation (frame stream input-context
                                           &optional (prefer-pointer-window t))
-  (when-let ((event (event-peek stream)))
+  (when-let ((event (stream-gesture-available-p stream)))
     (let ((sheet (event-sheet event)))
       (when (or (and (typep event 'pointer-event)
 		     (or prefer-pointer-window
 			 (eq stream sheet)))
 		(typep event 'keyboard-event))
-	(frame-input-context-track-pointer frame input-context sheet event)
-	(when (typep event 'pointer-button-press-event)
-          (event-read stream)
-          (funcall *pointer-button-press-handler* stream event))))))
+	(frame-input-context-track-pointer frame input-context sheet event)))))
 
 ;;; FIXME missing functions
 ;;;

--- a/Core/clim-core/presentations/typed-input.lisp
+++ b/Core/clim-core/presentations/typed-input.lisp
@@ -32,15 +32,12 @@
                          object type)))))
 
 (defun input-context-wait-test (stream)
-  (when-let ((event (event-peek stream)))
-    (let ((sheet (event-sheet event)))
-      (and (output-recording-stream-p sheet)
-           (typep event '(or pointer-event keyboard-event))))))
+  (when-let ((gesture (stream-gesture-available-p stream)))
+    (when (eventp gesture)
+      (output-recording-stream-p (event-sheet gesture)))))
 
 (defun input-context-event-handler (stream)
-  (highlight-applicable-presentation *application-frame*
-                                     stream
-                                     *input-context*))
+  (highlight-applicable-presentation *application-frame* stream *input-context*))
 
 (defun input-context-button-press-handler (stream button-event)
   (declare (ignore stream))

--- a/Tests/input-streams.lisp
+++ b/Tests/input-streams.lisp
@@ -1,0 +1,30 @@
+(cl:in-package #:clim-tests)
+
+(def-suite* :mcclim.input-streams
+  :in :mcclim)
+
+(test input-streams.smoke-test
+  (let ((lame-event (make-instance 'pointer-event))
+        (sis (make-instance 'standard-input-stream))
+        (seis (make-instance 'standard-extended-input-stream)))
+    (is (null (climi::stream-gesture-available-p sis)))
+    (is (null (climi::stream-gesture-available-p seis)))
+    ;;
+    (finishes (climi::stream-append-gesture sis #\d))
+    (signals error (climi::stream-append-gesture sis lame-event))
+    (finishes (climi::stream-append-gesture seis #\d))
+    (finishes (climi::stream-append-gesture seis lame-event))
+    ;;
+    (is (climi::stream-gesture-available-p sis))
+    (is (climi::stream-gesture-available-p seis))
+    ;;
+    (is (char= #\d (stream-read-char sis)))
+    (is (eql #\d (stream-read-gesture seis)))
+    (is (eql lame-event (stream-read-gesture seis :peek-p t)))
+    (is (eql lame-event (stream-read-gesture seis)))
+    ;;
+    (is (null (stream-read-gesture sis :timeout 0)))
+    (is (null (stream-read-gesture seis :timeout 0)))
+    ;;
+    (is (null (climi::stream-gesture-available-p sis)))
+    (is (null (climi::stream-gesture-available-p seis)))))

--- a/mcclim.asd
+++ b/mcclim.asd
@@ -96,6 +96,7 @@ interface management system."
                 :components ((:file "package")
                              (:file "utils")
                              (:file "input-editing")
+                             (:file "input-streams")
                              (:file "commands")
                              (:file "text-selection")
                              (:file "text-formatting")


### PR DESCRIPTION
This pull request separates the event queue and the stream's input buffer. It is a preliminary step towards cross-frame presentation sensitivity.