### PR TITLE
make-clim-stream-pane

### DIFF
--- a/Apps/Listener/listener.lisp
+++ b/Apps/Listener/listener.lisp
@@ -92,7 +92,7 @@
               :default-view +listener-view+))
             (doc :pointer-documentation :default-view +listener-pointer-documentation-view+)
             (wholine (make-pane 'wholine-pane
-                                :display-function 'display-wholine :scroll-bars nil
+                                :display-function 'display-wholine
                                 :display-time :command-loop :end-of-line-action :allow)))
   (:top-level (default-frame-top-level :prompt 'print-listener-prompt))
   (:command-table (listener

--- a/Core/clim-core/panes/composition.lisp
+++ b/Core/clim-core/panes/composition.lisp
@@ -1029,12 +1029,6 @@
 (defun spacing-p (pane)
   (typep pane 'spacing-pane))
 
-(defmethod initialize-instance :after ((spacing spacing-pane) &key thickness contents &allow-other-keys)
-  (declare (ignorable thickness contents))
-  (with-slots (user-width user-min-width user-max-width
-               user-height user-min-height user-max-height)
-      spacing))
-
 (defmethod compose-space ((pane spacing-pane) &key width height)
   (declare (ignore width height))
   (with-slots (border-width) pane

--- a/Core/clim-core/panes/stream-panes.lisp
+++ b/Core/clim-core/panes/stream-panes.lisp
@@ -411,13 +411,19 @@ current background message was set."))
 (defun make-clim-interactor-pane (&rest options)
   (apply #'make-clim-stream-pane :type 'interactor-pane options))
 
-(defun make-clim-application-pane (&rest options)
+(defun make-clim-application-pane (&rest options &key (scroll-bar t scroll-bar-p) (scroll-bars scroll-bar scroll-bars-p) &allow-other-keys)
+  (unless (or scroll-bar-p scroll-bars-p)
+    (setf (getf options :scroll-bars) t))
   (apply #'make-clim-stream-pane :type 'application-pane options))
 
-(defun make-clim-pointer-documentation-pane (&rest options)
+(defun make-clim-pointer-documentation-pane (&rest options &key (scroll-bar nil scroll-bar-p) (scroll-bars scroll-bar scroll-bars-p) &allow-other-keys)
+  (unless (or scroll-bar-p scroll-bars-p)
+    (setf (getf options :scroll-bars) nil))
   (apply #'make-clim-stream-pane :type 'pointer-documentation-pane options))
 
-(defun make-clim-command-menu-pane (&rest options)
+(defun make-clim-command-menu-pane (&rest options &key (scroll-bar t scroll-bar-p) (scroll-bars scroll-bar scroll-bars-p) &allow-other-keys)
+  (unless (or scroll-bar-p scroll-bars-p)
+    (setf (getf options :scroll-bars) t))
   (apply #'make-clim-stream-pane :type 'command-menu-pane options))
 
 

--- a/Core/clim-core/panes/stream-panes.lisp
+++ b/Core/clim-core/panes/stream-panes.lisp
@@ -43,17 +43,6 @@
                             sheet-multiple-child-mixin   ; needed for GADGET-OUTPUT-RECORD
                             basic-pane)
   ((redisplay-needed :initarg :display-time)
-   (scroll-bars :type scroll-bar-spec ; (member t :vertical :horizontal nil)
-                :initform nil
-                :initarg :scroll-bar
-                :initarg :scroll-bars
-                :accessor pane-scroll-bars)
-
-                                        ; Should inherit from label-pane for this one ??
-   (label :type string
-          :initform ""
-          :initarg :label
-          :reader pane-label)
    (text-margin :initarg :text-margin
                 :reader pane-text-margin)
    (vertical-spacing :initarg :vertical-spacing
@@ -257,7 +246,6 @@
   ()
   (:default-initargs :display-time nil
                      :end-of-line-action :scroll
-                     :scroll-bars :vertical
                      :incremental-redisplay t))
 
 (defmethod initialize-instance :after ((pane interactor-pane) &rest args)
@@ -281,8 +269,7 @@
 
 (defclass application-pane (clim-stream-pane)
   ()
-  (:default-initargs :display-time :command-loop
-                     :scroll-bars t))
+  (:default-initargs :display-time :command-loop))
 
 ;;; COMMAND-MENU PANE
 
@@ -290,7 +277,6 @@
   ()
   (:default-initargs :display-time :command-loop
                      :incremental-redisplay t
-                     :scroll-bars t
                      :display-function 'display-command-menu))
 
 ;;; TITLE PANE
@@ -300,7 +286,6 @@
           :accessor title-string))
   (:default-initargs :display-time t
                      :title-string "Default Title"
-                     :scroll-bars nil
                      :text-style (make-text-style :serif :bold :very-large)
                      :display-function 'display-title))
 
@@ -332,7 +317,6 @@ be shown when there is no pointer documentation to show.")
 current background message was set."))
   (:default-initargs
    :display-time nil
-   :scroll-bars nil
    :default-view +pointer-documentation-view+
    :height     '(2 :line)
    :min-height '(2 :line)

--- a/Core/clim/text-editor-gadget.lisp
+++ b/Core/clim/text-editor-gadget.lisp
@@ -230,7 +230,6 @@ cause the activate callback to be called."))
                                :disarmed-callback disarmed-callback
                                :activation-gestures activation-gestures
                                :activate-callback activate-callback
-                               :scroll-bars scroll-bars
                                :ncolumns ncolumns
                                :nlines nlines
                                :value-changed-callback

--- a/Examples/output-record-example-1.lisp
+++ b/Examples/output-record-example-1.lisp
@@ -135,7 +135,7 @@
 ;;; we say that explicitly.
 (clim:define-application-frame output-record-example-1 ()
   ()
-  (:panes (application (clim:make-pane 'pane :scroll-bars nil))
+  (:panes (application (clim:make-pane 'pane))
           (interactor :interactor))
   (:layouts (default (clim:vertically ()
                        (7/10 application)


### PR DESCRIPTION
In the first commit I remove a method that do nothing.

In the second commit (the most important) the default value of `:scroll-bars` for the subtypes of `clim-stream-pane` are used when the pane is created with functions `make-clim-{type}-pane`

In this way the pointer-documentation-pane of the Listener now hasn't the scroll-bars.

The last commit (maybe controversial) remove the slots `scroll-bars` and `label` from `clim-stream-pane`. 

