### PR TITLE
Better keyword checking and processing in table formatting

### DIFF
--- a/Documentation/Specification/table-formatting.tex
+++ b/Documentation/Specification/table-formatting.tex
@@ -415,11 +415,13 @@ returns \term{false}.
 
 \definitarg {:x-spacing}
 \definitarg {:y-spacing}
+\definitarg {:multiple-columns}
 \definitarg {:multiple-columns-x-spacing}
 \Definitarg {:equalize-column-widths}
 
-All subclasses of \cl{table-output-record} must handle these initargs, which are
-used to specify, respectively, the $x$ and $y$ spacing, the multiple column $x$
+All subclasses of \cl{table-output-record} must handle these initargs,
+which are used to specify, respectively, the $x$ and $y$ spacing, the
+presence and number of multiple columns, the multiple column $x$
 spacing, and equal-width columns attributes of the table.
 
 \Defclass {standard-table-output-record}


### PR DESCRIPTION
* All `formatting-*` macros are specified to accept a `record-type` keyword argument and to allow other keyword arguments. This is almost certainly intended as a mechanism for passing initargs in case non-default record types are used. To make this mechanism work consistently across all macros:

  * Use `apply` with `invoke-with-new-output-record` and the passed initargs in all `invoke-with-*` functions

  * Use `&allow-other-keys` in all macros.

  * Use `gen-invoke-trampoline` in all macro.

* Check initargs which are passed as keyword argument in `formatting-*` at macroexpansion-time when possible.