### PR TITLE
Replace 606

### DIFF
--- a/Core/clim-basic/extended-streams/pointer-tracking.lisp
+++ b/Core/clim-basic/extended-streams/pointer-tracking.lisp
@@ -154,12 +154,12 @@
          (modifier-state))
     (flet ((track-pointer-event (event)
              (multiple-value-call #'track-event state event
-               (let ((sheet (event-sheet event)))
-                 (get-pointer-position (sheet event)
-                   (if (not transformp)
-                       (values x y)
-                       (with-sheet-medium (medium sheet)
-                         (transform-position (medium-transformation medium) x y))))))))
+               (let ((x (pointer-event-x event))
+                     (y (pointer-event-y event)))
+                 (if (not transformp)
+                     (values x y)
+                     (with-sheet-medium (medium (event-sheet event))
+                       (transform-position (medium-transformation medium) x y)))))))
       ;; Synthesize a pointer motion event for the current pointer
       ;; position so that appropriate handlers are called even if no
       ;; event immediately follows the INVOKE-TRACKING-POINTER call.

--- a/Core/clim-basic/windowing/events.lisp
+++ b/Core/clim-basic/windowing/events.lisp
@@ -273,35 +273,6 @@
 (defconstant +hyper-key+             #x1000)
 (defconstant +alt-key+               #x2000)
 
-(defmacro key-modifier-state-match-p (button modifier-state &body clauses)
-  (let ((button-names '((:left       . +pointer-left-button+)
-                        (:middle     . +pointer-middle-button+)
-                        (:right      . +pointer-right-button+)
-                        (:wheel-up   . +pointer-wheel-up+)
-                        (:wheel-down . +pointer-wheel-down+)))
-        (modifier-names '((:shift . +shift-key+)
-                          (:control . +control-key+)
-                          (:meta . +meta-key+)
-                          (:super . +super-key+)
-                          (:hyper . +hyper-key+)))
-        (b (gensym))
-        (m (gensym)))
-    (labels ((do-substitutes (c)
-               (cond
-                 ((null c)
-                  nil)
-                 ((consp c)
-                  (cons (do-substitutes (car c)) (do-substitutes (cdr c))))
-                 ((assoc c button-names)
-                  (list 'check-button (cdr (assoc c button-names))))
-                 ((assoc c modifier-names)
-                  (list 'check-modifier (cdr (assoc c modifier-names))))
-                 (t
-                  c))))
-      `(flet ((check-button (,b) (= ,button ,b))
-              (check-modifier (,m) (not (zerop (logand ,m ,modifier-state)))))
-         (and ,@(do-substitutes clauses))))))
-
 ;; Key names are a symbol whose value is port-specific. Key names
 ;; corresponding to the set of standard characters (such as the
 ;; alphanumerics) will be a symbol in the keyword package.

--- a/Core/clim-basic/windowing/events.lisp
+++ b/Core/clim-basic/windowing/events.lisp
@@ -120,6 +120,12 @@
    (key-character :initarg :key-character :reader keyboard-event-character
                   :initform nil)))
 
+(defmethod print-object ((event keyboard-event) stream)
+  (print-unreadable-object (event stream :type t :identity nil)
+    (format stream "NAME ~s CHARACTER ~s"
+            (keyboard-event-key-name event)
+            (keyboard-event-character event))))
+
 (define-event-class key-press-event (keyboard-event)
   ())
 
@@ -133,6 +139,12 @@
    (y :reader pointer-event-native-y)
    (graft-x :reader pointer-event-native-graft-x)
    (graft-y :reader pointer-event-native-graft-y) ))
+
+(defmethod print-object ((event pointer-event) stream)
+  (print-unreadable-object (event stream :type t :identity nil)
+    (format stream "~S ~S"
+            (pointer-event-x event)
+            (pointer-event-y event))))
 
 (defmacro get-pointer-position ((sheet event) &body body)
   (alexandria:once-only (sheet event)

--- a/Core/clim-basic/windowing/events.lisp
+++ b/Core/clim-basic/windowing/events.lisp
@@ -69,7 +69,8 @@
    ;; This slot is pretty much required in order to call handle-event. Some
    ;; events have something other than a sheet in this slot, which is gross.
    (sheet :initarg :sheet
-          :reader event-sheet)))
+          :reader event-sheet))
+  (:default-initargs :sheet (alexandria:required-argument :sheet)))
 
 (defmethod initialize-instance :after ((event standard-event) &rest initargs)
   (declare (ignore initargs))

--- a/Core/clim-basic/windowing/ports.lisp
+++ b/Core/clim-basic/windowing/ports.lisp
@@ -256,8 +256,8 @@ is a McCLIM extension.")
              (new-event (shallow-copy-object event event-class)))
         (when (typep new-event 'pointer-event)
           (get-pointer-position (target-sheet new-event)
-            (setf (slot-value new-event 'x) x
-                  (slot-value new-event 'y) y)))
+            (setf (slot-value new-event 'sheet-x) x
+                  (slot-value new-event 'sheet-y) y)))
         (setf (slot-value new-event 'sheet) target-sheet)
         (dispatch-event target-sheet new-event))))
 

--- a/Core/clim-core/frames/frames.lisp
+++ b/Core/clim-core/frames/frames.lisp
@@ -931,7 +931,9 @@ frames and will not have focus.
                                       (#.+pointer-middle-button+ "M")
                                       (#.+pointer-right-button+ "R")
                                       (#.+pointer-wheel-up+ "WheelUp")
-                                      (#.+pointer-wheel-down+ "WheelDown")))
+                                      (#.+pointer-wheel-down+ "WheelDown")
+                                      (#.+pointer-wheel-left+ "WheelLeft")
+                                      (#.+pointer-wheel-right+ "WheelRight")))
 
 (defconstant +modifier-documentation+
   '((#.+shift-key+ "sh" "Shift")

--- a/Core/clim-core/gadgets/concrete.lisp
+++ b/Core/clim-core/gadgets/concrete.lisp
@@ -1231,12 +1231,11 @@ if INVOKE-CALLBACK is given."))
   (declare (ignore invoke-callback))
   (setf (slot-value pane 'items) newval))
 
-(defmethod (setf list-pane-items)
-    :after
+(defmethod (setf list-pane-items) :after
     (newval (pane meta-list-pane) &key invoke-callback)
   (when (slot-boundp pane 'value)
     (let ((new-values
-            (coerce (climi::generic-list-pane-item-values pane) 'list))
+            (coerce (generic-list-pane-item-values pane) 'list))
           (test (list-pane-test pane)))
       (setf (gadget-value pane :invoke-callback invoke-callback)
             (if (list-pane-exclusive-p pane)
@@ -1800,8 +1799,8 @@ it in a layout between two panes that are to be resizeable.  E.g.:
                (untransform-position
                 (sheet-delta-transformation
                  (sheet-mirrored-ancestor (box-client-pane left)) nil)
-                (climi::pointer-event-native-graft-x event)
-                (climi::pointer-event-native-graft-y event))))
+                (pointer-event-native-graft-x event)
+                (pointer-event-native-graft-y event))))
         (let ((position (- (ecase orientation
                              (:vertical (left-pointer-position))
                              (:horizontal (nth-value 1 (left-pointer-position))))

--- a/Core/clim-core/panes/composition.lisp
+++ b/Core/clim-core/panes/composition.lisp
@@ -1719,13 +1719,18 @@ SCROLLER-PANE appear on the ergonomic left hand side, or leave set to
         ;; must be "sx0 < x < sx1 - viewport-width"  and
         ;;         "sy0 < y < sy1 - viewport-height"
         (scroll-extent sheet
-                       (max sx0 (min (- sx1 viewport-width)  (+ vx0 (* delta horizontal))))
-                       (max sy0 (min (- sy1 viewport-height) (+ vy0 (* delta vertical)))))))))
+                       (max sx0 (min (- sx1 viewport-width)
+                                     (+ vx0 (* delta horizontal))))
+                       (max sy0 (min (- sy1 viewport-height)
+                                     (+ vy0 (* delta vertical)))))))))
 
 (defmethod handle-event ((sheet mouse-wheel-scroll-mixin)
                          (event pointer-scroll-event))
-  (multiple-value-bind (viewport sheet) (find-viewport-for-scroll sheet)
-    (when viewport
-      (scroll-sheet sheet
-                    (pointer-event-delta-x event)
-                    (pointer-event-delta-y event)))))
+  (if (zerop (event-modifier-state event))
+      (multiple-value-bind (viewport sheet*)
+          (find-viewport-for-scroll sheet)
+        (when viewport
+          (scroll-sheet sheet*
+                        (pointer-event-delta-x event)
+                        (pointer-event-delta-y event))))
+      (call-next-method)))

--- a/Core/clim-core/panes/stream-panes.lisp
+++ b/Core/clim-core/panes/stream-panes.lisp
@@ -93,6 +93,20 @@
                          (event window-manager-focus-event))
   (setf (port-keyboard-input-focus (port sheet)) sheet))
 
+;;; This method is defined to prevent the sheet scrolling defined for the
+;;; mouse-wheel-scroll-mixin when the event activates a command. In other
+;;; words, we scroll the clim-stream-pane only when scrolling does not match
+;;; the current input context. -- jd 2020-08-29
+(defmethod handle-event ((sheet clim-stream-pane) (event pointer-scroll-event))
+  (unless (find-innermost-applicable-presentation
+           *input-context*
+           sheet
+           (pointer-event-x event)
+           (pointer-event-y event)
+           :frame (pane-frame sheet)
+           :event event)
+    (call-next-method)))
+
 (defmethod interactive-stream-p ((stream clim-stream-pane))
   t)
 

--- a/Libraries/ESA/esa.lisp
+++ b/Libraries/ESA/esa.lisp
@@ -1,31 +1,19 @@
-;;; -*- Mode: Lisp; Package: ESA -*-
-
-;;;  (c) copyright 2005 by
-;;;           Robert Strandh (strandh@labri.fr)
-;;;  (c) copyright 2006-2007 by
-;;;           Troels Henriksen (athas@sigkill.dk)
-
-;;; This library is free software; you can redistribute it and/or
-;;; modify it under the terms of the GNU Library General Public
-;;; License as published by the Free Software Foundation; either
-;;; version 2 of the License, or (at your option) any later version.
+;;; ---------------------------------------------------------------------------
+;;;   License: LGPL-2.1+ (See file 'Copyright' for details).
+;;; ---------------------------------------------------------------------------
 ;;;
-;;; This library is distributed in the hope that it will be useful,
-;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;;; Library General Public License for more details.
+;;;  (c) copyright 2005 by Robert Strandh (strandh@labri.fr)
+;;;  (c) copyright 2006-2007 by Troels Henriksen (athas@sigkill.dk)
 ;;;
-;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;;; Boston, MA  02111-1307  USA.
-
+;;; ---------------------------------------------------------------------------
+;;;
 ;;; Emacs-Style Application
+;;;
 
-(in-package :esa)
+(in-package #:esa)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; Querying ESAs.
 
 (defvar *esa-instance* nil
@@ -75,7 +63,7 @@ will probably have the same value as `*application-frame*'.")
                  previously executed by the application."))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; Info pane, a pane that displays some information about another pane
 
 (defclass info-pane (application-pane)
@@ -84,7 +72,7 @@ will probably have the same value as `*application-frame*'.")
    :background +gray85+))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; Minibuffer pane
 
 (defgeneric minibuffer (application-frame)
@@ -141,10 +129,10 @@ current message was set."))
   ;; match]".
   (unwind-protect
        (loop
-        (handler-case
-            (with-input-focus (pane)
-              (return (call-next-method)))
-          (parse-error () nil)))
+         (handler-case
+             (with-input-focus (pane)
+               (return (call-next-method)))
+           (parse-error () nil)))
     (window-clear pane)))
 
 (defmethod stream-accept ((pane minibuffer-pane) type &rest args
@@ -180,9 +168,9 @@ current message was set."))
   (let ((input-cont (gensym "INPUT-CONT"))
         (handler-cont (gensym "HANDLER-CONT")))
     `(flet ((,input-cont ()
-	      ,input-form)
-	    (,handler-cont ()
-	      ,@handler-forms))
+              ,input-form)
+            (,handler-cont ()
+              ,@handler-forms))
        (declare (dynamic-extent #',input-cont #',handler-cont))
        (invoke-handle-empty-input ,stream #',input-cont #',handler-cont))))
 
@@ -193,16 +181,16 @@ current message was set."))
 (defun empty-input-p
     (stream begin-scan-pointer activation-gestures delimiter-gestures)
   (let ((scan-pointer (stream-scan-pointer stream))
-	(fill-pointer (fill-pointer (stream-input-buffer stream))))
+        (fill-pointer (fill-pointer (stream-input-buffer stream))))
     ;; activated?
     (cond ((and (eql begin-scan-pointer scan-pointer)
-		(eql scan-pointer fill-pointer))
-	   t)
-	  ((or (eql begin-scan-pointer scan-pointer)
-	       (eql begin-scan-pointer (1- scan-pointer)))
-	   (let ((gesture 
-                  (aref (stream-input-buffer stream) begin-scan-pointer)))
-	     (and (characterp gesture)
+                (eql scan-pointer fill-pointer))
+           t)
+          ((or (eql begin-scan-pointer scan-pointer)
+               (eql begin-scan-pointer (1- scan-pointer)))
+           (let ((gesture
+                   (aref (stream-input-buffer stream) begin-scan-pointer)))
+             (and (characterp gesture)
                   (flet ((gesture-matches-p (g)
                            (if (characterp g)
                                (char= gesture g)
@@ -213,24 +201,24 @@ current message was set."))
                                (event-matches-gesture-name-p gesture g))))
                     (or (some #'gesture-matches-p activation-gestures)
                         (some #'gesture-matches-p delimiter-gestures))))))
-	  (t nil))))
+          (t nil))))
 
 (defun invoke-handle-empty-input
     (stream input-continuation handler-continuation)
   (unless (input-editing-stream-p stream)
     (return-from invoke-handle-empty-input (funcall input-continuation)))
   (let ((begin-scan-pointer (stream-scan-pointer stream))
-	(activation-gestures *activation-gestures*)
-	(delimiter-gestures *delimiter-gestures*))
+        (activation-gestures *activation-gestures*)
+        (delimiter-gestures *delimiter-gestures*))
     (block empty-input
-      (handler-bind 
+      (handler-bind
           ((parse-error
-            #'(lambda (c)
-                (declare (ignore c))
-                (when (empty-input-p stream begin-scan-pointer 
-                                     activation-gestures delimiter-gestures)
-                  (return-from empty-input nil)))))
-	(return-from invoke-handle-empty-input (funcall input-continuation))))
+             #'(lambda (c)
+                 (declare (ignore c))
+                 (when (empty-input-p stream begin-scan-pointer
+                                      activation-gestures delimiter-gestures)
+                   (return-from empty-input nil)))))
+        (return-from invoke-handle-empty-input (funcall input-continuation))))
     (funcall handler-continuation)))
 
 (defun accept-1-for-minibuffer
@@ -245,8 +233,8 @@ current message was set."))
        (delimiter-gestures nil delimitersp)
        (additional-delimiter-gestures nil  additional-delimiters-p))
   (declare (ignore provide-default history active-p
-		   prompt prompt-mode
-		   display-default query-identifier))
+                   prompt prompt-mode
+                   display-default query-identifier))
   (when (and defaultp (not default-type-p))
     (error ":default specified without :default-type"))
   (when (and activationsp additional-activations-p)
@@ -254,7 +242,7 @@ current message was set."))
             :additional-activation-gestures may be passed to accept."))
   (unless (or activationsp additional-activations-p *activation-gestures*)
     (setq activation-gestures *standard-activation-gestures*))
-  (with-input-editing 
+  (with-input-editing
       ;; this is the main change from CLIM:ACCEPT-1 -- no sensitizer.
       (stream :input-sensitizer nil)
     ;; KLUDGE: no call to CLIMI::WITH-INPUT-POSITION here, but that's
@@ -270,52 +258,52 @@ current message was set."))
       ;; setup.
       (presentation-replace-input stream default default-type view))
     (with-input-context (type)
-      (object object-type event options)
-      (with-activation-gestures ((if additional-activations-p
-				     additional-activation-gestures
-				     activation-gestures)
-				 :override activationsp)
-	(with-delimiter-gestures ((if additional-delimiters-p
-				      additional-delimiter-gestures
-				      delimiter-gestures)
-				  :override delimitersp)
-	  (let ((accept-results nil))
-	    (climi::handle-empty-input
-	     (stream)
-	     (setq accept-results
-		   (multiple-value-list
-		    (if defaultp
-			(funcall-presentation-generic-function
-			 accept type stream view
-			 :default default :default-type default-type)
-			(funcall-presentation-generic-function
-			 accept type stream view))))
-	     ;; User entered activation or delimiter gesture
-	     ;; without any input.
-	     (if defaultp
-		 (presentation-replace-input
-		  stream default default-type view :rescan nil)
-		 (simple-parse-error
-		  "Empty input for type ~S with no supplied default"
-		  type))
-	     (setq accept-results (list default default-type)))
-	    ;; Eat trailing activation gesture
-	    ;; XXX what about pointer gestures?
-	    ;; XXX and delimiter gestures?
-	    ;;
-	    ;; deleted check for *RECURSIVE-ACCEPT-P*
-	    (let ((ag (read-gesture :stream stream :timeout 0)))
-	      (unless (or (null ag) (eq ag stream))
-		(unless (activation-gesture-p ag)
-		  (unread-gesture ag :stream stream))))
-	    (values (car accept-results)
-		    (if (cdr accept-results) (cadr accept-results) type)))))
+        (object object-type event options)
+        (with-activation-gestures ((if additional-activations-p
+                                       additional-activation-gestures
+                                       activation-gestures)
+                                   :override activationsp)
+          (with-delimiter-gestures ((if additional-delimiters-p
+                                        additional-delimiter-gestures
+                                        delimiter-gestures)
+                                    :override delimitersp)
+            (let ((accept-results nil))
+              (climi::handle-empty-input
+                  (stream)
+                  (setq accept-results
+                        (multiple-value-list
+                         (if defaultp
+                             (funcall-presentation-generic-function
+                              accept type stream view
+                              :default default :default-type default-type)
+                             (funcall-presentation-generic-function
+                              accept type stream view))))
+                ;; User entered activation or delimiter gesture
+                ;; without any input.
+                (if defaultp
+                    (presentation-replace-input
+                     stream default default-type view :rescan nil)
+                    (simple-parse-error
+                     "Empty input for type ~S with no supplied default"
+                     type))
+                (setq accept-results (list default default-type)))
+              ;; Eat trailing activation gesture
+              ;; XXX what about pointer gestures?
+              ;; XXX and delimiter gestures?
+              ;;
+              ;; deleted check for *RECURSIVE-ACCEPT-P*
+              (let ((ag (read-gesture :stream stream :timeout 0)))
+                (unless (or (null ag) (eq ag stream))
+                  (unless (activation-gesture-p ag)
+                    (unread-gesture ag :stream stream))))
+              (values (car accept-results)
+                      (if (cdr accept-results) (cadr accept-results) type)))))
       ;; A presentation was clicked on, or something.
       (t
-       (when (and replace-input 
+       (when (and replace-input
                   (getf options :echo t)
                   (not (stream-rescanning-p stream)))
-         (presentation-replace-input 
+         (presentation-replace-input
           stream object object-type view :rescan nil))
        (values object object-type)))))
 
@@ -353,7 +341,7 @@ on the `format-string' and the `format-args'."
     (apply #'format minibuffer format-string format-args)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; ESA pane mixin
 
 (defclass esa-pane-mixin ()
@@ -365,7 +353,7 @@ on the `format-string' and the `format-args'."
   nil)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; Command processing
 
 (defparameter *esa-abort-gestures* `((:keyboard #\g ,(make-modifier-state :control))))
@@ -378,20 +366,20 @@ bound to the current command processor.")
 
 (defun find-gestures (gestures start-table)
   (loop with table = (find-command-table start-table)
-	for (gesture . rest) on gestures
-	for item = (find-keystroke-item  gesture table :errorp nil)
-	while item
-	do (if (eq (command-menu-item-type item) :command)
-	       (return (if (null rest) item nil))
-	       (setf table (command-menu-item-value item)))
-	finally (return item)))
+        for (gesture . rest) on gestures
+        for item = (find-keystroke-item  gesture table :errorp nil)
+        while item
+        do (if (eq (command-menu-item-type item) :command)
+               (return (if (null rest) item nil))
+               (setf table (command-menu-item-value item)))
+        finally (return item)))
 
 (defun find-gestures-with-inheritance (gestures start-table)
   (or (find-gestures gestures start-table)
       (some (lambda (table)
-	      (find-gestures-with-inheritance gestures table))
-	    (command-table-inherit-from
-	     (find-command-table start-table)))))
+              (find-gestures-with-inheritance gestures table))
+            (command-table-inherit-from
+             (find-command-table start-table)))))
 
 
 (defun gesture-matches-gesture-name-p (gesture gesture-name)
@@ -399,11 +387,11 @@ bound to the current command processor.")
 
 (defvar *meta-digit-table*
   (loop for i from 0 to 9
-	collect (list :keyboard (digit-char i) (make-modifier-state :meta))))
+        collect (list :keyboard (digit-char i) (make-modifier-state :meta))))
 
 (defun meta-digit (gesture)
   (position gesture *meta-digit-table*
-	    :test #'gesture-matches-gesture-name-p))
+            :test #'gesture-matches-gesture-name-p))
 
 (defun proper-gesture-p (gesture)
   "Return non-NIL if `gesture' is a proper gesture, NIL
@@ -444,8 +432,8 @@ preferring to a command."))
    (%remaining-keys :initform '() :accessor remaining-keys)
    (%accumulated-gestures :initform '() :accessor accumulated-gestures)
    (%overriding-handler :initform nil
-                      :accessor overriding-handler
-                      :documentation "When non-NIL, any action on
+                        :accessor overriding-handler
+                        :documentation "When non-NIL, any action on
 the command processor will be forwarded to this object.")
    (%command-executor :initform 'execute-frame-command
                       :accessor command-executor
@@ -493,9 +481,9 @@ their opinion. `Gestures' is a list of gestures.")
 
 (defmethod (setf executingp) :after ((new-val (eql t)) (drei instant-macro-execution-mixin))
   (loop until (null (remaining-keys drei))
-	for gesture = (pop (remaining-keys drei))
-	do (process-gesture drei gesture)
-	finally (setf (executingp drei) nil)))
+        for gesture = (pop (remaining-keys drei))
+        do (process-gesture drei gesture)
+        finally (setf (executingp drei) nil)))
 
 (defclass asynchronous-command-processor (command-processor
                                           instant-macro-execution-mixin)
@@ -507,7 +495,7 @@ asynchronous event handling, and not through
 
 (defmethod process-gesture :before ((command-processor asynchronous-command-processor) gesture)
   (when (and (find gesture *abort-gestures*
-              :test #'gesture-matches-gesture-name-p)
+                   :test #'gesture-matches-gesture-name-p)
              (directly-processing-p command-processor))
     (setf (accumulated-gestures command-processor) nil)
     (signal 'abort-gesture :event gesture)))
@@ -575,7 +563,7 @@ to do stuff such as incremental search)."))
 
 (defmethod process-gesture :around ((command-processor command-loop-command-processor) gesture)
   (cond ((find gesture *abort-gestures*
-          :test #'gesture-matches-gesture-name-p)
+               :test #'gesture-matches-gesture-name-p)
          ;; It is to be expected that the abort function might signal
          ;; `abort-gesture'. If that happens, we must end the command
          ;; loop, but ONLY if this is signalled.
@@ -605,50 +593,50 @@ M-2 = -12. As a special case, C-u - and M-- = -1.  In the absence
 of a prefix arg returns 1 (and nil)."
   (let ((first-gesture (pop gestures)))
     (cond ((gesture-matches-gesture-name-p
-	    first-gesture 'universal-argument)
-	   (let ((numarg 4))
-	     (loop for gesture = (first gestures)
-		   while (gesture-matches-gesture-name-p
-			  gesture 'universal-argument)
-		   do (setf numarg (* 4 numarg))
-		      (pop gestures))
-	     (let ((gesture (pop gestures))
-		   (sign +1))
-	       (when (and (characterp gesture)
-			  (char= gesture #\-))
-		 (setf gesture (pop gestures)
-		       sign -1))
+            first-gesture 'universal-argument)
+           (let ((numarg 4))
+             (loop for gesture = (first gestures)
+                   while (gesture-matches-gesture-name-p
+                          gesture 'universal-argument)
+                   do (setf numarg (* 4 numarg))
+                      (pop gestures))
+             (let ((gesture (pop gestures))
+                   (sign +1))
+               (when (and (characterp gesture)
+                          (char= gesture #\-))
+                 (setf gesture (pop gestures)
+                       sign -1))
                (cond ((and (characterp gesture)
-			   (digit-char-p gesture 10))
+                           (digit-char-p gesture 10))
                       (setf numarg (digit-char-p gesture 10))
-		      (loop for gesture = (first gestures)
-			    while (and (characterp gesture)
-				       (digit-char-p gesture 10))
-			    do (setf numarg (+ (* 10 numarg)
-					       (digit-char-p gesture 10)))
-			       (pop gestures)
-			    finally (return (values (* numarg sign) t gestures))))
-		     (t
-		      (values (if (minusp sign) -1 numarg) t
+                      (loop for gesture = (first gestures)
+                            while (and (characterp gesture)
+                                       (digit-char-p gesture 10))
+                            do (setf numarg (+ (* 10 numarg)
+                                               (digit-char-p gesture 10)))
+                               (pop gestures)
+                            finally (return (values (* numarg sign) t gestures))))
+                     (t
+                      (values (if (minusp sign) -1 numarg) t
                               (when gesture
                                 (cons gesture gestures))))))))
-	  ((or (meta-digit first-gesture)
-	       (gesture-matches-gesture-name-p
-		first-gesture 'meta-minus))
-	   (let ((numarg 0)
-		 (sign +1))
-	     (cond ((meta-digit first-gesture)
-		    (setf numarg (meta-digit first-gesture)))
-		   (t (setf sign -1)))
-	     (loop for gesture = (first gestures)
-		   while (meta-digit gesture)
-		   do (setf numarg (+ (* 10 numarg) (meta-digit gesture)))
-		      (pop gestures)
-		   finally (return (values (if (and (= sign -1) (= numarg 0))
-					       -1
-					       (* sign numarg))
-					   t gestures)))))
-	  (t (values 1 nil (when first-gesture
+          ((or (meta-digit first-gesture)
+               (gesture-matches-gesture-name-p
+                first-gesture 'meta-minus))
+           (let ((numarg 0)
+                 (sign +1))
+             (cond ((meta-digit first-gesture)
+                    (setf numarg (meta-digit first-gesture)))
+                   (t (setf sign -1)))
+             (loop for gesture = (first gestures)
+                   while (meta-digit gesture)
+                   do (setf numarg (+ (* 10 numarg) (meta-digit gesture)))
+                      (pop gestures)
+                   finally (return (values (if (and (= sign -1) (= numarg 0))
+                                               -1
+                                               (* sign numarg))
+                                           t gestures)))))
+          (t (values 1 nil (when first-gesture
                              (cons first-gesture gestures)))))))
 
 (defgeneric process-gestures (command-processor)
@@ -674,7 +662,7 @@ never refer to a command."))
              (let* ((command-table (esa-command-table command-processor))
                     (item (or (find-gestures-with-inheritance gestures command-table)
                               (command-for-unbound-gestures command-processor gestures))))
-               (cond 
+               (cond
                  ((not item)
                   (setf (accumulated-gestures command-processor) nil)
                   (error 'unbound-gesture-sequence :gestures gestures))
@@ -688,7 +676,7 @@ never refer to a command."))
                       (setf command (list command)))
                     ;; Call `*partial-command-parser*' to handle numeric
                     ;; argument.
-                    (unwind-protect 
+                    (unwind-protect
                          (setq command
                                (funcall *partial-command-parser*
                                         (esa-command-table command-processor)
@@ -719,26 +707,26 @@ never refer to a command."))
   (process-gestures command-processor))
 
 (defun esa-read-gesture (&key (command-processor *command-processor*)
-                         (stream *standard-input*))
+                           (stream *standard-input*))
   (unless (null (remaining-keys command-processor))
     (return-from esa-read-gesture
       (pop (remaining-keys command-processor))))
   (loop for gesture = (read-gesture :stream stream)
-	until (proper-gesture-p gesture)
-	finally (return gesture)))
+        until (proper-gesture-p gesture)
+        finally (return gesture)))
 
 (defun esa-unread-gesture (gesture &key (command-processor *command-processor*)
-                           (stream *standard-input*))
+                                     (stream *standard-input*))
   (cond ((recordingp command-processor)
          (cond ((equal (first (recorded-keys command-processor)) gesture)
                 (pop (recorded-keys command-processor)))
                ((equal (first (accumulated-gestures command-processor)) gesture)
                 (pop (accumulated-gestures command-processor))))
-	 (unread-gesture gesture :stream stream))
-	((executingp command-processor)
-	 (push gesture (remaining-keys command-processor)))
-	(t 
-	 (unread-gesture gesture :stream stream))))
+         (unread-gesture gesture :stream stream))
+        ((executingp command-processor)
+         (push gesture (remaining-keys command-processor)))
+        (t
+         (unread-gesture gesture :stream stream))))
 
 (define-gesture-name universal-argument :keyboard (#\u :control))
 
@@ -751,10 +739,10 @@ corresponding commands in `command-table' and invoke them using
 `command-executor'."))
 
 (defmethod process-gestures-or-command :around ((command-processor application-frame))
-  (with-input-context 
+  (with-input-context
       ('menu-item)
       (object)
-      (with-input-context 
+      (with-input-context
           (`(command :command-table ,(esa-command-table command-processor)))
           (object)
           (call-next-method)
@@ -764,7 +752,7 @@ corresponding commands in `command-table' and invoke them using
     (menu-item
      (let ((command (command-menu-item-value object)))
        (unless (listp command)
-         (setq command (list command)))       
+         (setq command (list command)))
        (when (member *unsupplied-argument-marker* command :test #'eq)
          (setq command
                (funcall
@@ -794,7 +782,7 @@ corresponding commands in `command-table' and invoke them using
             (return)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; ESA frame mixin
 
 (defclass esa-frame-mixin (command-processor)
@@ -850,7 +838,7 @@ on `frame' should be found in."))
   (esa-command-table (car (windows frame))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; Top level
 
 (defvar *extended-command-prompt*
@@ -859,67 +847,67 @@ command. This only applies when the ESA command parser is being
 used.")
 
 (defgeneric esa-top-level (frame &key
-                                 command-parser
-                                 command-unparser
-                                 partial-command-parser
-                                 prompt)
+                                   command-parser
+                                   command-unparser
+                                   partial-command-parser
+                                   prompt)
   (:documentation "Run a top-level loop for `frame', reading
   gestures and invoking the appropriate commands."))
 
 (defmacro define-esa-top-level ((frame command-parser
-                                       command-unparser
-                                       partial-command-parser
-                                       prompt) &key bindings)
+                                 command-unparser
+                                 partial-command-parser
+                                 prompt) &key bindings)
   `(defmethod esa-top-level (,frame &key
-                             (,command-parser 'esa-command-parser)
-                             ;; FIXME: maybe customize this?  Under what
-                             ;; circumstances would it be used?  Maybe try
-                             ;; turning the clim listener into an ESA?
-                             (,command-unparser  'command-line-command-unparser)
-                             (,partial-command-parser 'esa-partial-command-parser)
-                             (,prompt "Extended Command: "))
+                                      (,command-parser 'esa-command-parser)
+                                      ;; FIXME: maybe customize this?  Under what
+                                      ;; circumstances would it be used?  Maybe try
+                                      ;; turning the clim listener into an ESA?
+                                      (,command-unparser  'command-line-command-unparser)
+                                      (,partial-command-parser 'esa-partial-command-parser)
+                                      (,prompt "Extended Command: "))
      ,(let ((frame (unlisted frame)))
-           `(with-slots (windows) ,frame
-              (let ((*standard-output* (car windows))
-                    (*standard-input* (frame-standard-input ,frame))
-                    (*minibuffer* (minibuffer ,frame))
-                    (*print-pretty* nil)
-                    (*abort-gestures* *esa-abort-gestures*)
-                    (*command-parser* ,command-parser)
-                    (*command-unparser* ,command-unparser)
-                    (*partial-command-parser* ,partial-command-parser)
-                    (*extended-command-prompt* ,prompt)
-                    (*pointer-documentation-output*
-                     (frame-pointer-documentation-output ,frame))
-                    (*esa-instance* ,frame))
-                (unless (eq (frame-state ,frame) :enabled)
-                  (enable-frame ,frame))
-                (redisplay-frame-panes ,frame :force-p t)
-                (loop
-                   do (restart-case
-                          (handler-case
-                              (let* ((*command-processor* ,frame)
-                                     (command-table (find-applicable-command-table ,frame))
-                                     ,@bindings)
-                                ;; for presentation-to-command-translators,
-                                ;; which are searched for in
-                                ;; (frame-command-table *application-frame*)
-                                (redisplay-frame-pane ,frame (frame-standard-input ,frame))
-                                (setf (frame-command-table ,frame) command-table)
-                                (process-gestures-or-command ,frame))
-                            (unbound-gesture-sequence (c)
-                              (display-message "~A is not bound" (gesture-name (gestures c)))
-                              (redisplay-frame-panes ,frame))
-                            (abort-gesture (c)
-                              (if (overriding-handler ,frame)
-                                  (let ((*command-processor* (overriding-handler ,frame)))
-                                    (process-gesture (overriding-handler ,frame)
-                                                     (climi::abort-gesture-event c)))
-                                  (display-message "Quit"))
-                              (redisplay-frame-panes ,frame)))
-                        (return-to-esa ()
-                          (setf (overriding-handler ,frame) nil)
-                          (setf (remaining-keys ,frame) nil)))))))))
+        `(with-slots (windows) ,frame
+           (let ((*standard-output* (car windows))
+                 (*standard-input* (frame-standard-input ,frame))
+                 (*minibuffer* (minibuffer ,frame))
+                 (*print-pretty* nil)
+                 (*abort-gestures* *esa-abort-gestures*)
+                 (*command-parser* ,command-parser)
+                 (*command-unparser* ,command-unparser)
+                 (*partial-command-parser* ,partial-command-parser)
+                 (*extended-command-prompt* ,prompt)
+                 (*pointer-documentation-output*
+                   (frame-pointer-documentation-output ,frame))
+                 (*esa-instance* ,frame))
+             (unless (eq (frame-state ,frame) :enabled)
+               (enable-frame ,frame))
+             (redisplay-frame-panes ,frame :force-p t)
+             (loop
+               do (restart-case
+                      (handler-case
+                          (let* ((*command-processor* ,frame)
+                                 (command-table (find-applicable-command-table ,frame))
+                                 ,@bindings)
+                            ;; for presentation-to-command-translators,
+                            ;; which are searched for in
+                            ;; (frame-command-table *application-frame*)
+                            (redisplay-frame-pane ,frame (frame-standard-input ,frame))
+                            (setf (frame-command-table ,frame) command-table)
+                            (process-gestures-or-command ,frame))
+                        (unbound-gesture-sequence (c)
+                          (display-message "~A is not bound" (gesture-name (gestures c)))
+                          (redisplay-frame-panes ,frame))
+                        (abort-gesture (c)
+                          (if (overriding-handler ,frame)
+                              (let ((*command-processor* (overriding-handler ,frame)))
+                                (process-gesture (overriding-handler ,frame)
+                                                 (climi::abort-gesture-event c)))
+                              (display-message "Quit"))
+                          (redisplay-frame-panes ,frame)))
+                    (return-to-esa ()
+                      (setf (overriding-handler ,frame) nil)
+                      (setf (remaining-keys ,frame) nil)))))))))
 
 (define-esa-top-level (frame command-parser
                              command-unparser
@@ -940,7 +928,7 @@ used.")
                                                    ,@abort-clauses)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; Event handling.
 
 (defgeneric convert-to-gesture (event)
@@ -958,20 +946,20 @@ used.")
 
 (defmethod convert-to-gesture ((ev key-press-event))
   (let ((modifiers (event-modifier-state ev))
-	(event ev)
-	(char nil))
+        (event ev)
+        (char nil))
     (when (or (zerop modifiers)
-	      (eql modifiers +shift-key+))
+              (eql modifiers +shift-key+))
       (setq char (keyboard-event-character ev)))
     (if char
         (climi::char-for-read char)
-	event)))
+        event)))
 
 (defmethod convert-to-gesture ((ev pointer-button-press-event))
   ev)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; command table manipulation
 
 ;;; Helper to avoid calling find-keystroke-item at load time. In Classic CLIM
@@ -980,15 +968,15 @@ used.")
 (defun compare-gestures (g1 g2)
   (and (eql (car g1) (car g2))
        (eql (apply #'make-modifier-state (cdr g1))
-	    (apply #'make-modifier-state (cdr g2)))))
+            (apply #'make-modifier-state (cdr g2)))))
 
 (defun find-gesture-item (table gesture)
   (map-over-command-table-keystrokes
-     (lambda (name gest item)
-       (declare (ignore name))
-       (when (compare-gestures gesture gest)
-	 (return-from find-gesture-item item)))
-     table)
+   (lambda (name gest item)
+     (declare (ignore name))
+     (when (compare-gestures gesture gest)
+       (return-from find-gesture-item item)))
+   table)
   nil)
 
 (defun ensure-subtable (table gesture)
@@ -999,44 +987,42 @@ used.")
                  :key-name nil
                  :key-character (car gesture)
                  :modifier-state (apply #'make-modifier-state (cdr gesture))))
-	 (item (find-keystroke-item event table :errorp nil)))
+         (item (find-keystroke-item event table :errorp nil)))
     (when (or (null item) (not (eq (command-menu-item-type item) :menu)))
       (let ((name (gensym)))
-	(make-command-table name :errorp nil)
-	(add-menu-item-to-command-table table (symbol-name name)
-					:menu name
-					:keystroke gesture)))
+        (make-command-table name :errorp nil)
+        (add-menu-item-to-command-table table (symbol-name name)
+                                        :menu name
+                                        :keystroke gesture)))
     (command-menu-item-value
      (find-keystroke-item event table :errorp nil))))
 
 (defun set-key (command table gestures)
-  ;; WTF?
-  #-(and)
   (unless (consp command)
     (setf command (list command)))
   (let ((gesture (car gestures)))
     (cond ((null (cdr gestures))
-	   (add-keystroke-to-command-table
-	    table gesture :command command :errorp nil)
-	   (when (and (listp gesture)
-		      (find :meta gesture))
+           (add-keystroke-to-command-table
+            table gesture :command command :errorp nil)
+           (when (and (listp gesture)
+                      (find :meta gesture))
              ;; KLUDGE: this is a workaround for poor McCLIM
              ;; behaviour; really this canonization should happen in
              ;; McCLIM's input layer.
-	     (set-key command table
-		      (list (list :escape)
-			    (let ((esc-list (remove :meta gesture)))
-			      (if (and (= (length esc-list) 2)
-				       (find :shift esc-list))
-				  (remove :shift esc-list)
-				  esc-list))))))
-	  (t (set-key command
-		      (ensure-subtable table gesture)
-		      (cdr gestures))))))
+             (set-key command table
+                      (list (list :escape)
+                            (let ((esc-list (remove :meta gesture)))
+                              (if (and (= (length esc-list) 2)
+                                       (find :shift esc-list))
+                                  (remove :shift esc-list)
+                                  esc-list))))))
+          (t (set-key command
+                      (ensure-subtable table gesture)
+                      (cdr gestures))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
-;;; standard key bindings 
+;;;
+;;; standard key bindings
 
 ;;; global
 
@@ -1050,7 +1036,7 @@ First ask if modified buffers should be saved. If you decide not to save a modif
 (set-key 'com-quit 'global-esa-table '((#\x :control) (#\c :control)))
 
 (define-command (com-extended-command
-		 :command-table global-esa-table)
+                 :command-table global-esa-table)
     ()
   "Prompt for a command name and arguments, then run it."
   (let ((item (handler-case
@@ -1060,14 +1046,14 @@ First ask if modified buffers should be saved. If you decide not to save a modif
                    :prompt "" :prompt-mode :raw)
                 ((or command-not-accessible command-not-present) ()
                   (beep)
-                 (display-message "No such command")
-                 (return-from com-extended-command nil)))))
+                  (display-message "No such command")
+                  (return-from com-extended-command nil)))))
     (execute-frame-command *application-frame* item)))
 
 (set-key 'com-extended-command 'global-esa-table '((#\x :meta)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; Help
 
 (defgeneric invoke-with-help-stream (esa title continuation)
@@ -1106,14 +1092,14 @@ sense for the ESA."
 (defun describe-key-briefly (frame)
   (let ((command-table (find-applicable-command-table frame)))
     (multiple-value-bind (command gestures)
-	(read-gestures-for-help command-table)
+        (read-gestures-for-help command-table)
       (when (consp command)
-	(setf command (car command)))
+        (setf command (car command)))
       (display-message "~{~A ~}~:[is not bound~;runs the command ~:*~A~]"
-		       (mapcar #'gesture-name gestures)
-		       (or (command-line-name-for-command
-			    command command-table :errorp nil)
-			   command)))))
+                       (mapcar #'gesture-name gestures)
+                       (or (command-line-name-for-command
+                            command command-table :errorp nil)
+                           command)))))
 
 (defgeneric gesture-name (gesture))
 
@@ -1126,29 +1112,29 @@ sense for the ESA."
 
 (defun translate-name-and-modifiers (key-name modifiers)
   (with-output-to-string (s)
-      (loop for (modifier name) on (list
-					;(+alt-key+ "A-")
-					+hyper-key+ "H-"
-					+super-key+ "s-"
-					+meta-key+ "M-"
-					+control-key+ "C-")
-	      by #'cddr
-	    when (plusp (logand modifier modifiers))
-	      do (princ name s))
-      (princ (if (typep key-name 'character)
-		 (gesture-name key-name)
-		 key-name) s)))
+    (loop for (modifier name) on (list
+                                        ;(+alt-key+ "A-")
+                                  +hyper-key+ "H-"
+                                  +super-key+ "s-"
+                                  +meta-key+ "M-"
+                                  +control-key+ "C-")
+          by #'cddr
+          when (plusp (logand modifier modifiers))
+            do (princ name s))
+    (princ (if (typep key-name 'character)
+               (gesture-name key-name)
+               key-name) s)))
 
 (defmethod gesture-name ((ev keyboard-event))
   (let ((key-name (keyboard-event-key-name ev))
-	(modifiers (event-modifier-state ev)))
+        (modifiers (event-modifier-state ev)))
     (translate-name-and-modifiers key-name modifiers)))
 
 (defmethod gesture-name ((gesture list))
   (cond ((eq (car gesture) :keyboard)
-	 (translate-name-and-modifiers (second gesture) (third gesture)))
-	;; Assume `gesture' is a list of gestures.
-	(t (format nil "~{~A~#[~; ~; ~]~}" (mapcar #'gesture-name gesture)))))
+         (translate-name-and-modifiers (second gesture) (third gesture)))
+        ;; Assume `gesture' is a list of gestures.
+        (t (format nil "~{~A~#[~; ~; ~]~}" (mapcar #'gesture-name gesture)))))
 
 (defun find-keystrokes-for-command (command command-table)
   (let ((keystrokes '()))
@@ -1172,39 +1158,39 @@ sense for the ESA."
 (defun find-keystrokes-for-command-with-inheritance (command start-table)
   (let ((keystrokes '()))
     (labels  ((helper (table)
-		(let ((keys (find-keystrokes-for-command command table)))
-		  (when keys (push keys keystrokes))
-		  (dolist (subtable (command-table-inherit-from
-				     (find-command-table table)))
-		    (helper subtable)))))
+                (let ((keys (find-keystrokes-for-command command table)))
+                  (when keys (push keys keystrokes))
+                  (dolist (subtable (command-table-inherit-from
+                                     (find-command-table table)))
+                    (helper subtable)))))
       (helper start-table))
     keystrokes))
 
 (defun find-all-keystrokes-and-commands (command-table)
   (let ((results '()))
     (labels ((helper (command-table prefix)
-	       (map-over-command-table-keystrokes
-		#'(lambda (menu-name keystroke item)
-		    (declare (ignore menu-name))
-		    (cond ((eq (command-menu-item-type item) :command) 
-			   (push (cons (cons keystroke prefix)
-				       (command-menu-item-value item))
-				 results))
-			  ((eq (command-menu-item-type item) :menu)
-			   (helper (command-menu-item-value item) (cons keystroke prefix)))
-			  (t nil)))
-		command-table)))
+               (map-over-command-table-keystrokes
+                #'(lambda (menu-name keystroke item)
+                    (declare (ignore menu-name))
+                    (cond ((eq (command-menu-item-type item) :command)
+                           (push (cons (cons keystroke prefix)
+                                       (command-menu-item-value item))
+                                 results))
+                          ((eq (command-menu-item-type item) :menu)
+                           (helper (command-menu-item-value item) (cons keystroke prefix)))
+                          (t nil)))
+                command-table)))
       (helper command-table nil)
       results)))
 
 (defun find-all-keystrokes-and-commands-with-inheritance (start-table)
   (let ((results '()))
     (labels  ((helper (table)
-		(let ((res (find-all-keystrokes-and-commands table)))
-		  (when res  (setf results (nconc res results)))
-		  (dolist (subtable (command-table-inherit-from
-				     (find-command-table table)))
-		    (helper subtable)))))
+                (let ((res (find-all-keystrokes-and-commands table)))
+                  (when res  (setf results (nconc res results)))
+                  (dolist (subtable (command-table-inherit-from
+                                     (find-command-table table)))
+                    (helper subtable)))))
       (helper start-table))
     results))
 
@@ -1213,137 +1199,137 @@ sense for the ESA."
     (map-over-command-table-commands
      (lambda (command)
        (let ((keys (find-keystrokes-for-command-with-inheritance command start-table)))
-	 (push (cons command keys) results)))
+         (push (cons command keys) results)))
      start-table
      :inherited t)
     results))
 
 (defun sort-by-name (list)
-  (sort list #'string< :key (lambda (item) 
-                              (symbol-name (if (listp (cdr item)) 
-                                               (cadr item) 
+  (sort list #'string< :key (lambda (item)
+                              (symbol-name (if (listp (cdr item))
+                                               (cadr item)
                                                (cdr item))))))
 
 (defun sort-by-keystrokes (list)
   (sort list (lambda (a b)
-	       (cond ((and (characterp a)
-			   (characterp b))
-		      (char< a b))
-		     ((characterp a)
-		      t)
-		     ((characterp b)
-		      nil)
-		     (t (string< (symbol-name a)
-				 (symbol-name b)))))
-	:key (lambda (item) (second (first (first item))))))
+               (cond ((and (characterp a)
+                           (characterp b))
+                      (char< a b))
+                     ((characterp a)
+                      t)
+                     ((characterp b)
+                      nil)
+                     (t (string< (symbol-name a)
+                                 (symbol-name b)))))
+        :key (lambda (item) (second (first (first item))))))
 
 (defun describe-bindings (stream command-table
-			  &optional (sort-function #'sort-by-name))
+                          &optional (sort-function #'sort-by-name))
   (formatting-table (stream)
     (loop for (keys . command)
-	  in (funcall sort-function
-		      (find-all-keystrokes-and-commands-with-inheritance
-			   command-table))
+            in (funcall sort-function
+                        (find-all-keystrokes-and-commands-with-inheritance
+                         command-table))
           when (consp command) do (setq command (car command))
-	  do (formatting-row (stream) 
-	       (formatting-cell (stream :align-x :right)
-		 (with-text-style (stream '(:sans-serif nil nil))
-		   (present command
-                            `(command-name :command-table ,command-table)
-                            :stream stream)))
-	       (formatting-cell (stream)
-		 (with-drawing-options (stream :ink +dark-blue+
-					       :text-style '(:fix nil nil))
-		   (format stream "~&~{~A~^ ~}"
-			   (mapcar #'gesture-name (reverse keys))))))
-	  count command into length
-	  finally (change-space-requirements stream
-			 :height (* length (stream-line-height stream)))
-		  (scroll-extent stream 0 0))))
+            do (formatting-row (stream)
+                 (formatting-cell (stream :align-x :right)
+                   (with-text-style (stream '(:sans-serif nil nil))
+                     (present command
+                              `(command-name :command-table ,command-table)
+                              :stream stream)))
+                 (formatting-cell (stream)
+                   (with-drawing-options (stream :ink +dark-blue+
+                                                 :text-style '(:fix nil nil))
+                     (format stream "~&~{~A~^ ~}"
+                             (mapcar #'gesture-name (reverse keys))))))
+          count command into length
+          finally (change-space-requirements stream
+                                             :height (* length (stream-line-height stream)))
+                  (scroll-extent stream 0 0))))
 
 (defun print-docstring-for-command (command-name command-table &optional (stream *standard-output*))
-  "Print documentation for `command-name', which should 
-   be a symbol bound to a function, to `stream'. If no 
+  "Print documentation for `command-name', which should
+   be a symbol bound to a function, to `stream'. If no
    documentation can be found, this fact will be printed to the stream."
   (declare (ignore command-table))
   ;; This needs more regex magic. Also, it is only an interim
   ;; solution.
   (with-text-style (stream '(:sans-serif nil nil))
     (let* ((command-documentation (or (documentation command-name 'function)
-                                     "This command is not documented."))
-	   (first-newline (position #\Newline command-documentation))
-	   (first-line (subseq command-documentation 0 first-newline)))
+                                      "This command is not documented."))
+           (first-newline (position #\Newline command-documentation))
+           (first-line (subseq command-documentation 0 first-newline)))
       ;; First line is special
       (format stream "~A~%" first-line)
       (when first-newline
-	(let* ((rest (subseq command-documentation first-newline))
-	       (paras (delete ""
-			      (loop for start = 0 then (+ 2 end)
-				    for end = (search '(#\Newline #\Newline) rest :start2 start)
-				    collecting
-				    (nsubstitute #\Space #\Newline (subseq rest start end))
-				    while end)
-			      :test #'string=)))
-	  (dolist (para paras)
-	    (terpri stream)
-	    (let ((words (loop with length = (length para)
-			       with index = 0
-			       with start = 0
-			       while (< index length)
-			       do (loop until (>= index length)
-					while (member (char para index) '(#\Space #\Tab))
-					do (incf index))
-				  (setf start index)
-				  (loop until (>= index length)
-					until (member (char para index) '(#\Space #\Tab))
-					do (incf index))
-			       until (= start index)
-			       collecting (string-trim '(#\Space #\Tab #\Newline)
-							(subseq para start index)))))
-	      (loop with margin = (stream-text-margin stream)
-		    with space-width = (stream-character-width stream #\Space)
-		    with current-width = 0
-		    for word in words
-		    for word-width = (stream-string-width stream word)
-		    when (> (+ word-width current-width)
-				   margin)
-		      do (terpri stream)
-			 (setf current-width 0)
-		    do (princ word stream)
-		       (princ #\Space stream)
-		       (incf current-width (+ word-width space-width))))
-	    (terpri stream)))))))
+        (let* ((rest (subseq command-documentation first-newline))
+               (paras (delete ""
+                              (loop for start = 0 then (+ 2 end)
+                                    for end = (search '(#\Newline #\Newline) rest :start2 start)
+                                    collecting
+                                    (nsubstitute #\Space #\Newline (subseq rest start end))
+                                    while end)
+                              :test #'string=)))
+          (dolist (para paras)
+            (terpri stream)
+            (let ((words (loop with length = (length para)
+                               with index = 0
+                               with start = 0
+                               while (< index length)
+                               do (loop until (>= index length)
+                                        while (member (char para index) '(#\Space #\Tab))
+                                        do (incf index))
+                                  (setf start index)
+                                  (loop until (>= index length)
+                                        until (member (char para index) '(#\Space #\Tab))
+                                        do (incf index))
+                               until (= start index)
+                               collecting (string-trim '(#\Space #\Tab #\Newline)
+                                                       (subseq para start index)))))
+              (loop with margin = (stream-text-margin stream)
+                    with space-width = (stream-character-width stream #\Space)
+                    with current-width = 0
+                    for word in words
+                    for word-width = (stream-string-width stream word)
+                    when (> (+ word-width current-width)
+                            margin)
+                      do (terpri stream)
+                         (setf current-width 0)
+                    do (princ word stream)
+                       (princ #\Space stream)
+                       (incf current-width (+ word-width space-width))))
+            (terpri stream)))))))
 
-(defun describe-command-binding-to-stream (gesture command &key 
-                                           (command-table (find-applicable-command-table *application-frame*))
-                                           (stream *standard-output*))
+(defun describe-command-binding-to-stream (gesture command &key
+                                                             (command-table (find-applicable-command-table *application-frame*))
+                                                             (stream *standard-output*))
   "Describe `command' as invoked by `gesture' to `stream'."
   (let* ((command-name (if (listp command)
                            (first command)
-                           command))        
+                           command))
          (command-args (if (listp command)
                            (rest command)))
-         (real-command-table (or (command-accessible-in-command-table-p 
+         (real-command-table (or (command-accessible-in-command-table-p
                                   command-name
                                   command-table)
                                  command-table)))
     (with-text-style (stream '(:sans-serif nil nil))
       (princ "The gesture " stream)
       (with-drawing-options (stream :ink +dark-blue+
-				    :text-style '(:fix nil nil))
+                                    :text-style '(:fix nil nil))
         (princ gesture stream))
       (princ " is bound to the command " stream)
       (if (command-present-in-command-table-p command-name real-command-table)
           (with-text-style (stream '(nil :bold nil))
-	    (present command-name `(command-name :command-table ,command-table) :stream stream))
+            (present command-name `(command-name :command-table ,command-table) :stream stream))
           (present command-name 'symbol :stream stream))
       (princ " in " stream)
       (present real-command-table 'command-table :stream stream)
       (format stream ".~%")
       (when command-args
         (apply #'format stream
-	       "This binding invokes the command with these arguments: ~@{~A~^, ~}.~%"
-	       (mapcar #'(lambda (arg)
+               "This binding invokes the command with these arguments: ~@{~A~^, ~}.~%"
+               (mapcar #'(lambda (arg)
                            (cond ((eq arg *unsupplied-argument-marker*)
                                   "unsupplied-argument")
                                  ((eq arg *numeric-argument-marker*)
@@ -1354,14 +1340,14 @@ sense for the ESA."
       (scroll-extent stream 0 0))))
 
 (defun describe-command-to-stream
-    (command-name &key 
-     (command-table (find-applicable-command-table *application-frame*))
-     (stream *standard-output*))
+    (command-name &key
+                    (command-table (find-applicable-command-table *application-frame*))
+                    (stream *standard-output*))
   "Describe `command' to `stream'."
   (let ((keystrokes (find-keystrokes-for-command-with-inheritance command-name command-table)))
     (with-text-style (stream '(:sans-serif nil nil))
       (with-text-style (stream '(nil :bold nil))
-	(present command-name `(command-name :command-table ,command-table) :stream stream))
+        (present command-name `(command-name :command-table ,command-table) :stream stream))
       (princ " calls the function " stream)
       (present command-name 'symbol :stream stream)
       (princ " and is accessible in " stream)
@@ -1370,17 +1356,17 @@ sense for the ESA."
                    'command-table
                    :stream stream)
           (princ "an unknown command table" stream))
-      
+
       (format stream ".~%")
       (when (plusp (length keystrokes))
         (princ "It is bound to " stream)
         (loop for gestures-list on (first keystrokes)
-	      do (with-drawing-options (stream :ink +dark-blue+
-					       :text-style '(:fix nil nil))
-		   (format stream "~{~A~^ ~}"
-			   (mapcar #'gesture-name (reverse (first gestures-list)))))
-	      when (not (null (rest gestures-list)))
-		do (princ ", " stream))
+              do (with-drawing-options (stream :ink +dark-blue+
+                                               :text-style '(:fix nil nil))
+                   (format stream "~{~A~^ ~}"
+                           (mapcar #'gesture-name (reverse (first gestures-list)))))
+              when (not (null (rest gestures-list)))
+                do (princ ", " stream))
         (terpri stream))
       (terpri stream)
       (print-docstring-for-command command-name command-table stream)
@@ -1391,7 +1377,7 @@ sense for the ESA."
 (define-command-table help-table)
 
 (define-command (com-describe-key-briefly :name t :command-table help-table) ()
-  "Prompt for a key and show the command it invokes."  
+  "Prompt for a key and show the command it invokes."
   (display-message "Describe key briefly:")
   (redisplay-frame-panes *application-frame*)
   (describe-key-briefly *application-frame*))
@@ -1401,22 +1387,22 @@ sense for the ESA."
 (define-command (com-where-is :name t :command-table help-table) ()
   "Prompt for a command name and show the key that invokes it."
   (let* ((command-table (find-applicable-command-table *application-frame*))
-	 (command
-	  (handler-case
-	      (accept
-	       `(command-name :command-table
-			      ,command-table)
-	       :prompt "Where is command")
-	    (error () (progn (beep)
-			     (display-message "No such command")
-			     (return-from com-where-is nil)))))
-	 (keystrokes (find-keystrokes-for-command-with-inheritance command command-table)))
+         (command
+           (handler-case
+               (accept
+                `(command-name :command-table
+                               ,command-table)
+                :prompt "Where is command")
+             (error () (progn (beep)
+                              (display-message "No such command")
+                              (return-from com-where-is nil)))))
+         (keystrokes (find-keystrokes-for-command-with-inheritance command command-table)))
     (display-message "~A is ~:[not on any key~;~:*on ~{~A~^, ~}~]"
-		     (command-line-name-for-command command command-table)
-		     (mapcar (lambda (keys)
-			       (format nil "~{~A~^ ~}"
-				       (mapcar #'gesture-name (reverse keys))))
-			     (car keystrokes)))))
+                     (command-line-name-for-command command command-table)
+                     (mapcar (lambda (keys)
+                               (format nil "~{~A~^ ~}"
+                                       (mapcar #'gesture-name (reverse keys))))
+                             (car keystrokes)))))
 
 (set-key 'com-where-is 'help-table '((#\h :control) (#\w)))
 
@@ -1435,8 +1421,8 @@ Without a numeric prefix, sorts the list by command name. With a numeric prefix,
 
 (define-command (com-describe-key :name t :command-table help-table)
     ()
-  "Display documentation for the command invoked by a given gesture sequence. 
-When invoked, this command will wait for user input. If the user inputs a gesture 
+  "Display documentation for the command invoked by a given gesture sequence.
+When invoked, this command will wait for user input. If the user inputs a gesture
 sequence bound to a command available in the syntax of the current buffer,
 documentation and other details will be displayed in a typeout pane."
   (let ((command-table (find-applicable-command-table *application-frame*)))
@@ -1449,8 +1435,8 @@ documentation and other details will be displayed in a typeout pane."
         (if command
             (with-help-stream (out-stream (format nil "~10THelp: Describe Key for ~A" gesture-name))
               (describe-command-binding-to-stream gesture-name command
-               :command-table command-table
-               :stream out-stream))
+                                                  :command-table command-table
+                                                  :stream out-stream))
             (display-message "Unbound gesture: ~A" gesture-name))))))
 
 (set-key 'com-describe-key
@@ -1462,12 +1448,12 @@ documentation and other details will be displayed in a typeout pane."
   "Display documentation for the given command."
   (let ((command-table (find-applicable-command-table *application-frame*)))
     (with-help-stream (out-stream (format nil "~10THelp: Describe Command for ~A"
-					  (command-line-name-for-command command
-									 command-table
-									 :errorp nil)))
+                                          (command-line-name-for-command command
+                                                                         command-table
+                                                                         :errorp nil)))
       (describe-command-to-stream command
-       :command-table command-table
-       :stream out-stream))))
+                                  :command-table command-table
+                                  :stream out-stream))))
 
 (set-key `(com-describe-command ,*unsupplied-argument-marker*)
          'help-table
@@ -1478,7 +1464,7 @@ documentation and other details will be displayed in a typeout pane."
                   :gesture :select
                   :documentation "Describe command")
     (object)
-    (list object))
+  (list object))
 
 (define-command (com-apropos-command :name t :command-table help-table)
     ((words '(sequence string) :prompt "Search word(s)"))
@@ -1488,30 +1474,30 @@ Words are comma delimited. When more than two words are given, the documentation
   (setf words (coerce words 'list))
   (when words
     (let* ((command-table (find-applicable-command-table *application-frame*))
-	   (results (loop for (function . keys)
-			  in (find-all-commands-and-keystrokes-with-inheritance
-				  command-table)
-			  when (consp function)
-			    do (setq function (car function))
-			  when (let ((documentation (or (documentation function 'function) ""))
-				     (score 0))
-				 (cond
-				   ((> (length words) 1)
-				    (loop for word in words
-					  until (> score 1)
-					  when (or
-						 (search word (symbol-name function)
-						       :test #'char-equal)
-						 (search word documentation :test #'char-equal))
-					    do (incf score)
-					  finally (return (> score 1))))
-				   (t (or
-				       (search (first words) (symbol-name function)
-					       :test #'char-equal)
-				       (search (first words) documentation :test #'char-equal)))))
-			    collect (cons function keys))))
+           (results (loop for (function . keys)
+                            in (find-all-commands-and-keystrokes-with-inheritance
+                                command-table)
+                          when (consp function)
+                            do (setq function (car function))
+                          when (let ((documentation (or (documentation function 'function) ""))
+                                     (score 0))
+                                 (cond
+                                   ((> (length words) 1)
+                                    (loop for word in words
+                                          until (> score 1)
+                                          when (or
+                                                (search word (symbol-name function)
+                                                        :test #'char-equal)
+                                                (search word documentation :test #'char-equal))
+                                            do (incf score)
+                                          finally (return (> score 1))))
+                                   (t (or
+                                       (search (first words) (symbol-name function)
+                                               :test #'char-equal)
+                                       (search (first words) documentation :test #'char-equal)))))
+                            collect (cons function keys))))
       (if (null results)
-	  (display-message "No results for ~{~A~^, ~}" words)
+          (display-message "No results for ~{~A~^, ~}" words)
           (with-help-stream (out-stream (format nil "~10THelp: Apropos ~{~A~^, ~}" words))
             (loop for (command . keys) in results
                   for documentation = (or (documentation command 'function)
@@ -1520,24 +1506,24 @@ Words are comma delimited. When more than two words are given, the documentation
                        (present command
                                 `(command-name :command-table ,command-table)
                                 :stream out-stream))
-                  (with-drawing-options (out-stream :ink +dark-blue+
-                                                    :text-style '(:fix nil nil))
-                    (format out-stream "~30T~:[M-x ... RETURN~;~:*~{~A~^, ~}~]"
-                            (mapcar (lambda (keystrokes)
-                                      (format nil "~{~A~^ ~}"
-                                              (mapcar #'gesture-name (reverse keystrokes))))
-                                    (car keys))))
-                  (with-text-style (out-stream '(:sans-serif nil nil))
-                    (format out-stream "~&~2T~A~%"
-                            (subseq documentation 0 (position #\Newline documentation))))
+                     (with-drawing-options (out-stream :ink +dark-blue+
+                                                       :text-style '(:fix nil nil))
+                       (format out-stream "~30T~:[M-x ... RETURN~;~:*~{~A~^, ~}~]"
+                               (mapcar (lambda (keystrokes)
+                                         (format nil "~{~A~^ ~}"
+                                                 (mapcar #'gesture-name (reverse keystrokes))))
+                                       (car keys))))
+                     (with-text-style (out-stream '(:sans-serif nil nil))
+                       (format out-stream "~&~2T~A~%"
+                               (subseq documentation 0 (position #\Newline documentation))))
                   count command into length
                   finally (change-space-requirements out-stream
-                           :height (* length (stream-line-height out-stream)))
-                  (scroll-extent out-stream 0 0)))))))
+                                                     :height (* length (stream-line-height out-stream)))
+                          (scroll-extent out-stream 0 0)))))))
 
 (set-key `(com-apropos-command ,*unsupplied-argument-marker*)
-	 'help-table
-	 '((#\h :control) (#\a)))
+         'help-table
+         '((#\h :control) (#\a)))
 
 (define-menu-table help-menu-table (help-table)
   'com-where-is
@@ -1548,14 +1534,14 @@ Words are comma delimited. When more than two words are given, the documentation
   `(com-apropos-command ,*unsupplied-argument-marker*))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; Keyboard macros
 
 (define-command-table keyboard-macro-table)
 
 (define-command (com-start-kbd-macro
-		 :name t
-		 :command-table keyboard-macro-table)
+                 :name t
+                 :command-table keyboard-macro-table)
     ()
   "Start recording keys to define a keyboard macro.
 Use C-x ) to finish recording the macro, and C-x e to run it."
@@ -1565,21 +1551,21 @@ Use C-x ) to finish recording the macro, and C-x e to run it."
 (set-key 'com-start-kbd-macro 'keyboard-macro-table '((#\x :control) #\())
 
 (define-command (com-end-kbd-macro
-		 :name t
-		 :command-table keyboard-macro-table)
+                 :name t
+                 :command-table keyboard-macro-table)
     ()
   "Finish recording keys that define a keyboard macro.
 Use C-x ( to start recording a macro, and C-x e to run it."
   (setf (recordingp *command-processor*) nil)
   (setf (recorded-keys *command-processor*)
-	;; this won't work if the command was invoked in any old way
-	(reverse (cddr (recorded-keys *command-processor*)))))
+        ;; this won't work if the command was invoked in any old way
+        (reverse (cddr (recorded-keys *command-processor*)))))
 
 (set-key 'com-end-kbd-macro 'keyboard-macro-table '((#\x :control) #\)))
 
 (define-command (com-call-last-kbd-macro
-		 :name t
-		 :command-table keyboard-macro-table)
+                 :name t
+                 :command-table keyboard-macro-table)
     ((count 'integer :prompt "How many times?" :default 1))
   "Run the last keyboard macro that was defined.
 Use C-x ( to start and C-x ) to finish recording a keyboard macro."
@@ -1596,15 +1582,15 @@ Use C-x ( to start and C-x ) to finish recording a keyboard macro."
   `(com-call-last-kbd-macro ,*unsupplied-argument-marker*))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; example application
 
 (defclass example-info-pane (info-pane)
   ()
   (:default-initargs
-      :height 20 :max-height 20 :min-height 20
-      :display-function 'display-info
-      :incremental-redisplay t))
+   :height 20 :max-height 20 :min-height 20
+   :display-function 'display-info
+   :incremental-redisplay t))
 
 (defun display-info (frame pane)
   (declare (ignore frame))
@@ -1613,32 +1599,32 @@ Use C-x ( to start and C-x ) to finish recording a keyboard macro."
 (defclass example-minibuffer-pane (minibuffer-pane)
   ()
   (:default-initargs
-      :height 20 :max-height 20 :min-height 20))
+   :height 20 :max-height 20 :min-height 20))
 
 (defclass example-pane (esa-pane-mixin application-pane)
   ((contents :initform "hello" :accessor contents)))
 
 (define-application-frame example (esa-frame-mixin
-				   standard-application-frame)
+                                   standard-application-frame)
   ()
   (:panes
    (window (let* ((my-pane (make-pane 'example-pane
-				      :width 900 :height 400
-				      :display-function 'display-my-pane
-				      :command-table 'global-example-table))
-		  (my-info-pane (make-pane 'example-info-pane
-					   :master-pane my-pane
-					   :width 900)))
-	     (setf (windows *application-frame*) (list my-pane))
-	     (vertically ()
-			 (scrolling ()
-				    my-pane)
-			 my-info-pane)))
+                                      :width 900 :height 400
+                                      :display-function 'display-my-pane
+                                      :command-table 'global-example-table))
+                  (my-info-pane (make-pane 'example-info-pane
+                                           :master-pane my-pane
+                                           :width 900)))
+             (setf (windows *application-frame*) (list my-pane))
+             (vertically ()
+               (scrolling ()
+                 my-pane)
+               my-info-pane)))
    (minibuffer (make-pane 'example-minibuffer-pane :width 900)))
   (:layouts
    (default (vertically (:scroll-bars nil)
-			window
-			minibuffer)))
+              window
+              minibuffer)))
   (:top-level (esa-top-level)))
 
 (defun display-my-pane (frame pane)
@@ -1648,13 +1634,13 @@ Use C-x ( to start and C-x ) to finish recording a keyboard macro."
 (defun example (&key (width 900) (height 400))
   "Starts up the example application"
   (let ((frame (make-application-frame
-		'example
-		:width width :height height)))
+                'example
+                :width width :height height)))
     (run-frame-top-level frame)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; 
+;;;
 ;;; Commands and key bindings
 
 (define-command-table global-example-table
-    :inherit-from (global-esa-table keyboard-macro-table))
+  :inherit-from (global-esa-table keyboard-macro-table))

--- a/Libraries/ESA/esa.lisp
+++ b/Libraries/ESA/esa.lisp
@@ -992,11 +992,13 @@ used.")
   nil)
 
 (defun ensure-subtable (table gesture)
+  ;; Not having a sheet here is not conforming.
   (let* ((event (make-instance
-		'key-press-event
-		:key-name nil
-		:key-character (car gesture)
-		:modifier-state (apply #'make-modifier-state (cdr gesture))))
+                 'key-press-event
+                 :sheet nil
+                 :key-name nil
+                 :key-character (car gesture)
+                 :modifier-state (apply #'make-modifier-state (cdr gesture))))
 	 (item (find-keystroke-item event table :errorp nil)))
     (when (or (null item) (not (eq (command-menu-item-type item) :menu)))
       (let ((name (gensym)))

--- a/Tests/input-streams.lisp
+++ b/Tests/input-streams.lisp
@@ -4,7 +4,7 @@
   :in :mcclim)
 
 (test input-streams.smoke-test
-  (let ((lame-event (make-instance 'pointer-event))
+  (let ((lame-event (make-instance 'pointer-event :sheet nil))
         (sis (make-instance 'standard-input-stream))
         (seis (make-instance 'standard-extended-input-stream)))
     (is (null (climi::stream-gesture-available-p sis)))

--- a/package.lisp
+++ b/package.lisp
@@ -1606,7 +1606,6 @@
   ;; draw-triangle
   ;; draw-triangle*
   ;; gadget-label-text-style
-  ;; key-modifier-state-match-p
   ;; pointer-button-click-and-hold-event
   ;; pointer-button-double-click-event
   ;; pointer-port


### PR DESCRIPTION
This PR is a replacement for #606. Slider improvements were merged earlier, so they are not backported, and scroll-bar handle-event method is not backported because I don't personally think it is a good idea -- it is not consistent with existing toolkits.

- recognize wheel-left and wheel-right pointer gestures
- add a pointer-scroll gesture
- add named gestures scroll-up and scroll-down
- clim-stream-pane does not scroll the sheet if the gesture has associated translator
- mouse-wheel-scroll-mixin forwards the pointer-scroll-event if it has modifiers