### PR TITLE
seis: remove character input methods

### DIFF
--- a/Core/clim-basic/extended-streams/stream-input.lisp
+++ b/Core/clim-basic/extended-streams/stream-input.lisp
@@ -381,18 +381,6 @@ keys read."))
             (t
              (return-from stream-read-gesture gesture)))))))
 
-;;; FIXME STANDARD-EXTENDED-INPUT-STREAM isn't a character stream, however the
-;;; implementation of ACCEPT assumes that it is.
-
-(defmethod stream-read-char-no-hang ((stream standard-extended-input-stream))
-  (loop
-    for ch = (stream-read-gesture stream :timeout 0)
-    when (or (characterp ch) (null ch))
-      return ch))
-
-(defmethod stream-unread-char ((stream standard-extended-input-stream) char)
-  (stream-unread-gesture stream char))
-
 
 ;;; stream-read-gesture on string strings. Needed for accept-from-string.
 

--- a/Core/clim-core/builtin-commands.lisp
+++ b/Core/clim-core/builtin-commands.lisp
@@ -351,11 +351,11 @@
     (if (or subform-read auto-activate)
         (values object ptype)
         (loop
-           for c = (read-char stream)
-           until (or (activation-gesture-p c) (delimiter-gesture-p c))
-           finally
-             (when (delimiter-gesture-p c)
-               (unread-char c stream))
+          for gesture = (read-gesture :stream stream)
+          until (or (activation-gesture-p gesture) (delimiter-gesture-p gesture))
+          finally
+             (when (delimiter-gesture-p gesture)
+               (unread-gesture gesture :stream stream))
              (return (values object ptype))))))
 
 (define-presentation-method accept ((type expression)
@@ -408,12 +408,12 @@
     (if (or subform-read auto-activate)
         (values object ptype)
         (loop
-           for c = (read-char stream)
-           until (or (activation-gesture-p c) (delimiter-gesture-p c))
-           finally
-           (when (delimiter-gesture-p c)
-             (unread-char c stream))
-           (return (values object ptype))))))
+          for gesture = (read-gesture :stream stream)
+          until (or (activation-gesture-p gesture) (delimiter-gesture-p gesture))
+          finally
+             (when (delimiter-gesture-p gesture)
+               (unread-gesture gesture :stream stream))
+             (return (values object ptype))))))
 
 
 (with-system-redefinition-allowed

--- a/Core/clim-core/commands.lisp
+++ b/Core/clim-core/commands.lisp
@@ -1076,7 +1076,7 @@ examine the type of the command menu item to see if it is
                       :stream stream :view view
                       :default default :prompt prompt
                       :additional-delimiter-gestures '(#\space))))
-    (read-char stream)
+    (read-gesture :stream stream)
     (accept type :stream stream :view view :prompt nil)))
 
 ;;; The default for :provide-output-destination-keyword is nil until we fix

--- a/Core/clim-core/input-editing.lisp
+++ b/Core/clim-core/input-editing.lisp
@@ -1224,10 +1224,10 @@ protocol retrieving gestures from a provided string."))
                         ;; XXX what about pointer gestures?
                         ;; XXX and delimiter gestures?
                         (unless *recursive-accept-p*
-                          (let ((ag (read-char-no-hang stream nil stream t)))
+                          (let ((ag (read-gesture :stream stream :timeout 0)))
                             (unless (or (null ag) (eq ag stream))
                               (unless (activation-gesture-p ag)
-                                (unread-char ag stream)))))
+                                (unread-gesture ag :stream stream)))))
                         (values (car accept-results) (if (cdr accept-results)
                                                          (cadr accept-results)
                                                          type)))))

--- a/Core/clim-core/standard-presentations.lisp
+++ b/Core/clim-core/standard-presentations.lisp
@@ -878,10 +878,10 @@
                            :prompt nil
                            :additional-delimiter-gestures separators)
      collect element
-     do (progn
-          (when (not (eql (peek-char nil stream nil nil) separator))
+     do (let ((gesture (stream-read-gesture stream :peek-p t)))
+          (when (not (eql gesture separator))
             (loop-finish))
-          (read-char stream)
+          (stream-read-gesture stream)
           (when echo-space
             ;; Make the space a noise string
             (input-editor-format stream " ")))))
@@ -982,10 +982,10 @@
                       :display-default nil
                       :additional-delimiter-gestures separators))
      collect element into sequence-val
-     do (progn
-          (when (not (eql (peek-char nil stream nil nil) separator))
+     do (let ((gesture (stream-read-gesture stream :peek-p t)))
+          (when (not (eql gesture separator))
             (loop-finish))
-          (read-char stream)
+          (stream-read-gesture stream)
           (when echo-space
             ;; Make the space a noise string
             (input-editor-format stream " ")))

--- a/Libraries/ESA/esa.lisp
+++ b/Libraries/ESA/esa.lisp
@@ -304,10 +304,10 @@ current message was set."))
 	    ;; XXX and delimiter gestures?
 	    ;;
 	    ;; deleted check for *RECURSIVE-ACCEPT-P*
-	    (let ((ag (read-char-no-hang stream nil stream t)))
+	    (let ((ag (read-gesture :stream stream :timeout 0)))
 	      (unless (or (null ag) (eq ag stream))
 		(unless (activation-gesture-p ag)
-		  (unread-char ag stream))))
+		  (unread-gesture ag :stream stream))))
 	    (values (car accept-results)
 		    (if (cdr accept-results) (cadr accept-results) type)))))
       ;; A presentation was clicked on, or something.


### PR DESCRIPTION
This commit solves the regression where reading sequences were not working.