### PR TITLE
Fix box-pane and rack layouts with +FILL+ and spacing

### DIFF
--- a/Core/clim-core/panes/composition.lisp
+++ b/Core/clim-core/panes/composition.lisp
@@ -618,9 +618,9 @@
                                ((lambda (major minor) height width) x 0)
                                ((lambda (major minor) width height) x 0)
                                ((lambda (major minor) height width) width real-width)
-                               ((lambda (major minor) height width) real-height height)))
-               (incf x major)
-               (incf x spacing))))
+                               ((lambda (major minor) height width) real-height height))
+                 (incf x spacing))
+               (incf x major))))
 
   (defmethod box-layout-mixin/xically-allocate-space ((pane rack-layout-mixin) real-width real-height)
     (multiple-value-bind (majors minors)
@@ -637,9 +637,9 @@
                                ((lambda (major minor) height width) x 0)
                                ((lambda (major minor) width height) x 0)
                                ((lambda (major minor) height width) width real-width)
-                               ((lambda (major minor) height width) real-height height)))
-               (incf x major)
-               (incf x spacing)))))
+                               ((lambda (major minor) height width) real-height height))
+                 (incf x spacing))
+               (incf x major)))))
 
 (defmethod reorder-sheets :after ((pane box-layout-mixin) new-order)
   ;; Bring the order of the clients in sync with the new order of the


### PR DESCRIPTION
The two `box-layout-mixin/xically-allocate-space` methods lay out child panes sequentially, keeping track of the offset in the major dimension. This offset is increased according to the allotted widths of children as well as the spacing between children. Before this change, a `+fill+` client (which does not have a pane and thus does not need spacing) caused one additional unit of spacing to be added to the offset, potentially pushing the final "real" client out of the allocated region.

The following screenshot shows the issue when adding `:x-spacing 8` to the `horizontally` containing the push buttons in the file selector demo:
![screenshot2](https://user-images.githubusercontent.com/150189/92264945-55091e00-eedf-11ea-85bc-18fef48acdf2.png)
