### PR TITLE
commands: MAKE-COMMAND-TABLE does not add GLOBAL-COMMAND-TABLE

### DIFF
--- a/Core/clim-core/commands/tables.lisp
+++ b/Core/clim-core/commands/tables.lisp
@@ -92,8 +92,6 @@
 
 ;;; adjusted to allow anonymous command-tables for menu-bars
 (defun make-command-table (name &key inherit-from menu inherit-menu (errorp t))
-  (unless inherit-from
-    (setq inherit-from '(global-command-table)))
   (if (and name errorp (gethash name *command-tables*))
       (error 'command-table-already-exists :command-table-name name)
       (let ((result (make-instance 'standard-command-table

--- a/Documentation/Manual/LaTeX/chap-using-command-tables.tex
+++ b/Documentation/Manual/LaTeX/chap-using-command-tables.tex
@@ -28,10 +28,6 @@ returned.
 \Defun {make-command-table} {\\name \key inherit-from menu
   inherit-menu (errorp t)}
 
-By default command tables inherit from
-\texttt{global-command-table}. According to the CLIM~2.0
-specification, a command table inherits from no command table if
-\texttt{nil} is passed as an explicit argument to
-\textit{inherit-from}. In revision~2.2 all command tables must inherit
-from \texttt{global-command-table}. McCLIM treats a \texttt{nil} value
-of \textit{inherit-from} as specifying \texttt{'(global-command-table)}.
+By default command tables inherit from \texttt{global-command-table}. A
+command table inherits from no command table if \texttt{nil} is passed as an
+explicit argument to \textit{inherit-from}.

--- a/Documentation/Manual/Texinfo/reference-manual.texi
+++ b/Documentation/Manual/Texinfo/reference-manual.texi
@@ -634,13 +634,9 @@ doesn't have to) trigger @gloss{layout-protocol}.  Macro
 @defun {@symbol{make-command-table,clim}} {name &key inherit-from inherit-menu (errorp t)}
 @end defun
 
-By default command tables inherit from
-@cl{global-command-table}. According to the @clim{} 2.0 specification, a
-command table inherits from no command table if @t{nil} is passed as an
-explicit argument to @var{inherit-from}. In revision 2.2 all command
-tables must inherit from @cl{global-command-table}. @mcclim{} treats a
-@t{nil} value of @var{inherit-from} as specifying
-@cl{'(global-command-table)}.
+By default command tables inherit from @cl{global-command-table}. A
+command table inherits from no command table if @t{nil} is passed as
+an explicit argument to @var{inherit-from}.
 
 @node Incremental redisplay
 @section Incremental redisplay


### PR DESCRIPTION
The specification entry for `make-command-table` explicitly says:

>  make-command-table does not implicitly include CLIM's global command
>  table in the inheritance list for the new command table.