### PR TITLE
stream-input: drop STRING-STREAM hack for SBCL and CMUCL

### DIFF
--- a/Core/clim-basic/extended-streams/stream-input.lisp
+++ b/Core/clim-basic/extended-streams/stream-input.lisp
@@ -384,24 +384,15 @@ keys read."))
 
 ;;; stream-read-gesture on string strings. Needed for accept-from-string.
 
-;;; XXX Evil hack because "string-stream" isn't the superclass of
-;;; string streams in CMUCL/SBCL...
-
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defvar *string-input-stream-class* (with-input-from-string (s "foo")
-                                        (class-name (class-of s)))))
-
-(defmethod stream-read-gesture ((stream #.*string-input-stream-class*)
+(defmethod stream-read-gesture ((stream string-stream)
                                 &key peek-p &allow-other-keys)
-  (let ((char (if peek-p
-                  (peek-char nil stream nil nil)
-                  (read-char stream nil nil))))
-    (if char
-        char
-        (values nil :eof))))
+  (if-let ((char (if peek-p
+                     (peek-char nil stream nil nil)
+                     (read-char stream nil nil))))
+    char
+    (values nil :eof)))
 
-(defmethod stream-unread-gesture ((stream #.*string-input-stream-class*)
-                                  gesture)
+(defmethod stream-unread-gesture ((stream string-stream) gesture)
   (unread-char gesture stream))
 
 


### PR DESCRIPTION
I verified with CMUCL 21D Unicode and SBCL 2.0.6 that `string-stream` is now a direct superclass of the respective string input stream class.