### PR TITLE
Fixup for layout changes

### DIFF
--- a/Core/clim-core/frames/define-application-frame.lisp
+++ b/Core/clim-core/frames/define-application-frame.lisp
@@ -98,7 +98,7 @@
                  (:top-level             1 :type (cons (or symbol cons) list))
                  ;; :icon is the CLIM specification but we don't support it
                  (:geometry              *)
-                 ;; :resize-frame is mentioned in a spec annotation but we don't support it
+                 (:resize-frame          1)
                  ;; McCLIM extensions
                  (:pointer-documentation 1)
                  ;; Default initargs
@@ -176,6 +176,7 @@
                             disabled-commands
                             (top-level '(default-frame-top-level))
                             geometry
+                            resize-frame
                             ;; McCLIM extensions
                             pointer-documentation
                             ;; Default initargs
@@ -201,6 +202,7 @@
           :menu-bar          ',menu-bar
           :current-layout    ',current-layout
           :layouts           ',layouts
+          :resize-frame      ',resize-frame
           :top-level         (list ',(car top-level) ,@(cdr top-level))
           :top-level-lambda  (lambda (,frame-arg)
                                (,(car top-level) ,frame-arg

--- a/Core/clim-core/frames/frames.lisp
+++ b/Core/clim-core/frames/frames.lisp
@@ -74,10 +74,6 @@
   (declare (ignore frame-manager frame command-name))
   nil)
 
-;;; Application-Frame class
-;;; XXX All these slots should move to a mixin or to standard-application-frame.
-;;; -- moore
-
 (defclass standard-application-frame (application-frame
                                       presentation-history-mixin)
   ((port :initform nil
@@ -174,20 +170,20 @@ documentation produced by presentations.")
                   :initarg :left
                   :initform nil)
    (geometry-right :accessor geometry-right
-                  :initarg :right
-                  :initform nil)
+                   :initarg :right
+                   :initform nil)
    (geometry-top :accessor geometry-top
-                  :initarg :top
-                  :initform nil)
+                 :initarg :top
+                 :initform nil)
    (geometry-bottom :accessor geometry-bottom
-                  :initarg :bottom
-                  :initform nil)
+                    :initarg :bottom
+                    :initform nil)
    (geometry-width :accessor geometry-width
-                  :initarg :width
-                  :initform nil)
+                   :initarg :width
+                   :initform nil)
    (geometry-height :accessor geometry-height
-                  :initarg :height
-                  :initform nil)))
+                    :initarg :height
+                    :initform nil)))
 
 (defmethod frame-parent ((frame standard-application-frame))
   (or (frame-calling-frame frame)

--- a/Core/clim-core/panes/layout-protocol.lisp
+++ b/Core/clim-core/panes/layout-protocol.lisp
@@ -454,6 +454,7 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
 
 (defmethod change-space-requirements ((pane layout-protocol-mixin)
                                       &key resize-frame &allow-other-keys)
+  (declare (ignore resize-frame))
   ;; do nothing here
   nil)
 


### PR DESCRIPTION
* Ignore unused variable

* Translate `:resize-frame` option to `define-application-frame` into a default initarg