### PR TITLE
Commands processor respects :ECHO option returned by translator

### DIFF
--- a/Core/clim-core/commands/processor.lisp
+++ b/Core/clim-core/commands/processor.lisp
@@ -371,8 +371,8 @@
         (start-position (and (getf options :echo t)
                              (input-editing-stream-p stream)
                              (stream-scan-pointer stream))))
-    (flet ((maybe-replace-input (input)
-             (when start-position
+    (flet ((maybe-replace-input (input options)
+             (when (and start-position (getf options :echo t))
                ;; Rescan is nil in case the clicked on thing returned
                ;; something unparseable. -- heshrobe 2020-05-15
                (presentation-replace-input stream input type view
@@ -386,12 +386,12 @@
                           (position *unsupplied-argument-marker* command))
                  command)))
       (with-input-context (type)
-          (object type)
+          (object type event options)
           (if-let ((command (funcall *command-parser* command-table stream)))
-            (values (maybe-replace-input (handle-command command)) type)
+            (values (maybe-replace-input (handle-command command) '()) type)
             (simple-parse-error "Empty command"))
         (command
-         (values (maybe-replace-input (handle-command object)) type))))))
+         (values (maybe-replace-input (handle-command object) options) type))))))
 
 (define-presentation-type command-or-form
     (&key (command-table (frame-command-table *application-frame*)))


### PR DESCRIPTION
Before this change, the `accept` method for the `command` presentation type, when `maybe-replace-input` is invoked via a presentation click, did not check whether the translator returned the :echo nil option in its third argument.

Test program:

``` common-lisp
(clim:define-presentation-type thing ()
  :inherit-from t)

(clim:define-application-frame test ()
  ()
  (:pane
   (clim:vertically ()
     (clim:make-pane :application :display-function (lambda (frame pane)
                                                      (clim:present 1 'thing)))
     (clim:make-pane :interactor))))

(define-test-command com-doit
    ((thing thing :gesture (:select :echo ni))))

(clim:run-frame-top-level (clim:make-application-frame 'test))
```