### PR TITLE
REDISPLAY-FRAME-PANES checks "viewability" of sheets

### DIFF
--- a/Core/clim-core/frames/frames.lisp
+++ b/Core/clim-core/frames/frames.lisp
@@ -394,7 +394,8 @@ documentation produced by presentations.")
 
 (defmethod redisplay-frame-panes ((frame application-frame) &key force-p)
   (map-over-sheets (lambda (sheet)
-                     (redisplay-frame-pane frame sheet :force-p force-p))
+                     (when (sheet-viewable-p sheet)
+                       (redisplay-frame-pane frame sheet :force-p force-p)))
                    (frame-top-level-sheet frame)))
 
 (defmethod frame-replay (frame stream &optional region)


### PR DESCRIPTION
According to the specification entry for `redisplay-frame-panes', the function calls

> `redisplay-frame-pane` on each of the panes in frame *that are visible* in the current layout.

Reasons for not being visible in the current layout include

* Not being part of the current layout. This is covered automatically and already worked before this change since our implementation traverses sheets from the top-level sheet of the frame.

* Not being enabled or having an ancestor that is not enabled. The specification entries for `[setf] sheet-enabled-p` state:

  > Note that a sheet is not visible unless it and all of its ancestors are enabled.

  This was not previously handled and is now handled by ignoring sheets for which `sheet-viewable-p` returns false.

The practical consequence of this change is that the tab layout behaves differently. Before this change, `redisplay-frame-panes` redisplayed all children of a `tab-layout-pane`, now it only redisplays the enabled child.