### PR TITLE
Climdemo Clim-Fig Arrows: Avoid undefined behavior for (atan 0 0)

### DIFF
--- a/Core/clim-basic/drawing/graphics.lisp
+++ b/Core/clim-basic/drawing/graphics.lisp
@@ -600,16 +600,22 @@
 (defun draw-arrow* (sheet x1 y1 x2 y2
                     &rest args
                     &key ink clipping-region transformation
-                      line-style line-thickness
-                      line-unit line-dashes line-cap-shape
-                      (to-head t) from-head (head-length 10) (head-width 5) angle)
+                         line-style line-thickness
+                         line-unit line-dashes line-cap-shape
+                         (to-head t) from-head (head-length 10) (head-width 5) angle)
   (declare (ignore ink clipping-region transformation
                    line-style line-thickness
                    line-unit line-dashes line-cap-shape))
   (with-medium-options (sheet args)
     (with-translation (sheet x2 y2)
-      (with-rotation (sheet (or angle (atan* (- x1 x2)
-                                             (- y1 y2))))
+      (unless angle
+        (let ((dx (- x1 x2))
+              (dy (- y1 y2)))
+          (if (and (zerop dx)
+                   (zerop dy))
+              (setf angle 0.0)
+              (setf angle (atan* dx dy)))))
+      (with-rotation (sheet angle)
         (let* ((end 0.0)
                (start (sqrt (+ (expt (- x2 x1) 2)
                                (expt (- y2 y1) 2))))

--- a/Core/clim-basic/geometry/transforms.lisp
+++ b/Core/clim-basic/geometry/transforms.lisp
@@ -705,7 +705,7 @@ real numbers, and default to 0."
   ;;
   ;; We coerce y to the same float type as pi to have a better
   ;; accuracy thanks with elliptical objects. -- jd 2019-11-19
-  (if (and (zerop x)(zerop y))
+  (if (and (zerop x) (zerop y))
       ;; ATAN when called with both arguments being zero has undefined
       ;; consequences, therefore we signal an error here. We don't distinguish
       ;; signed zero for consistency between implementations.

--- a/Core/clim-basic/geometry/transforms.lisp
+++ b/Core/clim-basic/geometry/transforms.lisp
@@ -705,8 +705,13 @@ real numbers, and default to 0."
   ;;
   ;; We coerce y to the same float type as pi to have a better
   ;; accuracy thanks with elliptical objects. -- jd 2019-11-19
-  (let ((r (atan (float y pi) x)))
-    (if (< r 0) (+ r (* 2 pi)) r)))
+  (if (and (zerop x)(zerop y))
+      ;; ATAN when called with both arguments being zero has undefined
+      ;; consequences, therefore we signal an error here. We don't distinguish
+      ;; signed zero for consistency between implementations.
+      (error 'arithmetic-error :operation 'atan* :operands (list x y))
+      (let ((r (atan (float y pi) x)))
+        (if (< r 0) (+ r (* 2 pi)) r))))
 
 (defun correct-angle (a phi)
   (if (< a phi)


### PR DESCRIPTION
* While running climdemo `clim-fig` with `Arrow` I get an `arithmetic-error` using clasp
* The problem stems from `atan*` which is called like (atan* 0 0.0). This finally calls (atan 0.0 0) which returns `#<single-float quiet NaN>`
* According to the table in http://www.lispworks.com/documentation/HyperSpec/Body/f_asin_.htm#atan:
`y = 0        x = 0        Origin           undefined consequences` this seems to be undefined behavior, at least when -0 is not supported
* Therefor I propose to directly return 0.0 in this case
* tested in clasp and sbcl 