### PR TITLE
drei: stream-process-gesture: ignore pointer events

### DIFF
--- a/Libraries/Drei/drei-clim.lisp
+++ b/Libraries/Drei/drei-clim.lisp
@@ -312,6 +312,10 @@ modifier key."))
       (display-drei drei :redisplay-minibuffer t)
       (propagate-changed-value drei))))
 
+;;; We don't want drei gadgets to append gestures to the input-buffer.
+(defmethod climi::stream-append-gesture ((stream drei-gadget-pane) gesture)
+  (declare (ignore stream gesture)))
+
 ;;; This is the method that functions as the entry point for all Drei
 ;;; gadget logic.
 (defmethod handle-event ((gadget drei-gadget-pane) (event key-press-event))

--- a/Libraries/Drei/input-editor.lisp
+++ b/Libraries/Drei/input-editor.lisp
@@ -616,6 +616,10 @@ if stuff is inserted after the insertion pointer."
 
 (defmethod stream-process-gesture ((stream drei-input-editing-mixin)
 				   gesture type)
+  ;; Drei is not interested in the pointer gestures.
+  (when (typep gesture 'pointer-event)
+    (return-from stream-process-gesture
+      (values nil 'null)))
   ;; If some other command processor has taken control, we do not want
   ;; to assume that an activation gesture really is an activation
   ;; gesture. For example, #\Newline should not cause input activation


### PR DESCRIPTION
This method is used to process input editing commands and is not prepared to
work with pointer events. Most notably esa-read-gesture which is called from
read-gestures-and-act does not recognize them as a proper gesture and waits
until some key is pressed (indefinetely). Fixes #1080.