### PR TITLE
command table menu rewrite

### DIFF
--- a/Core/clim-core/commands/commands.lisp
+++ b/Core/clim-core/commands/commands.lisp
@@ -35,7 +35,7 @@
 (defclass %menu-item (command-item)
   ((menu-name
     :initarg :menu-name
-    :reader command-menu-item-name)
+    :accessor command-menu-item-name)
    (type
     :initarg :type
     :reader command-menu-item-type)
@@ -46,7 +46,8 @@
     :initarg :text-style
     :reader command-menu-item-text-style)
    (keystroke
-    :initarg :keystroke)
+    :initarg :keystroke
+    :accessor command-menu-item-keystroke)
    (documentation
     :initarg :documentation))
   (:default-initargs :menu-name nil
@@ -107,7 +108,12 @@
   (make-instance '%menu-item
                  :menu-name name :type type :value value
                  :documentation documentation
-                 :keystroke keystroke
+                 :keystroke (if (or (null keystroke)
+                                    (and (symbolp keystroke)
+                                         (gethash keystroke *gesture-names*)))
+                                keystroke
+                                (multiple-value-list
+                                 (realize-gesture-spec :keyboard keystroke)))
                  :text-style text-style
                  :command-name command-name
                  :command-line-name command-line-name))
@@ -210,7 +216,7 @@
                 ',func ',command-table
                 :name ,name :menu ',menu
                 :keystroke ',keystroke :errorp nil
-                ,@(and menu
+                ,@(and (or menu keystroke)
                        `(:menu-command
                          (list ',func
                                ,@(make-list (length required-args)

--- a/Core/clim-core/commands/processor.lisp
+++ b/Core/clim-core/commands/processor.lisp
@@ -22,7 +22,9 @@
                                          &body body)
   (with-gensyms (table)
     `(let* ((,table (find-command-table ,command-table))
-            (,keystroke-var (slot-value ,table 'keystroke-accelerators)))
+            (,keystroke-var (loop for item in (slot-value ,table 'menu)
+                                  for acc = (command-menu-item-keystroke item)
+                                  when acc collect acc)))
        ,@body)))
 
 (defun command-line-command-parser (command-table stream)

--- a/Core/clim-core/commands/tables.lisp
+++ b/Core/clim-core/commands/tables.lisp
@@ -133,10 +133,11 @@
 
 (defun apply-with-command-table-inheritance (fun command-table)
   (funcall fun command-table)
-  (mapc #'(lambda (inherited-command-table)
-            (apply-with-command-table-inheritance
-             fun (find-command-table inherited-command-table)))
-        (command-table-inherit-from command-table)))
+  (map nil
+       (lambda (inherited-command-table)
+         (apply-with-command-table-inheritance
+          fun (find-command-table inherited-command-table)))
+       (command-table-inherit-from command-table)))
 
 ;;; do-command-table-inheritance has been shipped off to utils.lisp.
 
@@ -346,7 +347,8 @@ designator) inherits menu items."
             (remhash (command-item-name item) (command-line-names table)))
           (remhash command-name commands)))))
 
-(defun map-over-command-table-menu-items (function command-table)
+(defun map-over-command-table-menu-items
+    (function command-table &key (inherited t))
   "Applies function to all of the items in `command-table's
 menu. `Command-table' must be a command table or the name of a
 command table. `Function' must be a function of three arguments,
@@ -371,7 +373,7 @@ examine the type of the command menu item to see if it is
                                   item)))
                    (slot-value table 'menu))))
       (map-table-entries table-object)
-      (when (inherit-menu-items table-object)
+      (when (and inherited (inherit-menu-items table-object))
         (dolist (table (command-table-inherit-from table-object))
           (map-over-command-table-menu-items function table))))
     (values)))
@@ -420,7 +422,9 @@ examine the type of the command menu item to see if it is
                              :key #'command-menu-item-name
                              :test #'string-equal))))))
 
-(defun map-over-command-table-keystrokes (function command-table)
+(defun map-over-command-table-keystrokes
+    (function command-table &key (inherited t))
+  (declare (ignore inherited))
   (let ((command-table (find-command-table command-table)))
     (with-slots (keystroke-accelerators keystroke-items)
         command-table

--- a/Core/clim-core/commands/tables.lisp
+++ b/Core/clim-core/commands/tables.lisp
@@ -58,18 +58,29 @@
   ((command-table-name :reader error-command-table-name
                        :initform nil
                        :initarg :command-table-name))
+  (:report (lambda (object stream)
+             (format stream
+                     "Command table name: ~s~%"
+                     (error-command-table-name object))
+             (apply #'format stream
+                    (simple-condition-format-control object)
+                    (simple-condition-format-arguments object))))
   (:default-initargs :format-control "" :format-arguments nil))
 
-(defmethod print-object ((object command-table-error) stream)
-  (print-unreadable-object (object stream :type t :identity t)
-    (when (error-command-table-name object)
-      (princ (error-command-table-name object) stream))))
+(define-condition command-table-not-found (command-table-error) ()
+  (:default-initargs :format-control "Command table not found."))
 
-(define-condition command-table-not-found (command-table-error) ())
-(define-condition command-table-already-exists (command-table-error) ())
-(define-condition command-not-present (command-table-error) ())
-(define-condition command-not-accessible (command-table-error) ())
-(define-condition command-already-present (command-table-error) ())
+(define-condition command-table-already-exists (command-table-error) ()
+  (:default-initargs :format-control "Command table already exists."))
+
+(define-condition command-not-present (command-table-error) ()
+  (:default-initargs :format-control "Command not present."))
+
+(define-condition command-not-accessible (command-table-error) ()
+  (:default-initargs :format-control "Command not accessible."))
+
+(define-condition command-already-present (command-table-error) ()
+  (:default-initargs :format-control "Command already accessible."))
 
 (defun command-table-designator-as-name (designator)
   "Return the name of `designator' if it is a command table,

--- a/Core/clim-core/commands/tables.lisp
+++ b/Core/clim-core/commands/tables.lisp
@@ -330,19 +330,21 @@ designator) inherits menu items."
                                           command-table
                                           &key (errorp t))
   (let* ((table (find-command-table command-table))
-         (item (gethash command-name (commands table))))
+         (commands (commands table))
+         (item (gethash command-name commands)))
     (if (null item)
         (when errorp
           (error 'command-not-present :command-table-name (command-table-name command-table)))
         (progn
           (when (typep item '%menu-item)
-            (remove-menu-item-from-command-table table
-                                                 (command-menu-item-name item)
-                                                 :errorp nil))
-
+            ;; Remove the keystroke and/or the menu entry.
+            (setf (slot-value table 'menu)
+                  (delete command-name
+                          (slot-value table 'menu)
+                          :key #'command-item-name)))
           (when (command-item-name item)
             (remhash (command-item-name item) (command-line-names table)))
-          (remhash command-name (commands table))))))
+          (remhash command-name commands)))))
 
 (defun map-over-command-table-menu-items (function command-table)
   "Applies function to all of the items in `command-table's

--- a/Core/clim-core/dialog.lisp
+++ b/Core/clim-core/dialog.lisp
@@ -278,7 +278,9 @@ highlighting, etc." ))
                                   ,(query-identifier
                                     (first
                                      (queries *accepting-values-stream*))))))
-           (*accelerator-gestures* (compute-inherited-keystrokes command-table)))
+           (*accelerator-gestures* (with-command-table-keystrokes
+                                       (keystrokes command-table)
+                                     keystrokes)))
       (letf (((frame-command-table *application-frame*)
               (find-command-table command-table)))
         (unwind-protect

--- a/Documentation/Specification/commands.tex
+++ b/Documentation/Specification/commands.tex
@@ -183,14 +183,18 @@ support command-line processor interactions).
 \cl{define-presentation-to-command-translator}.
 
 \item A table that associates keyboard gesture names to menu items (used to
-support keystroke accelerator interactions).  The keystroke accelerator table
-does not contain any items inherited from superior command tables.
+support keystroke accelerator interactions).  By default, the keystroke
+accelerator table does not contain any items inherited from superior command
+tables, although this can be overridden by supplying \cl{t} or
+\cl{:keystrokes} as the value of the \cl{:inherit-menu} option to
+\cl{define-command-table}.
 
 \item A menu that associates menu names to command menu items (used to support
-interaction via command menus).  The command menu items can invoke commands or
-sub-menus.  By default, the menu does not contain any command menu items
-inherited from superior command tables, although this can be overridden by the
-\cl{:inherit-menu} option to \cl{define-command-table}.
+interaction via command menus).  The command menu items can invoke commands
+or sub-menus.  By default, the menu does not contain any command menu items
+inherited from superior command tables, although this can be overridden by
+supplying \cl{t} or \cl{:menu} as the \cl{:inherit-menu} option to
+\cl{define-command-table}.
 \end{itemize}
 
 We say that a command is \concept{present} in a command table when it has been
@@ -243,10 +247,11 @@ to inherit from CLIM's global command table.  (This command table contains such
 things as the ``menu'' translator that is associated with the right-hand button
 on pointers.)
 
-If \arg{inherit-menu} is \term{true}, the new command table will inherit the
-menu items and keystroke accelerators from all of the inherited command tables.
-If it is \term{false} (the default), no menu items or keystroke accelerators
-will be inherited.
+If \arg{inherit-menu} is \cl{t}, the new command table will inherit the menu
+items and keystroke accelerators from all of the inherited command tables.  If
+it is \term{nil} (the default), no menu items or keystroke accelerators will
+be inherited. If it is \cl{:menu}, only menu items will be inherited. If it is
+\cl{:keystrokes}, only keystroke accelerators will be inherited.
 
 \arg{menu} can be used to specify a menu for the command table.  The value of
 \arg{menu} is a list of clauses.  Each clause is a list with the syntax
@@ -576,7 +581,8 @@ If the item is not present in the command table's menu and \arg{errorp} is
 that the character case of \arg{string} is ignored when searching the command
 table's menu.
 
-\Defun {map-over-command-table-menu-items} {function command-table}
+
+\Defun {map-over-command-table-menu-items} {function command-table \key (inherited t)}
 
 Applies \arg{function} to all of the items in \arg{command-table}'s menu.
 \arg{function} must be a function of three arguments, the menu name, the
@@ -589,13 +595,19 @@ over in the order specified by \cl{add-menu-item-to-command-table}.
 programmer requires this behavior, he should examine the type of the command
 menu item to see if it is \cl{:menu}.
 
+If \arg{inherited} is \term{false}, this applies \arg{function} only to those
+menu items present in \arg{command-table}, that is, it does not map over any
+inherited menu items. If \arg{inherited} is \term{true}, then the inherited
+menus are traversed in the same order as for
+\cl{do-command-table-inheritance}.
+
 
 \Defun {find-menu-item} {menu-name command-table \key (errorp t)}
 
-Given a menu name and a command table, returns two values, the command menu item
-and the command table in which it was found.  (Since menus are not inherited,
-the second returned value will always be \arg{command-table}.)
-\arg{command-table} is a \term{command table designator}.
+Given a menu name and a command table, returns two values, the command menu
+item and the command table in which it was found.  \arg{command-table} is a
+\term{command table designator}.
+
 \ReadOnly
 
 If there is no command menu item corresponding to \arg{menu-name} present in
@@ -707,7 +719,7 @@ command table's menu and \arg{errorp} is \term{true}, then the
 \cl{command-not-present} error will be signalled.
 
 
-\Defun {map-over-command-table-keystrokes} {function command-table}
+\Defun {map-over-command-table-keystrokes} {function command-table \key (inherited t)}
 
 Applies \arg{function} to all of the keystroke accelerators in
 \arg{command-table}'s accelerator table.  \arg{function} must be a function of
@@ -719,13 +731,18 @@ keystroke accelerator, and the command menu item; it has dynamic extent.
 programmer requires this behavior, he should examine the type of the command
 menu item to see if it is \cl{:menu}.
 
+If \arg{inherited} is \term{false}, this applies \arg{function} only to those
+keystroke accelerators present in \arg{command-table}, that is, it does not
+map over any inherited menu items. If \arg{inherited} is \term{true}, then the
+inherited menus are traversed in the same order as for
+\cl{do-command-table-inheritance}.
+
 
 \Defun {find-keystroke-item} {gesture command-table \key test (errorp t)}
 
-Given a keyboard gesture \arg{gesture} and a command table, returns two values,
-the command menu item associated with the gesture and the command table in which
-it was found.  (Since keystroke accelerators are not inherited, the second
-returned value will always be \arg{command-table}.)
+Given a keyboard gesture \arg{gesture} and a command table, returns two
+values, the command menu item associated with the gesture and the command
+table in which it was found.
 
 \ReadOnly
 
@@ -743,13 +760,17 @@ Given a keyboard gesture \arg{gesture} and a command table, returns two values,
 the command menu item associated with the gesture and the command table in which
 it was found.  Note that \arg{gesture} may be either a keyboard gesture name of
 a gesture object, and is handled in the same way as in \cl{find-keystroke-item}.
+
 \ReadOnly
 
 Unlike \cl{find-keystroke-item}, this follows the sub-menu chains that can be
-created with \cl{add-menu-item-to-command-table}.  If the keystroke accelerator
-cannot be found in the command table or any of the command tables from which it
-inherits, \cl{lookup-keystroke-item} will return \cl{nil}.  \arg{command-table}
-is a \term{command table designator}.
+created with \cl{add-menu-item-to-command-table}. If a given sub-menu has an
+associated keystroke that is not \arg{gesture}, the function does not look in
+the keystroke accelerators table associated with the sub-menu.
+
+If the keystroke accelerator cannot be found in the command table or its
+menus, \cl{lookup-keystroke-item} will return \cl{nil}. \arg{command-table} is
+a \term{command table designator}.
 
 \arg{test} is the test used to compare the supplied gesture to the gesture name
 in the command table.  The supplied gesture will generally be an event object,

--- a/Tests/commands.lisp
+++ b/Tests/commands.lisp
@@ -266,6 +266,22 @@
         (test-look :y root nil nil)
         (test-look :z root '(com-z) men2)))))
 
+;;; This test checks, whether with-command-table-keystrokes correctly
+;;; traverses all menus and inherited command-tables.
+(test commands.command-table.keystroke.5
+  (with-gestures ((:w #\w) (:x #\x) (:y #\y) (:z #\z))
+    (with-command-tables ((men1 nil :menu `(("W" :command (com-w) :keystroke :w)))
+                          (men2 nil :menu `(("X" :command (com-y) :keystroke :x)))
+                          (root nil :menu `(("Y" :menu ,men1  :keystroke :y)
+                                            ("M" :menu ,men2)))
+                          (sub1 nil :inherit-from (list root) :inherit-menu t
+                                    :menu `(("Z" :command '(com-z) :keystroke :z))))
+      (with-command-table-keystrokes (keystrokes sub1)
+        (is (member :z keystrokes) "Keystrokes are not collected.")
+        (is (member :y keystrokes) "Keystrokes are not inherited.")
+        (is (not (member :w keystrokes)) "Keystroked-menu is traversed.")
+        (is (member :x keystrokes) "Keystrokes in sub-menus are not collected.")))))
+
 
 ;;; command table errors (see 27.2)
 

--- a/Tests/commands.lisp
+++ b/Tests/commands.lisp
@@ -64,11 +64,33 @@
     (is (= 1 count))))
 
 (test commands.add-and-remove-command
-  (let ((ct (make-command-table nil)))
-    (add-command-to-command-table 'com-test-command ct)
-    (remove-command-from-command-table 'com-test-command ct)
-    (signals command-not-present
-      (remove-command-from-command-table 'com-test-command ct))))
+  (with-command-table (ct nil :inherit-from nil)
+    (with-gestures ((:x #\x) (:y #\y))
+      (add-command-to-command-table 'com-test1 ct)
+      (add-command-to-command-table 'com-test2 ct :menu "test2")
+      (add-command-to-command-table 'com-test3 ct :keystroke :x)
+      (add-command-to-command-table 'com-test4 ct :menu "test4" :keystroke :y)
+      ;;
+      (is (find-menu-item "test2" ct :errorp nil))
+      (is (find-menu-item "test4" ct :errorp nil))
+      (is (find-keystroke-item :x ct :test #'eql :errorp nil))
+      (is (find-keystroke-item :y ct :test #'eql :errorp nil))
+      ;;
+      (remove-command-from-command-table 'com-test1 ct)
+      (remove-command-from-command-table 'com-test2 ct)
+      (remove-command-from-command-table 'com-test3 ct)
+      (remove-command-from-command-table 'com-test4 ct)
+      (signals command-not-present
+        (remove-command-from-command-table 'com-test5 ct))
+      ;;
+      (is (null (find-menu-item "test2" ct :errorp nil)))
+      (is (null (find-menu-item "test4" ct :errorp nil)))
+      (is (null (find-keystroke-item :x ct :test #'eql :errorp nil)))
+      (is (null (find-keystroke-item :y ct :test #'eql :errorp nil)))
+      (mapc (lambda (com)
+              (signals command-not-present
+                (remove-command-from-command-table com ct)))
+            '(com-test1 com-test2 com-test3 com-test4)))))
 
 
 ;;; command table menu items and keystrokes definition


### PR DESCRIPTION
This PR addresses number of issues encountered when working with menus and keystroke accelerators. Part of said issues are a result of inconsistent specification - it is also modified. The "commands" test suite is updated accordingly (with other fixes along the way).