### PR TITLE
Fix name collisions of ad-hoc classes generated by CLX backend for mirroring

### DIFF
--- a/Backends/CLX-fb/frame-manager.lisp
+++ b/Backends/CLX-fb/frame-manager.lisp
@@ -1,5 +1,15 @@
-(in-package :clim-clx-fb)
+;;; ---------------------------------------------------------------------------
+;;;   License: LGPL-2.1+ (See file 'Copyright' for details).
+;;; ---------------------------------------------------------------------------
+;;;
+;;;  (c) copyright 2016 Alessandro Serra <gas2serra@gmail.com>
+;;;  (c) copyright 2018-2020 Daniel Kochmański <daniel@turtleware.eu>
+;;;
+;;; ---------------------------------------------------------------------------
+;;;
+;;; The frame manager the CLX framebuffer backend.
 
+(in-package #:clim-clx-fb)
 
 (defclass clx-fb-frame-manager (clim-clx::clx-frame-manager)
   ()
@@ -9,7 +19,7 @@
 ;;; if the pane is a subclass of basic-pane and it is not mirrored we create a new class.
 (defun maybe-mirroring (fm concrete-pane-class)
   (when (and (not (subtypep concrete-pane-class 'mirrored-sheet-mixin))
-	     (funcall (clim-clx::mirroring-p fm) concrete-pane-class))
+             (funcall (clim-clx::mirroring-p fm) concrete-pane-class))
     (let* ((concrete-pane-class-symbol (if (typep concrete-pane-class 'class)
                                           (class-name concrete-pane-class)
                                           concrete-pane-class)))
@@ -18,7 +28,7 @@
            (alexandria:symbolicate (clim-clx::class-gensym fm) "-"
                                    (symbol-name concrete-pane-class-symbol))
            :clim-clx-fb)
-	(unless foundp
+        (unless foundp
           (let ((superclasses (if (subtypep concrete-pane-class 'sheet-with-medium-mixin)
                                   (list 'clx-fb-mirrored-sheet-mixin
                                         'climi::always-repaint-background-mixin

--- a/Backends/CLX-fb/frame-manager.lisp
+++ b/Backends/CLX-fb/frame-manager.lisp
@@ -20,15 +20,16 @@
                                      pane-type &optional (errorp t))
   ;; This backend doesn't have any specialized pane implementations
   ;; but depending on circumstances it may add optional mirroring to
-  ;; the class. See CLX backend for more information.
+  ;; the class. Such automatically defined concrete class has the same
+  ;; name but with a gensym prefix and symbol in the backend package.
   (let ((concrete-pane-class (find-concrete-pane-class t pane-type errorp)))
     (maybe-add-mirroring-superclasses
      concrete-pane-class (mirroring fm)
      (symbol-name (class-gensym fm)) (find-package '#:clim-clx-fb)
-     (lambda (concrete-pane-class concrete-pane-class-name)
-       `(clx-fb-mirrored-sheet-mixin
-         climi::always-repaint-background-mixin
+     (lambda (concrete-pane-class)
+       `(,(find-class 'clx-fb-mirrored-sheet-mixin)
+         ,(find-class 'climi::always-repaint-background-mixin)
          ,@(unless (subtypep concrete-pane-class 'sheet-with-medium-mixin)
-             '(;; temporary-medium-sheet-output-mixin
-               permanent-medium-sheet-output-mixin))
-         ,concrete-pane-class-name)))))
+             `(;; temporary-medium-sheet-output-mixin
+               ,(find-class 'permanent-medium-sheet-output-mixin)))
+         ,concrete-pane-class)))))

--- a/Backends/CLX-fb/frame-manager.lisp
+++ b/Backends/CLX-fb/frame-manager.lisp
@@ -13,7 +13,7 @@
 
 (defclass clx-fb-frame-manager (clim-clx::clx-frame-manager)
   ()
-  (:default-initargs :mirroring (clim-clx::mirror-factory :single)
+  (:default-initargs :mirroring :single
                      :class-gensym (gensym "CLXFB")))
 
 (defmethod find-concrete-pane-class ((fm clx-fb-frame-manager)
@@ -21,12 +21,14 @@
   ;; This backend doesn't have any specialized pane implementations
   ;; but depending on circumstances it may add optional mirroring to
   ;; the class. See CLX backend for more information.
-  (maybe-mirroring fm (find-concrete-pane-class t pane-type errorp)
-                   (find-package '#:clim-clx-fb)
-                   (lambda (concrete-pane-class concrete-pane-class-name)
-                     `(clx-fb-mirrored-sheet-mixin
-                       climi::always-repaint-background-mixin
-                       ,@(unless (subtypep concrete-pane-class 'sheet-with-medium-mixin)
-                           '(;; temporary-medium-sheet-output-mixin
-                             permanent-medium-sheet-output-mixin))
-                       ,concrete-pane-class-name))))
+  (let ((concrete-pane-class (find-concrete-pane-class t pane-type errorp)))
+    (maybe-add-mirroring-superclasses
+     concrete-pane-class (mirroring fm)
+     (symbol-name (class-gensym fm)) (find-package '#:clim-clx-fb)
+     (lambda (concrete-pane-class concrete-pane-class-name)
+       `(clx-fb-mirrored-sheet-mixin
+         climi::always-repaint-background-mixin
+         ,@(unless (subtypep concrete-pane-class 'sheet-with-medium-mixin)
+             '(;; temporary-medium-sheet-output-mixin
+               permanent-medium-sheet-output-mixin))
+         ,concrete-pane-class-name)))))

--- a/Backends/CLX-fb/frame-manager.lisp
+++ b/Backends/CLX-fb/frame-manager.lisp
@@ -16,41 +16,17 @@
   (:default-initargs :mirroring (clim-clx::mirror-factory :single)
                      :class-gensym (gensym "CLXFB")))
 
-;;; if the pane is a subclass of basic-pane and it is not mirrored we create a new class.
-(defun maybe-mirroring (fm concrete-pane-class)
-  (when (and (not (subtypep concrete-pane-class 'mirrored-sheet-mixin))
-             (funcall (clim-clx::mirroring-p fm) concrete-pane-class))
-    (let* ((concrete-pane-class-symbol (if (typep concrete-pane-class 'class)
-                                          (class-name concrete-pane-class)
-                                          concrete-pane-class)))
-      (multiple-value-bind (class-symbol foundp)
-          (alexandria:ensure-symbol
-           (alexandria:symbolicate (clim-clx::class-gensym fm) "-"
-                                   (symbol-name concrete-pane-class-symbol))
-           :clim-clx-fb)
-        (unless foundp
-          (let ((superclasses (if (subtypep concrete-pane-class 'sheet-with-medium-mixin)
-                                  (list 'clx-fb-mirrored-sheet-mixin
-                                        'climi::always-repaint-background-mixin
-                                        concrete-pane-class-symbol)
-                                  (list 'clx-fb-mirrored-sheet-mixin
-                                        'climi::always-repaint-background-mixin
-                                        ;;'temporary-medium-sheet-output-mixin
-                                        'permanent-medium-sheet-output-mixin
-                                        concrete-pane-class-symbol))))
-            (eval
-             `(defclass ,class-symbol
-                  ,superclasses
-                ()
-                (:metaclass ,(type-of (find-class concrete-pane-class-symbol)))))))
-        (format *debug-io* "dummy class mirror ~A: ~A~%" concrete-pane-class-symbol class-symbol)
-        (setf concrete-pane-class (find-class class-symbol)))))
-  concrete-pane-class)
-
 (defmethod find-concrete-pane-class ((fm clx-fb-frame-manager)
                                      pane-type &optional (errorp t))
   ;; This backend doesn't have any specialized pane implementations
   ;; but depending on circumstances it may add optional mirroring to
-  ;; the class. Such automatically defined concrete class has the same
-  ;; name but with a gensym prefix and symbol in the backend package.
-  (maybe-mirroring fm (find-concrete-pane-class t pane-type errorp)))
+  ;; the class. See CLX backend for more information.
+  (maybe-mirroring fm (find-concrete-pane-class t pane-type errorp)
+                   (find-package '#:clim-clx-fb)
+                   (lambda (concrete-pane-class concrete-pane-class-name)
+                     `(clx-fb-mirrored-sheet-mixin
+                       climi::always-repaint-background-mixin
+                       ,@(unless (subtypep concrete-pane-class 'sheet-with-medium-mixin)
+                           '(;; temporary-medium-sheet-output-mixin
+                             permanent-medium-sheet-output-mixin))
+                       ,concrete-pane-class-name))))

--- a/Backends/CLX-fb/package.lisp
+++ b/Backends/CLX-fb/package.lisp
@@ -43,7 +43,9 @@
                 #:clx-port-screen
                 #:clx-graft
                 #:clx-port-window
-                #:maybe-mirroring
+                #:mirroring
+                #:class-gensym
+                #:maybe-add-mirroring-superclasses
                 #:sheet-xmirror
                 #:sheet-direct-xmirror)
   (:import-from #:climi

--- a/Backends/CLX-fb/package.lisp
+++ b/Backends/CLX-fb/package.lisp
@@ -43,6 +43,7 @@
                 #:clx-port-screen
                 #:clx-graft
                 #:clx-port-window
+                #:maybe-mirroring
                 #:sheet-xmirror
                 #:sheet-direct-xmirror)
   (:import-from #:climi

--- a/Backends/CLX/frame-manager.lisp
+++ b/Backends/CLX/frame-manager.lisp
@@ -1,25 +1,19 @@
-;;; -*- Mode: Lisp; Package: CLIM-CLX -*-
-
-;;;  (c) copyright 1998,1999,2000,2001 by Michael McDonald (mikemac@mikemac.com)
-;;;  (c) copyright 2004 by Gilbert Baumann <unk6@rz.uni-karlsruhe.de>
-;;;  (c) copyright 2014 by Robert Strandh (robert.strandh@gmail.com)
-
-;;; This library is free software; you can redistribute it and/or
-;;; modify it under the terms of the GNU Library General Public
-;;; License as published by the Free Software Foundation; either
-;;; version 2 of the License, or (at your option) any later version.
+;;; ---------------------------------------------------------------------------
+;;;   License: LGPL-2.1+ (See file 'Copyright' for details).
+;;; ---------------------------------------------------------------------------
 ;;;
-;;; This library is distributed in the hope that it will be useful,
-;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;;; Library General Public License for more details.
+;;;  (c) copyright 1998,1999,2000,2001 Michael McDonald <mikemac@mikemac.com>
+;;;  (c) copyright 2004 Gilbert Baumann <unk6@rz.uni-karlsruhe.de>
+;;;  (c) copyright 2014 Robert Strandh <robert.strandh@gmail.com>
+;;;  (c) copyright 2016-2018 Elias Mårtenson <lokedhs@gmail.com>
+;;;  (c) copyright 2016-2019 Daniel Kochmański <daniel@turtleware.eu>
 ;;;
-;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;;; Boston, MA  02111-1307  USA.
+;;; ---------------------------------------------------------------------------
+;;;
+;;; The frame manager and ad-hoc sheet class generation logic of the
+;;; CLX backend.
 
-(in-package :clim-clx)
+(in-package #:clim-clx)
 
 ;;; CLX-FRAME-MANAGER class
 

--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -1,29 +1,20 @@
-;;; -*- Mode: Lisp; Package: CLIM-CLX; -*-
-
-;;;  (c) copyright 1998,1999,2000 by Michael McDonald (mikemac@mikemac.com)
-;;;  (c) copyright 2000,2001 by
-;;;           Iban Hatchondo (hatchond@emi.u-bordeaux.fr)
-;;;           Julien Boninfante (boninfan@emi.u-bordeaux.fr)
-;;;  (c) copyright 2000, 2001, 2014, 2016 by
-;;;           Robert Strandh (robert.strandh@gmail.com)
-
-;;; This library is free software; you can redistribute it and/or
-;;; modify it under the terms of the GNU Library General Public
-;;; License as published by the Free Software Foundation; either
-;;; version 2 of the License, or (at your option) any later version.
+;;; ---------------------------------------------------------------------------
+;;;   License: LGPL-2.1+ (See file 'Copyright' for details).
+;;; ---------------------------------------------------------------------------
 ;;;
-;;; This library is distributed in the hope that it will be useful,
-;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-;;; Library General Public License for more details.
+;;;  (c) copyright 1998,1999,2000 Michael McDonald <mikemac@mikemac.com>
+;;;  (c) copyright 2000,2001 Iban Hatchondo <hatchond@emi.u-bordeaux.fr>
+;;;  (c) copyright 2000,2001 Julien Boninfante <boninfan@emi.u-bordeaux.fr>
+;;;  (c) copyright 2000, 2001, 2014, 2016 Robert Strandh <robert.strandh@gmail.com>
+;;;  (c) copyright 2016-2020 Daniel Kochmański <daniel@turtleware.eu>
+;;;  (c) copyright 2019 Jan Moringen <jmoringe@techfak.uni-bielefeld.de>
 ;;;
-;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;;; Boston, MA  02111-1307  USA.
+;;; ---------------------------------------------------------------------------
+;;;
+;;; Server path processing, port initialization and mirroring
+;;; functions.
 
-(in-package :clim-clx)
-
+(in-package #:clim-clx)
 
 ;;; CLX-PORT class
 
@@ -32,9 +23,8 @@
 
 (defclass clx-port (clim-xcommon:keysym-port-mixin
                     clx-selection-mixin
-		    clx-basic-port)
+                    clx-basic-port)
   ((color-table :initform (make-hash-table :test #'eq))
-
    (design-cache :initform (make-hash-table :test #'eq))))
 
 (defclass clx-render-port (clx-port) ())
@@ -44,32 +34,32 @@
   (let ((name (get-environment-variable "DISPLAY")))
     (assert name (name)
             "Environment variable DISPLAY is not set")
-    (let* (; this code courtesy telent-clx.
-           (slash-i (or (position #\/ name) -1))
+    ;; this code courtesy telent-clx.
+    (let* ((slash-i (or (position #\/ name) -1))
            (colon-i (position #\: name :start (1+ slash-i)))
            (decnet-colon-p (and colon-i (eql (elt name (1+ colon-i)) #\:)))
            (host (subseq name (1+ slash-i) colon-i))
            (dot-i (and colon-i (position #\. name :start colon-i)))
            (display (and colon-i
-                      (parse-integer name
-                                     :start (if decnet-colon-p
-                                                (+ colon-i 2)
-                                                (1+ colon-i))
-                                     :end dot-i)))
+                         (parse-integer name
+                                        :start (if decnet-colon-p
+                                                   (+ colon-i 2)
+                                                   (1+ colon-i))
+                                        :end dot-i)))
            (screen (and dot-i
-                     (parse-integer name :start (1+ dot-i))))
+                        (parse-integer name :start (1+ dot-i))))
            (protocol
-            (cond ((or (string= host "") (string-equal host "unix")) :local)
-                  (decnet-colon-p :decnet)
-                  ((> slash-i -1) (intern
-                                   (string-upcase (subseq name 0 slash-i))
-                                   :keyword))
-                  (t :internet))))
+             (cond ((or (string= host "") (string-equal host "unix")) :local)
+                   (decnet-colon-p :decnet)
+                   ((> slash-i -1) (intern
+                                    (string-upcase (subseq name 0 slash-i))
+                                    :keyword))
+                   (t :internet))))
       (list port-type
-	    :host host
-	    :display-id (or display 0)
-	    :screen-id (or screen 0)
-	    :protocol protocol))))
+            :host host
+            :display-id (or display 0)
+            :screen-id (or screen 0)
+            :protocol protocol))))
 
 (defun helpfully-automagic-clx-server-path (port-type)
   (restart-case (automagic-clx-server-path port-type)
@@ -110,26 +100,26 @@
   (print-unreadable-object (object stream :identity t :type t)
     (when (slot-boundp object 'display)
       (let ((display (slot-value object 'display)))
-	(when display
-	  (format stream "~S ~S ~S ~S"
-		  :host (xlib:display-host display)
-		  :display-id (xlib:display-display display)))))))
+        (when display
+          (format stream "~S ~S ~S ~S"
+                  :host (xlib:display-host display)
+                  :display-id (xlib:display-display display)))))))
 
 
 (defun realize-mirror-aux (port sheet
-				&key (width 100) (height 100) (x 0) (y 0)
-				(override-redirect :off)
-				(map t)
-				(backing-store :not-useful)
+                                &key (width 100) (height 100) (x 0) (y 0)
+                                (override-redirect :off)
+                                (map t)
+                                (backing-store :not-useful)
                                 (save-under :off)
-				(event-mask `(:exposure
-					      :key-press :key-release
-					      :button-press :button-release
+                                (event-mask `(:exposure
+                                              :key-press :key-release
+                                              :button-press :button-release
                                               :owner-grab-button
-					      :enter-window :leave-window
-					      :structure-notify
-					      :pointer-motion
-					      :button-motion)))
+                                              :enter-window :leave-window
+                                              :structure-notify
+                                              :pointer-motion
+                                              :button-motion)))
   (when (null (port-lookup-mirror port sheet))
     ;;(update-mirror-geometry sheet (%%sheet-native-transformation sheet))
     (let* ((desired-color (typecase sheet
@@ -145,23 +135,23 @@
            (color (multiple-value-bind (r g b)
                       (color-rgb desired-color)
                     (xlib:make-color :red r :green g :blue b)))
-	   (screen (clx-port-screen port))
+           (screen (clx-port-screen port))
            (pixel (xlib:alloc-color (xlib:screen-default-colormap screen) color))
-	   (mirror-region (%sheet-mirror-region sheet))
-	   (mirror-transformation (%sheet-mirror-transformation sheet))
+           (mirror-region (%sheet-mirror-region sheet))
+           (mirror-transformation (%sheet-mirror-transformation sheet))
            (window (xlib:create-window
                     :parent (sheet-xmirror (sheet-parent sheet))
                     :width (if mirror-region
                                (round-coordinate (bounding-rectangle-width mirror-region))
                                width)
                     :height (if mirror-region
-				(round-coordinate (bounding-rectangle-height mirror-region))
-				height)
+                                (round-coordinate (bounding-rectangle-height mirror-region))
+                                height)
                     :x (if mirror-transformation
-			   (round-coordinate (nth-value 0 (transform-position
-							   mirror-transformation
-							   0 0)))
-			   x)
+                           (round-coordinate (nth-value 0 (transform-position
+                                                           mirror-transformation
+                                                           0 0)))
+                           x)
                     :y (if mirror-transformation
                            (round-coordinate (nth-value 1 (transform-position
                                                            mirror-transformation
@@ -216,14 +206,14 @@
 
 (defmethod %realize-mirror ((port clx-port) (sheet unmanaged-sheet-mixin))
   (realize-mirror-aux port sheet
-		      :override-redirect :on
+                      :override-redirect :on
                       :save-under :on
-		      :map nil))
+                      :map nil))
 
 (defmethod make-graft ((port clx-port) &key (orientation :default) (units :device))
   (let ((graft (make-instance 'clx-graft
-		 :port port :mirror (clx-port-window port)
-		 :orientation orientation :units units))
+                 :port port :mirror (clx-port-window port)
+                 :orientation orientation :units units))
         (width (xlib:screen-width (clx-port-screen port)))
         (height (xlib:screen-height (clx-port-screen port))))
     (let ((region (make-bounding-rectangle 0 0 width height)))
@@ -232,15 +222,15 @@
 
 (defmethod make-medium ((port clx-port) sheet)
   (make-instance 'clx-medium
-		 ;; :port port
-		 ;; :graft (find-graft :port port)
-		 :sheet sheet))
+                 ;; :port port
+                 ;; :graft (find-graft :port port)
+                 :sheet sheet))
 
 (defmethod make-medium ((port clx-render-port) sheet)
   (make-instance 'clx-render-medium
-		 ;; :port port
-		 ;; :graft (find-graft :port port)
-		 :sheet sheet))
+                 ;; :port port
+                 ;; :graft (find-graft :port port)
+                 :sheet sheet))
 
 (defmethod graft ((port clx-port))
   (first (port-grafts port)))
@@ -250,11 +240,11 @@
 (defmethod realize-mirror ((port clx-port) (pixmap pixmap))
   (when (null (port-lookup-mirror port pixmap))
     (let* ((window (sheet-xmirror (pixmap-sheet pixmap)))
-	   (pix (xlib:create-pixmap
-		    :width (round (pixmap-width pixmap))
-		    :height (round (pixmap-height pixmap))
-		    :depth (xlib:drawable-depth window)
-		    :drawable window)))
+           (pix (xlib:create-pixmap
+                    :width (round (pixmap-width pixmap))
+                    :height (round (pixmap-height pixmap))
+                    :depth (xlib:drawable-depth window)
+                    :drawable window)))
       (port-register-mirror port pixmap pix))
     (values)))
 
@@ -268,10 +258,10 @@
 
 (defmethod port-allocate-pixmap ((port clx-port) sheet width height)
   (let ((pixmap (make-instance 'mirrored-pixmap
-			       :sheet sheet
-			       :width width
-			       :height height
-			       :port port)))
+                               :sheet sheet
+                               :width width
+                               :height height
+                               :port port)))
     (when (sheet-grafted-p sheet)
       (realize-mirror port pixmap))
     pixmap))
@@ -280,9 +270,9 @@
   (when (port-lookup-mirror port pixmap)
     (destroy-mirror port pixmap)))
 
-;; Top-level-sheet
+;;; Top-level-sheet
 
-;; this is evil.
+;;; FIXME this is evil.
 (defmethod allocate-space :after ((pane top-level-sheet-mixin) width height)
   (when (sheet-direct-xmirror pane)
     (with-slots (space-requirement) pane

--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -80,7 +80,7 @@
 
 (defun parse-clx-server-path (path)
   (let* ((port-type (pop path))
-         (mirroring (mirror-factory (getf path :mirroring))))
+         (mirroring (getf path :mirroring)))
     (remf path :mirroring)
     (if path
         `(,port-type


### PR DESCRIPTION
* Cosmetic changes, untabifying and file headers

* Also share a single implementation of `maybe-mirroring` between CLX and CLX-fb

* Simplify mirroring decision logic

* Simplify CLX server path parsing