### PR TITLE
New mechanism for looking up the port

### DIFF
--- a/Backends/CLX-fb/port.lisp
+++ b/Backends/CLX-fb/port.lisp
@@ -5,8 +5,8 @@
 		       clim-clx::clx-basic-port)
   ())
 
-(setf (get :clx-fb :port-type) 'clx-fb-port)
-(setf (get :clx-fb :server-path-parser) 'clim-clx::parse-clx-server-path)
+(defmethod find-port-type ((type (eql :clx-fb)))
+  (values 'clx-fb-port (nth-value 1 (find-port-type :clx))))
 
 (defmethod initialize-instance :after ((port clx-fb-port) &rest args)
   (declare (ignore args))
@@ -17,7 +17,6 @@
   (initialize-clx port)
   (initialize-clx-framebuffer port)
   (clim-extensions:port-all-font-families port))
-
 
 (defun initialize-clx-framebuffer (port)
   (clim-sys:make-process (lambda ()

--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -80,10 +80,11 @@
                        (server-options-from-environment-with-localhost-fallback))
                  ,@(when mirroringp `(:mirroring ,mirroring)))))
 
-(setf (get :x11 :port-type) 'clx-port)
-(setf (get :x11 :server-path-parser) 'parse-clx-server-path)
-(setf (get :clx :port-type) 'clx-port)
-(setf (get :clx :server-path-parser) 'parse-clx-server-path)
+(defmethod find-port-type ((type (eql :x11)))
+  (find-port-type :clx))
+
+(defmethod find-port-type ((type (eql :clx)))
+  (values 'clx-port 'parse-clx-server-path))
 
 (defmethod initialize-instance :after ((port clx-port) &key)
   (let ((options (cdr (port-server-path port))))

--- a/Backends/Null/port.lisp
+++ b/Backends/Null/port.lisp
@@ -30,14 +30,8 @@
    (pointer :accessor port-pointer :initform (make-instance 'null-pointer))
    (window :initform nil :accessor null-port-window)))
 
-(defun parse-null-server-path (path)
-  path)
-
-;;; FIXME: if :port-type and :server-path-parser aren't CLIM-specified
-;;; keywords, they should be altered to be in some mcclim-internal
-;;; package instead.
-(setf (get :null :port-type) 'null-port)
-(setf (get :null :server-path-parser) 'parse-null-server-path)
+(defmethod find-port-type ((type (eql :null)))
+  (values 'null-port 'identity))
 
 (defmethod initialize-instance :after ((port null-port) &rest initargs)
   (declare (ignore initargs))

--- a/Backends/PDF/sheet.lisp
+++ b/Backends/PDF/sheet.lisp
@@ -190,8 +190,5 @@
 
 ;;; Port
 
-(setf (get :pdf :port-type) 'pdf-port)
-(setf (get :pdf :server-path-parser) 'parse-pdf-server-path)
-
-(defun parse-pdf-server-path (path)
-  path)
+(defmethod find-port-type ((type (eql :pdf)))
+  (values 'pdf-port 'identity))

--- a/Backends/PostScript/package.lisp
+++ b/Backends/PostScript/package.lisp
@@ -19,7 +19,7 @@
 ;;; Boston, MA  02111-1307  USA.
 
 (cl:defpackage #:clim-postscript
-  (:use #:clim #:clim-extensions #:clim-lisp #:clim-postscript-font)
+  (:use #:clim #:clime #:climb #:clim-lisp #:clim-postscript-font)
   (:import-from #:clim-internals
                 #:get-environment-variable
                 #:map-repeated-sequence

--- a/Backends/PostScript/sheet.lisp
+++ b/Backends/PostScript/sheet.lisp
@@ -257,8 +257,5 @@
 
 ;;; Port
 
-(setf (get :ps :port-type) 'postscript-port)
-(setf (get :ps :server-path-parser) 'parse-postscript-server-path)
-
-(defun parse-postscript-server-path (path)
-  path)
+(defmethod find-port-type ((type (eql :ps)))
+  (values 'postscript-port 'identity))

--- a/Backends/RasterImage/port.lisp
+++ b/Backends/RasterImage/port.lisp
@@ -32,11 +32,6 @@
 (defmethod destroy-port :before ((port raster-image-port))
   (%destroy-all-mirrors port))
 
-;;; server path
-
-(defun parse-raster-image-server-path (path)
-  path)
-
 ;;; Port-Graft methods
 
 (defmethod make-graft ((port raster-image-port) &key (orientation :default) (units :device))

--- a/Backends/RasterImage/rgb-port.lisp
+++ b/Backends/RasterImage/rgb-port.lisp
@@ -7,8 +7,8 @@
 (defclass rgb-image-port (raster-image-port)
   ())
 
-(setf (get :rgb-image :port-type) 'rgb-image-port)
-(setf (get :rgb-image :server-path-parser) 'parse-raster-image-server-path)
+(defmethod find-port-type ((type (eql :rgb-image)))
+  (values 'rgb-image-port 'identity))
 
 (defmethod realize-mirror ((port rgb-image-port) sheet)
   (setf (sheet-parent sheet) (graft port))

--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -8,8 +8,8 @@
 (defclass clx-freetype-port (clim-clx:clx-render-port) ())
 (defclass clx-freetype-medium (clim-clx:clx-render-medium) ())
 
-(setf (get :clx-ff :port-type) 'clx-freetype-port)
-(setf (get :clx-ff :server-path-parser) 'clim-clx::parse-clx-server-path)
+(defmethod climb:find-port-type ((port (eql :clx-ff)))
+  (values 'clx-freetype-port (nth-value 1 (climb:find-port-type :clx))))
 
 (defmethod clim:make-medium ((port clx-freetype-port) sheet)
   (make-instance 'clx-freetype-medium :sheet sheet))

--- a/Extensions/fonts/xrender-fonts.lisp
+++ b/Extensions/fonts/xrender-fonts.lisp
@@ -57,8 +57,8 @@
 
 (defclass clx-ttf-port (clim-clx:clx-render-port) ())
 
-(setf (get :clx-ttf :port-type) 'clx-ttf-port)
-(setf (get :clx-ttf :server-path-parser) 'clim-clx::parse-clx-server-path)
+(defmethod climb:find-port-type ((port (eql :clx-ttf)))
+  (values 'clx-ttf-port (nth-value 1 (climb:find-port-type :clx))))
 
 (defclass clx-truetype-font (cached-truetype-font)
   ((display           :initarg :display :reader clx-truetype-font-display)

--- a/package.lisp
+++ b/package.lisp
@@ -2004,6 +2004,7 @@
   (:use :clim :clim-extensions)
   (:export
    ;; CLIM-INTERNALS
+   #:find-port-type
    #:make-graft
    #:medium-draw-circle*
    #:mirror-transformation


### PR DESCRIPTION
Introduced change is backward-compatible (fallback method regresses back to symbol plist).