### PR TITLE
invoke-with-output-to-raster-image: don't destroy the port on exit

### DIFF
--- a/Backends/RasterImage/rgb-port.lisp
+++ b/Backends/RasterImage/rgb-port.lisp
@@ -10,11 +10,14 @@
 (defmethod find-port-type ((type (eql :rgb-image)))
   (values 'rgb-image-port 'identity))
 
-(defmethod realize-mirror ((port rgb-image-port) sheet)
-  (setf (sheet-parent sheet) (graft port))
+(defmethod realize-mirror ((port rgb-image-port) (sheet mirrored-sheet-mixin))
   (let ((mirror (make-instance 'image-mirror-mixin)))
     (port-register-mirror port sheet mirror)
-    (%make-image mirror sheet)))
+    (%make-image mirror sheet)
+    mirror))
+
+(defmethod destroy-mirror ((port rgb-image-port) (sheet mirrored-sheet-mixin))
+  (port-unregister-mirror port sheet (sheet-direct-mirror sheet)))
 
 ;;;
 ;;; Pixmap


### PR DESCRIPTION
Previously the body of the function was wrapped in the macro with-port - that
caused destroyal of all mirrors upon exit. When the function invocation was
nested (i.e to compute some sub-image), the inner function destroyed also
parent's mirror and that lead to error upon exit.

The function had another problem rgb-port did not adopt the top-level sheet by
the graft but rather manually hard-wire it in the method realize-mirror. That
is fixed, so now when the sheet is degrafted, destroy-mirror is called (and
the function port-unregister-mirror is called). Thanks to that we may simply
call find-port to bind the port and before exitting disown the top-level-sheet
- port is not destroyed and there is no resource leakage. Fixes #1095.