### PR TITLE
Fix bordered output styles :UNDERLINE and :CROSSOUT

### DIFF
--- a/Core/clim-core/bordered-output.lisp
+++ b/Core/clim-core/bordered-output.lisp
@@ -448,37 +448,37 @@
                                        line-dashes)
   (let ((line-style (%%line-style-for-method)))
     (labels ((fn (record)
-               (loop for child across (output-record-children record) do
-                     (typecase child
-                       (text-displayed-output-record
-                        (with-bounding-rectangle* (left top right bottom) child
-                          (declare (ignore top))
-                          (draw-line* stream left bottom right bottom
-                                      :ink ink
-                                      :line-style line-style)))
-                       (updating-output-record nil)
-                       (compound-output-record (fn child))))))
+               (loop for child across (output-record-children record)
+                     do (typecase child
+                          ((or text-displayed-output-record draw-text-output-record)
+                           (with-bounding-rectangle* (left top right bottom) child
+                             (declare (ignore top))
+                             (draw-line* stream left bottom right bottom
+                                         :ink ink
+                                         :line-style line-style)))
+                          (updating-output-record nil)
+                          (compound-output-record (fn child))))))
       (fn record))))
 
 (define-border-type :crossout (stream record
-                                       (ink (medium-ink stream))
-                                       line-style
-                                       line-unit
-                                       line-thickness
-                                       line-cap-shape
-                                       line-dashes)
+                                      (ink (medium-ink stream))
+                                      line-style
+                                      line-unit
+                                      line-thickness
+                                      line-cap-shape
+                                      line-dashes)
   (let ((line-style (%%line-style-for-method)))
     (labels ((fn (record)
-               (loop for child across (output-record-children record) do
-                     (typecase child
-                       (text-displayed-output-record
-                        (with-bounding-rectangle* (left top right bottom) child
-                          (let ((middle (/ (+ bottom top) 2)))
-                            (draw-line* stream left middle right middle
-                                        :ink ink
-                                        :line-style line-style))))
-                       (updating-output-record nil)
-                       (compound-output-record (fn child))))))
+               (loop for child across (output-record-children record)
+                     do (typecase child
+                          ((or text-displayed-output-record draw-text-output-record)
+                           (with-bounding-rectangle* (left top right bottom) child
+                             (let ((middle (/ (+ bottom top) 2)))
+                               (draw-line* stream left middle right middle
+                                           :ink ink
+                                           :line-style line-style))))
+                          (updating-output-record nil)
+                          (compound-output-record (fn child))))))
       (fn record))))
 
 (define-border-type :inset (stream left top right bottom


### PR DESCRIPTION
Before this change, the styles `:underline` and `:crossout` searched the output record to which the style is applied for child output records of type `text-displayed-output-record`.
However, in some cases relevant children are of type `draw-text-output-record`.

To reproduce the problem:
1. Start demodemo
2. Start Drawing Tests
3. Enable the "side-by-side view with the renderer output" option
4. Select the Text » Underlining or Text » Crossing out test
5. Note that the text decorations do not appear in the output of the render backend