### PR TITLE
graft: extend the core interface

### DIFF
--- a/Core/clim-basic/decls.lisp
+++ b/Core/clim-basic/decls.lisp
@@ -376,8 +376,9 @@ different icons for different purposes based on the icon sizes."))
 (defgeneric graft-units (graft))
 (defgeneric graft-width (graft &key units))
 (defgeneric graft-height (graft &key units))
-(declfun graft-pixels-per-millimeter (graft))
-(declfun graft-pixels-per-inch (graft))
+(defgeneric graft-pixel-aspect-ratio (graft))
+(declfun graft-pixels-per-millimeter (graft &key orientation))
+(declfun graft-pixels-per-inch (graft &key orientation))
 
 ;;; Not in the spec, clearly needed.
 (defgeneric make-graft (port &key orientation units))

--- a/Core/clim-basic/windowing/grafts.lisp
+++ b/Core/clim-basic/windowing/grafts.lisp
@@ -60,13 +60,25 @@
   `(let ((graft ,graft))
      ,@body))
 
-(defun graft-pixels-per-millimeter (graft)
-  ;; We assume square pixels here --GB
-  (/ (graft-width graft :units :device)
-     (graft-width graft :units :millimeters)))
+(defmethod graft-pixel-aspect-ratio ((graft graft))
+  (values (graft-pixels-per-inch graft :orientation :horizontal)
+          (graft-pixels-per-inch graft :orientation :vertical)))
 
-(defun graft-pixels-per-inch (graft)
-  ;; We assume square pixels here --GB
-  (/ (graft-width graft :units :device)
-     (graft-width graft :units :inches)))
+(defun graft-pixels-per-millimeter (graft &key (orientation :horizontal))
+  (ecase orientation
+    (:horizontal
+     (/ (graft-width graft :units :device)
+        (graft-width graft :units :millimeters)))
+    (:vertical
+     (/ (graft-height graft :units :device)
+        (graft-height graft :units :millimeters)))))
+
+(defun graft-pixels-per-inch (graft &key (orientation :horizontal))
+  (ecase orientation
+    (:horizontal
+     (/ (graft-width graft :units :device)
+        (graft-width graft :units :inches)))
+    (:vertical
+     (/ (graft-height graft :units :device)
+        (graft-height graft :units :inches)))))
 

--- a/package.lisp
+++ b/package.lisp
@@ -2031,6 +2031,7 @@
    #:with-port
    #:invoke-with-port
    #:find-concrete-pane-class
+   #:graft-pixel-aspect-ratio
    ;; Text-style
    #:text-style-character-width
    #:text-bounding-rectangle*


### PR DESCRIPTION
- introduce a function graft-pixel-aspect-ratio

- extend functions graft-pixels-per-millimeter and graft-pixels-per-millimeter
  by allowing a key argument orientation

This change is backward compatible opens a path for working with backends
which have non-rectangular pixels.