### PR TITLE
[wip] improve mirror protocols

### DIFF
--- a/Backends/CLX/mirror.lisp
+++ b/Backends/CLX/mirror.lisp
@@ -83,7 +83,8 @@
 (defmethod destroy-mirror ((port clx-basic-port) (sheet mirrored-sheet-mixin))
   (when-let ((mirror (sheet-mirror sheet)))
     (xlib:destroy-window mirror)
-    (port-unregister-mirror port sheet mirror)))
+    (port-unregister-mirror port sheet mirror)
+    (xlib:display-force-output (clx-port-display port))))
 
 (defmethod raise-mirror ((port clx-basic-port) (sheet basic-sheet))
   (let ((mirror (sheet-mirror sheet)))
@@ -104,7 +105,9 @@
                                    (xlib:drawable-y mirror)))
 
 (defmethod port-enable-sheet ((port clx-basic-port) (mirror mirrored-sheet-mixin))
-  (xlib:map-window (sheet-direct-mirror mirror)) )
+  (xlib:map-window (sheet-direct-mirror mirror))
+  (xlib:display-force-output (clx-port-display port)))
 
 (defmethod port-disable-sheet ((port clx-basic-port) (mirror mirrored-sheet-mixin))
-  (xlib:unmap-window (sheet-direct-mirror mirror)) )
+  (xlib:unmap-window (sheet-direct-mirror mirror))
+  (xlib:display-force-output (clx-port-display port)))

--- a/Backends/CLX/mirror.lisp
+++ b/Backends/CLX/mirror.lisp
@@ -111,3 +111,11 @@
 (defmethod port-disable-sheet ((port clx-basic-port) (mirror mirrored-sheet-mixin))
   (xlib:unmap-window (sheet-direct-mirror mirror))
   (xlib:display-force-output (clx-port-display port)))
+
+(defmethod port-shrink-sheet ((port clx-basic-port) (mirror mirrored-sheet-mixin))
+  (xlib:iconify-window (sheet-direct-mirror mirror) (clx-port-screen port))
+  (xlib:display-force-output (clx-port-display port)))
+
+(defmethod port-puffup-sheet ((port clx-basic-port) (mirror mirrored-sheet-mixin))
+  (xlib:map-window (sheet-direct-mirror mirror))
+  (xlib:display-force-output (clx-port-display port)))

--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -191,7 +191,7 @@
     (%set-window-name window pretty-name)
     (%set-window-icon-name window pretty-name)
     (when icon
-      (port-set-mirror-icon port window icon))
+      (%mirror-install-icons window icon))
     (setf (xlib:wm-hints window) (xlib:make-wm-hints :input :on))
     (setf (xlib:wm-protocols window) `(:wm_take_focus :wm_delete_window))
     (xlib:change-property window

--- a/Backends/Null/port.lisp
+++ b/Backends/Null/port.lisp
@@ -66,6 +66,12 @@
 (defmethod port-disable-sheet ((port null-port) (mirror mirrored-sheet-mixin))
   nil)
 
+(defmethod port-shrink-sheet ((port null-port) (mirror mirrored-sheet-mixin))
+  nil)
+
+(defmethod port-puffup-sheet ((port null-port) (mirror mirrored-sheet-mixin))
+  nil)
+
 (defmethod destroy-port :before ((port null-port))
   nil)
 

--- a/Backends/Null/port.lisp
+++ b/Backends/Null/port.lisp
@@ -44,11 +44,11 @@
   (print-unreadable-object (object stream :identity t :type t)
     (format stream "~S ~S" :id (slot-value object 'id))))
 
-(defmethod port-set-mirror-region ((port null-port) mirror mirror-region)
+(defmethod port-set-mirror-region ((port null-port) sheet region)
   ())
                                    
 (defmethod port-set-mirror-transformation
-    ((port null-port) mirror mirror-transformation)
+    ((port null-port) sheet transformation)
   ())
 
 (defmethod realize-mirror ((port null-port) (sheet mirrored-sheet-mixin))

--- a/Backends/RasterImage/port.lisp
+++ b/Backends/RasterImage/port.lisp
@@ -62,12 +62,13 @@
   (declare (ignore port sheet))
   nil)
 
-(defmethod port-set-mirror-region ((port raster-image-port) mirror region)
-  (declare (ignore port mirror region))
+(defmethod port-set-mirror-region ((port raster-image-port) sheet region)
+  (declare (ignore port sheet region))
   nil)
 
-(defmethod port-set-mirror-transformation ((port raster-image-port) mirror transformation)
-  (declare (ignore port mirror transformation))
+(defmethod port-set-mirror-transformation
+    ((port raster-image-port) sheet transformation)
+  (declare (ignore port sheet transformation))
   nil)
 
 (defgeneric make-raster-top-level-sheet (port format))

--- a/Core/clim-basic/decls.lisp
+++ b/Core/clim-basic/decls.lisp
@@ -1314,6 +1314,8 @@ rendered on MEDIUM with the style LINE-STYLE."))
 (defgeneric port-deallocate-pixmap (port pixmap))
 (defgeneric port-enable-sheet (port sheet))
 (defgeneric port-disable-sheet (port sheet))
+(defgeneric port-shrink-sheet (port sheet))
+(defgeneric port-puffup-sheet (port sheet))
 (defgeneric port-pointer (port))
 
 (defgeneric pointer-update-state (pointer event)

--- a/Core/clim-basic/decls.lisp
+++ b/Core/clim-basic/decls.lisp
@@ -376,8 +376,9 @@ different icons for different purposes based on the icon sizes."))
 (defgeneric graft-units (graft))
 (defgeneric graft-width (graft &key units))
 (defgeneric graft-height (graft &key units))
-(declfun graft-pixels-per-millimeter (graft))
-(declfun graft-pixels-per-inch (graft))
+(defgeneric graft-pixel-aspect-ratio (graft))
+(declfun graft-pixels-per-millimeter (graft &key orientation))
+(declfun graft-pixels-per-inch (graft &key orientation))
 
 ;;; Not in the spec, clearly needed.
 (defgeneric make-graft (port &key orientation units))

--- a/Core/clim-basic/windowing/grafts.lisp
+++ b/Core/clim-basic/windowing/grafts.lisp
@@ -60,13 +60,28 @@
   `(let ((graft ,graft))
      ,@body))
 
-(defun graft-pixels-per-millimeter (graft)
-  ;; We assume square pixels here --GB
-  (/ (graft-width graft :units :device)
-     (graft-width graft :units :millimeters)))
+(defmethod graft-pixel-aspect-ratio ((graft graft))
+  (let ((x/inch (graft-pixels-per-inch graft :orientation :horizontal))
+        (y/inch (graft-pixels-per-inch graft :orientation :vertical)))
+    (if (= x/inch y/inch)
+        (values 1 1)
+        (values x/inch y/inch))))
 
-(defun graft-pixels-per-inch (graft)
-  ;; We assume square pixels here --GB
-  (/ (graft-width graft :units :device)
-     (graft-width graft :units :inches)))
+(defun graft-pixels-per-millimeter (graft &key (orientation :horizontal))
+  (ecase orientation
+    (:horizontal
+     (/ (graft-width graft :units :device)
+        (graft-width graft :units :millimeters)))
+    (:vertical
+     (/ (graft-height graft :units :device)
+        (graft-height graft :units :millimeters)))))
+
+(defun graft-pixels-per-inch (graft &key (orientation :horizontal))
+  (ecase orientation
+    (:horizontal
+     (/ (graft-width graft :units :device)
+        (graft-width graft :units :inches)))
+    (:vertical
+     (/ (graft-height graft :units :device)
+        (graft-height graft :units :inches)))))
 

--- a/Core/clim-basic/windowing/mirrors.lisp
+++ b/Core/clim-basic/windowing/mirrors.lisp
@@ -117,14 +117,12 @@ infinite recursion on (setf sheet-*).")
   (when (and (sheet-direct-mirror sheet)
              (not (eql *configuration-event-p* sheet)))
     (let ((port (port sheet)))
+      ;; TOP-LEVEL-SHEET-MIXIN is a sheet representing the window, however we
+      ;; can't always set its exact location and region (because the window
+      ;; manager may add decorations or ignore our request altogether - like a
+      ;; tiling window manager). -- jd 2020-11-30
       (port-set-mirror-region port sheet MR)
-      ;; TOP-LEVEL-SHEET-PANE is our window (and it is managed by the window
-      ;; manager - decorations and such. We can't pinpoint exact translation. On
-      ;; the other hand UNMANAGED-TOP-LEVEL-SHEET-PANE is essential for menus
-      ;; and has exact position set (thanks to not being managed by WM).
-      (unless (and (typep sheet 'top-level-sheet-mixin)
-                   (null (typep sheet 'unmanaged-sheet-mixin)))
-        (port-set-mirror-transformation port sheet MT)))
+      (port-set-mirror-transformation port sheet MT))
     (when invalidate-transformations
       (with-slots (native-transformation device-transformation) sheet
         (setf native-transformation nil

--- a/Core/clim-basic/windowing/mirrors.lisp
+++ b/Core/clim-basic/windowing/mirrors.lisp
@@ -116,16 +116,15 @@ infinite recursion on (setf sheet-*).")
   (setf (%sheet-mirror-transformation sheet) MT)
   (when (and (sheet-direct-mirror sheet)
              (not (eql *configuration-event-p* sheet)))
-    (let ((port (port sheet))
-          (mirror (sheet-direct-mirror sheet)))
-      (port-set-mirror-region port mirror MR)
+    (let ((port (port sheet)))
+      (port-set-mirror-region port sheet MR)
       ;; TOP-LEVEL-SHEET-PANE is our window (and it is managed by the window
       ;; manager - decorations and such. We can't pinpoint exact translation. On
       ;; the other hand UNMANAGED-TOP-LEVEL-SHEET-PANE is essential for menus
       ;; and has exact position set (thanks to not being managed by WM).
       (unless (and (typep sheet 'top-level-sheet-mixin)
                    (null (typep sheet 'unmanaged-sheet-mixin)))
-        (port-set-mirror-transformation port mirror MT)))
+        (port-set-mirror-transformation port sheet MT)))
     (when invalidate-transformations
       (with-slots (native-transformation device-transformation) sheet
         (setf native-transformation nil
@@ -277,10 +276,9 @@ very hard)."
                  (setf (%sheet-mirror-transformation sheet) MT)
                  (when (and (sheet-direct-mirror sheet)
                             (not (eql *configuration-event-p* sheet)))
-                   (let ((port (port sheet))
-                         (mirror (sheet-direct-mirror sheet)))
-                     (port-set-mirror-region port mirror MR)
-                     (port-set-mirror-transformation port mirror MT)))
+                   (let ((port (port sheet)))
+                     (port-set-mirror-region port sheet MR)
+                     (port-set-mirror-transformation port sheet MT)))
                  ;; update the native transformation if necessary.
                  (unless (and old-native-transformation
                               (transformation-equal native-transformation

--- a/Core/clim-basic/windowing/sheets.lisp
+++ b/Core/clim-basic/windowing/sheets.lisp
@@ -702,16 +702,10 @@ might be different from the sheet's native region."
         (port-disable-sheet (port sheet) sheet))))
 
 (defmethod (setf sheet-pretty-name) :after (new-name (sheet mirrored-sheet-mixin))
-  ;; SHEET might not yet have a mirror if this is called e.g. during
-  ;; the pane generation phase of an application frame.
-  (when-let ((mirror (sheet-direct-mirror sheet)))
-    (climb:port-set-mirror-name (port sheet) mirror new-name)))
+  (port-set-mirror-name (port sheet) sheet new-name))
 
 (defmethod (setf sheet-icon) :after (new-value (sheet mirrored-sheet-mixin))
-  ;; SHEET might not yet have a mirror if this is called e.g. during
-  ;; the pane generation phase of an application frame.
-  (when-let ((mirror (sheet-direct-mirror sheet)))
-    (climb:port-set-mirror-icon (port sheet) mirror new-value)))
+  (port-set-mirror-icon (port sheet) sheet new-value))
 
 (defmethod invalidate-cached-transformations ((sheet mirrored-sheet-mixin))
   (with-slots (native-transformation device-transformation) sheet

--- a/Core/clim-basic/windowing/sheets.lisp
+++ b/Core/clim-basic/windowing/sheets.lisp
@@ -73,6 +73,8 @@
 (defgeneric note-sheet-disowned (sheet))
 (defgeneric note-sheet-enabled (sheet))
 (defgeneric note-sheet-disabled (sheet))
+(defgeneric note-sheet-iconified (sheet))
+(defgeneric note-sheet-deiconified (sheet))
 (defgeneric note-sheet-region-changed (sheet))
 (defgeneric note-sheet-transformation-changed (sheet))
 
@@ -111,7 +113,11 @@
    (enabled-p :type boolean
 	      :initarg :enabled-p
               :initform t
-              :accessor sheet-enabled-p)))
+              :accessor sheet-enabled-p)
+   (shrank-p :type boolean
+             :initarg :shrank-p
+             :initform nil
+             :accessor sheet-shrank-p)))
 
 ;;; Native region is volatile, and is only computed at the first
 ;;; request when it's equal to nil.
@@ -218,6 +224,13 @@
     (dispatch-repaint (sheet-parent sheet)
                       (transform-region (sheet-transformation sheet)
                                         (sheet-region sheet)))))
+
+(defmethod (setf sheet-shrank-p) :around (shrank-p (sheet basic-sheet))
+  (unless (eql shrank-p (sheet-shrank-p sheet))
+    (call-next-method)
+    (if shrank-p
+        (note-sheet-iconified sheet)
+        (note-sheet-deiconified sheet))))
 
 (defmethod sheet-transformation ((sheet basic-sheet))
   (error "Attempting to get the TRANSFORMATION of a SHEET that doesn't contain one"))
@@ -366,6 +379,14 @@
 
 (defmethod note-sheet-disabled ((sheet basic-sheet))
   (declare (ignorable sheet))
+  nil)
+
+(defmethod note-sheet-iconified ((sheet basic-sheet))
+  (declare (ignore sheet))
+  nil)
+
+(defmethod note-sheet-deiconified ((sheet basic-sheet))
+  (declare (ignore sheet))
   nil)
 
 (defmethod note-sheet-region-changed ((sheet basic-sheet))
@@ -700,6 +721,15 @@ might be different from the sheet's native region."
     (if new-value
         (port-enable-sheet (port sheet) sheet)
         (port-disable-sheet (port sheet) sheet))))
+
+(defmethod (setf sheet-shrank-p) :after
+    (new-value (sheet mirrored-sheet-mixin))
+  (format *debug-io* "after~%")
+  (when (sheet-direct-mirror sheet)
+    ;; We do this only if the sheet actually has a mirror.
+    (if new-value
+        (port-shrink-sheet (port sheet) sheet)
+        (port-puffup-sheet (port sheet) sheet))))
 
 (defmethod (setf sheet-pretty-name) :after (new-name (sheet mirrored-sheet-mixin))
   (port-set-mirror-name (port sheet) sheet new-name))

--- a/Core/clim-core/frames/frames.lisp
+++ b/Core/clim-core/frames/frames.lisp
@@ -65,6 +65,14 @@
   (declare (ignore frame))
   t)
 
+(defmethod note-frame-iconified ((fm frame-manager) frame)
+  (declare (ignore frame))
+  t)
+
+(defmethod note-frame-deiconified ((fm frame-manager) frame)
+  (declare (ignore frame))
+  t)
+
 ;;; XXX These should force the redisplay of the menu bar. They don't yet.
 
 (defmethod note-command-enabled (frame-manager frame command-name)
@@ -775,14 +783,29 @@ documentation produced by presentations.")
   frame)
 
 (defmethod enable-frame ((frame application-frame))
-  (setf (sheet-enabled-p (frame-top-level-sheet frame)) t)
-  (setf (slot-value frame 'state) :enabled)
-  (note-frame-enabled (frame-manager frame) frame))
+  (ecase (slot-value frame 'state)
+    (:disabled
+     (setf (sheet-enabled-p (frame-top-level-sheet frame)) t)
+     (note-frame-enabled (frame-manager frame) frame))
+    (:shrunk
+     (setf (sheet-shrank-p (frame-top-level-sheet frame)) nil)
+     (note-frame-deiconified (frame-manager frame) frame))
+    (:enabled))
+  (setf (slot-value frame 'state) :enabled))
 
 (defmethod disable-frame ((frame application-frame))
-  (setf (sheet-enabled-p (frame-top-level-sheet frame)) nil)
+  (let ((top-level-sheet (frame-top-level-sheet frame)))
+    (setf (sheet-shrank-p top-level-sheet) nil)
+    (setf (sheet-enabled-p top-level-sheet) nil))
   (setf (slot-value frame 'state) :disabled)
   (note-frame-disabled (frame-manager frame) frame))
+
+(defmethod shrink-frame ((frame application-frame))
+  (unless (eq (slot-value frame 'state) :disabled)
+    (setf (sheet-shrank-p (frame-top-level-sheet frame)) t)
+    (setf (slot-value frame 'state) :shrunk)
+    (note-frame-iconified (frame-manager frame) frame))
+  (frame-state frame))
 
 (defmethod destroy-frame ((frame application-frame))
   (when (eq (frame-state frame) :enabled)
@@ -939,6 +962,10 @@ frames and will not have focus.
   (setf (sheet-enabled-p (frame-top-level-sheet frame)) nil)
   (setf (slot-value frame 'state) :disabled)
   (note-frame-disabled (frame-manager frame) frame))
+
+(defmethod shrink-frame ((frame menu-frame))
+  (declare (ignore frame))
+  (warn "MENU-FRAME can't be shrunk."))
 
 (defun make-menu-frame (pane &key (left 0) (top 0) (min-width 1))
   (make-instance 'menu-frame :panes pane :left left :top top :min-width min-width))

--- a/Core/clim-core/frames/frames.lisp
+++ b/Core/clim-core/frames/frames.lisp
@@ -772,7 +772,6 @@ documentation produced by presentations.")
   (sheet-disown-child (graft frame) (frame-top-level-sheet frame))
   (setf (%frame-manager frame) nil)
   (setf (slot-value frame 'state) :disowned)
-  (port-force-output (port fm))
   frame)
 
 (defmethod enable-frame ((frame application-frame))
@@ -781,10 +780,7 @@ documentation produced by presentations.")
   (note-frame-enabled (frame-manager frame) frame))
 
 (defmethod disable-frame ((frame application-frame))
-  (let ((t-l-s (frame-top-level-sheet frame)))
-    (setf (sheet-enabled-p t-l-s) nil)
-    (when (port t-l-s)
-      (port-force-output (port t-l-s))))
+  (setf (sheet-enabled-p (frame-top-level-sheet frame)) nil)
   (setf (slot-value frame 'state) :disabled)
   (note-frame-disabled (frame-manager frame) frame))
 
@@ -940,13 +936,9 @@ frames and will not have focus.
   (note-frame-enabled (frame-manager frame) frame))
 
 (defmethod disable-frame ((frame menu-frame))
-  (let ((t-l-s (frame-top-level-sheet frame)))
-    (setf (sheet-enabled-p t-l-s) nil)
-    (when (port t-l-s)
-      (port-force-output (port t-l-s))))
+  (setf (sheet-enabled-p (frame-top-level-sheet frame)) nil)
   (setf (slot-value frame 'state) :disabled)
   (note-frame-disabled (frame-manager frame) frame))
-
 
 (defun make-menu-frame (pane &key (left 0) (top 0) (min-width 1))
   (make-instance 'menu-frame :panes pane :left left :top top :min-width min-width))

--- a/Extensions/render/backend/port.lisp
+++ b/Extensions/render/backend/port.lisp
@@ -17,11 +17,14 @@
 
 ;;; change geometry
 
-(defmethod port-set-mirror-region :after ((port render-port-mixin) mirror region)
-  (%set-image-region (mirror->%image port mirror) region))
+(defmethod port-set-mirror-region :after
+    ((port render-port-mixin) (sheet mirrored-sheet-mixin) region)
+  (when-let ((mirror (sheet-direct-mirror sheet)))
+    (%set-image-region (mirror->%image port mirror) region)))
 
-(defmethod port-set-mirror-transformation :after ((port render-port-mixin) mirror transformation)
-  (declare (ignore port mirror transformation))
+(defmethod port-set-mirror-transformation :after
+    ((port render-port-mixin) (sheet mirrored-sheet-mixin) transformation)
+  (declare (ignore port sheet transformation))
   nil)
 
 ;;; realize/destroy mirrors

--- a/package.lisp
+++ b/package.lisp
@@ -2016,6 +2016,8 @@
    #:port-deallocate-pixmap
    #:port-disable-sheet
    #:port-enable-sheet
+   #:port-shrink-sheet
+   #:port-puffup-sheet
    #:port-force-output
    #:port-grab-pointer
    #:port-ungrab-pointer

--- a/package.lisp
+++ b/package.lisp
@@ -2031,6 +2031,7 @@
    #:with-port
    #:invoke-with-port
    #:find-concrete-pane-class
+   #:graft-pixel-aspect-ratio
    ;; Text-style
    #:text-style-character-width
    #:text-bounding-rectangle*


### PR DESCRIPTION
- unify calling convention of protocols that involve mirrors (i.e specialize on a sheet)
- extend the graft to account for screens with non-rectangular pixels
- allow "moving" the top-level-sheet-mixin's mirror
- implement shrink-frame