### PR TITLE
wip: Fix the pop up menu not popping down bug

### DIFF
--- a/Core/clim-core/gadgets/concrete.lisp
+++ b/Core/clim-core/gadgets/concrete.lisp
@@ -1583,10 +1583,11 @@ if INVOKE-CALLBACK is given."))
                       ((in-menu (event-sheet event) x y)
                        (handle-event (event-sheet event) event)))))))
         ;; Cleanup and exit
-        (when retain-value
-          (setf (gadget-value parent :invoke-callback t)
-                (gadget-value list-pane)))
-        (disown-frame manager menu-frame)))))
+        (unwind-protect
+             (when retain-value
+               (setf (gadget-value parent :invoke-callback t)
+                     (gadget-value list-pane)))
+          (disown-frame manager menu-frame))))))
 
 (defmethod handle-event ((pane generic-option-pane) (event pointer-button-press-event))
   (popup-list-box pane)


### PR DESCRIPTION
In core/clim-core/gadgets/concrete.lisp:

Put an unwind-protect around (disown-frame manager menu-frame) at the end to guarantee that the pop-up menu is removed.  The previous form can lead to a throw that bypasses this, leaving the menu dangling.   Here's an example:
```
(defun test-avv (&optional (stream *standard-output*))
  (let ((x 1) (a 0)
        (y 2) (b 0)
        (z 'a))
    (accepting-values (stream :resynchronize-every-pass t)
      (format stream "~%Adaptive Dialog~%")
      (format t "~%X = ~a Y = ~a A = ~a B = ~a~% Z = ~a" x y a b z)
      (terpri stream)
      (setq z (clim:accept `(clim:member a b c d e)
                             :stream stream
                             :view #-mcclim clim:+textual-view+ #+mcclim clim:+option-pane-view+
                             :prompt "Which"
                             :default z))
      (terpri stream)
      (if (> x y)
          (format stream "~%X is larger than Y")
          (format stream "~%X is not larger than Y"))
      (terpri stream)
      (setq x (clim:accept '(integer 0 20) :stream stream :prompt "X?"
                                           :view '(slider-view :orientation :horizontal :decimal-places 2) :Default x ))
      (when (> x y)
        (terpri stream)
        (setq a (clim:accept 'number :default a :prompt "A?" :stream stream)))
      (terpri stream)
      (setq y (clim:accept 'number :default y :prompt "Y?" :stream stream))
      (when (>= y x)
        (terpri stream)
        (setq b (clim:accept 'number :default b :prompt "B?" :stream stream))))
    (values x y a b z)))
```