### PR TITLE
franz: fix DRAGGING-DRAWING

### DIFF
--- a/Extensions/Franz/franz.lisp
+++ b/Extensions/Franz/franz.lisp
@@ -25,7 +25,7 @@ symbol)."
         (tracking-pointer (stream :pointer pointer
                                   :multiple-window multiple-window)
           (:pointer-motion (x y)
-            (when ox (funcall drawer x y :erase))
+            (when ox (funcall drawer ox oy :erase))
             (funcall drawer x y :draw)
             (setf ox x oy y))
           (:pointer-button-press (x y)


### PR DESCRIPTION
Commit 5bc9b44b simplified DRAGGING-DRAWING but introduced a bug: the
the drawing is not visible during the dragging and it is visible
at the end. The required behaviuor is the opposite, the drawing must
be visible during the dragging and must be erased at the end.

This commit fix this. To test try in the listener the following
functions that use DRAGGING-DRAWING:

CLIME:POINTER-PLACE-RUBBER-BAND-LINE*
CLIME:POINTER-INPUT-RECTANGLE*