### PR TITLE
tracking-pointer: intercept keyboard event

### DIFF
--- a/Core/clim-basic/extended-streams/pointer-tracking.lisp
+++ b/Core/clim-basic/extended-streams/pointer-tracking.lisp
@@ -191,6 +191,7 @@
               ;; the other hand, we pass events for TRACKED-SHEET (or
               ;; all events if MULTIPLE-WINDOW is true) to TRACK-EVENT.
               do (cond ((not (or multiple-window
+                                 (and (typep event 'keyboard-event) (keyboard-handler state))
                                  (eql tracked-sheet (event-sheet event))))
                         ;; Event is not intercepted.
                         (handle-event (event-sheet event) event))


### PR DESCRIPTION
If a :keyboard clause is present in the tracking-pointer body than
also the keyboard events needs to be tracked.

Fix: #1118