### PR TITLE
Call FINISH-OUTPUT after a Drei buffer have been updated

### DIFF
--- a/Libraries/Drei/drei-redisplay.lisp
+++ b/Libraries/Drei/drei-redisplay.lisp
@@ -1148,7 +1148,8 @@ calculated by `drei-bounding-rectangle*'."
                                  (region-contains-position-p viewport-region x1 y1))))
               (scroll-extent stream
                              (max 0 (- x2 viewport-width))
-                             (max 0 (- y2 viewport-height))))))))))
+                             (max 0 (- y2 viewport-height))))))))
+    (finish-output stream)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;


### PR DESCRIPTION
The GTK backend only redraws the window content when FINISH-OUTPUT
is called, so this fix adds this call to Drei.