### PR TITLE
Better Cairo and Pango Cleanup

### DIFF
--- a/Backends/GTK/mcclim-gtk.asd
+++ b/Backends/GTK/mcclim-gtk.asd
@@ -1,5 +1,5 @@
 (defsystem #:mcclim-gtk
-  :depends-on ("clim" "log4cl" "cl-cffi-gtk")
+  :depends-on ("clim" "log4cl" "cl-cffi-gtk" "trivial-garbage")
   :components ((:file "package")
                (:file "pango-updates" :depends-on ("package"))
                (:file "basic" :depends-on ("pango-updates"))

--- a/Backends/GTK/medium.lisp
+++ b/Backends/GTK/medium.lisp
@@ -28,8 +28,7 @@
          (let ((,image (bordeaux-threads:with-lock-held ((gtk-mirror/lock ,mirror-sym))
                          (update-mirror-if-needed ,medium ,mirror-sym)
                          (let ((,image (gtk-mirror/image ,mirror-sym)))
-                           (cairo:cairo-surface-reference ,image)
-                           ,image))))
+                           (cairo:cairo-surface-reference ,image)))))
            (unwind-protect
                 (let ((,image-sym ,image))
                   ,@body)
@@ -211,12 +210,10 @@
   (let ((image (alexandria:if-let ((mirror (sheet-direct-mirror (sheet-mirrored-ancestor (medium-sheet medium)))))
                  (bordeaux-threads:with-lock-held ((gtk-mirror/lock mirror))
                    (let ((image (gtk-mirror/image mirror)))
-                     (cairo:cairo-surface-reference image)
-                     image))
+                     (cairo:cairo-surface-reference image)))
                  ;; ELSE: No mirror, use the dedicated image
                  (let ((image (gtk-port/image-fallback (port medium))))
-                   (cairo:cairo-surface-reference image)
-                   image))))
+                   (cairo:cairo-surface-reference image)))))
     (unwind-protect
          (let ((context (cairo:cairo-create image)))
            (unwind-protect

--- a/Backends/GTK/medium.lisp
+++ b/Backends/GTK/medium.lisp
@@ -141,6 +141,7 @@
         (cairo:cairo-set-source-surface cr image 0 0)
 	(cairo:cairo-surface-destroy image)))
     (let ((image (cairo:cairo-image-surface-create :argb32 width height)))
+      (cairo:cairo-surface-flush image)
       (loop
         with image-data = (cairo:cairo-image-surface-get-data image)
         with stride-in-words = (let ((v (/ (cairo:cairo-image-surface-get-stride image) 4)))

--- a/Backends/GTK/medium.lisp
+++ b/Backends/GTK/medium.lisp
@@ -157,7 +157,8 @@
           (call-with-computed-transformation transform
                                              (lambda (matrix)
                                                (cairo:cairo-pattern-set-matrix cairo-pattern matrix))))
-        (cairo:cairo-set-source cr cairo-pattern)))))
+        (cairo:cairo-set-source cr cairo-pattern))
+      (cairo:cairo-surface-destroy image))))
 
 (defun update-attrs (cr medium)
   (set-clipping-region cr medium)
@@ -331,6 +332,7 @@
 
 (defun measure-text-bounds-from-font (cr string font)
   (let ((layout (pango:pango-cairo-create-layout cr)))
+    ;; LAYOUT has no g-object-unref...
     (set-current-font layout font)
     (pango:pango-layout-set-text layout string)
     (multiple-value-bind (ink-rect logical-rect)

--- a/Backends/GTK/medium.lisp
+++ b/Backends/GTK/medium.lisp
@@ -198,11 +198,12 @@
                               (lambda (,context-sym) ,@body))))
 
 (defun call-with-fallback-cairo-context (port fn)
-  (let* ((image (gtk-port/image-fallback port))
+  (let* ((image (cairo:cairo-surface-reference (gtk-port/image-fallback port)))
          (context (cairo:cairo-create image)))
     (unwind-protect
          (funcall fn context)
-      (cairo:cairo-destroy context))))
+      (cairo:cairo-destroy context)
+      (cairo:cairo-surface-destroy image))))
 
 (defmacro with-fallback-cairo-context ((context-sym port) &body body)
   (alexandria:once-only (port)

--- a/Backends/GTK/medium.lisp
+++ b/Backends/GTK/medium.lisp
@@ -138,7 +138,8 @@
                                                      :displaced-to data)
                                          `(:array :uint32 ,(* height width)))
       (let ((image (cairo:cairo-image-surface-create-for-data native-buf :argb32 width height (* width 4))))
-        (cairo:cairo-set-source-surface cr image 0 0)))
+        (cairo:cairo-set-source-surface cr image 0 0)
+	(cairo:cairo-surface-destroy image)))
     (let ((image (cairo:cairo-image-surface-create :argb32 width height)))
       (loop
         with image-data = (cairo:cairo-image-surface-get-data image)
@@ -156,7 +157,8 @@
           (call-with-computed-transformation transform
                                              (lambda (matrix)
                                                (cairo:cairo-pattern-set-matrix cairo-pattern matrix))))
-        (cairo:cairo-set-source cr cairo-pattern))
+        (cairo:cairo-set-source cr cairo-pattern)
+	(cairo:cairo-pattern-destroy cairo-pattern))
       (cairo:cairo-surface-destroy image))))
 
 (defun update-attrs (cr medium)

--- a/Backends/GTK/medium.lisp
+++ b/Backends/GTK/medium.lisp
@@ -275,7 +275,10 @@
       (when size
         (let ((size-num (coerce (* (climb:normalize-font-size size) pango:+pango-scale+) 'double-float)))
           (pango:pango-font-description-set-absolute-size desc size-num)))
-      (make-instance 'gtk-medium-font :port port :font-description desc))))
+      (let ((instance (make-instance 'gtk-medium-font :port port :font-description desc)))
+	(trivial-garbage:finalize instance (lambda ()
+					     (pango:pango-font-description-free desc)))
+	instance))))
 
 (defmethod (setf text-style-mapping) (font-name
                                       (port gtk-port)

--- a/Backends/GTK/medium.lisp
+++ b/Backends/GTK/medium.lisp
@@ -339,7 +339,8 @@
     (multiple-value-bind (ink-rect logical-rect)
         (pango:pango-layout-get-pixel-extents layout)
       (let ((baseline (/ (pango:pango-layout-get-baseline layout) pango:+pango-scale+)))
-        (values ink-rect logical-rect baseline)))))
+	(gobject:g-object-unref (gobject:pointer layout))
+	(values ink-rect logical-rect baseline)))))
 
 (defun measure-text-bounds (medium string text-style)
   (with-cairo-context-measure (cr medium)

--- a/Backends/GTK/pango-updates.lisp
+++ b/Backends/GTK/pango-updates.lisp
@@ -51,7 +51,7 @@
 (export 'pango-font-description-new)
 
 (defcfun ("pango_font_description_free" pango-font-description-free) :void
-  (desc :pointer))
+  (desc (g-boxed-foreign pango-font-description)))
 
 (export 'pango-font-description-free)
 

--- a/Backends/GTK/port.lisp
+++ b/Backends/GTK/port.lisp
@@ -113,6 +113,7 @@
          (cr (cairo:cairo-create image)))
     (apply-colour-from-ink cr ink)
     (cairo:cairo-paint cr)
+    (cairo:cairo-destroy cr)
     image))
 
 (defmethod realize-mirror ((port gtk-port) (sheet mirrored-sheet-mixin))

--- a/Backends/GTK/port.lisp
+++ b/Backends/GTK/port.lisp
@@ -67,7 +67,10 @@
   (declare (ignore initargs))
   (push (make-instance 'gtk-frame-manager :port port)
 	(slot-value port 'climi::frame-managers))
-  (setf (slot-value port 'image-fallback) (cairo:cairo-image-surface-create :argb32 10 10))
+  (let ((image-fallback (cairo:cairo-image-surface-create :argb32 10 10)))
+    (setf (slot-value port 'image-fallback) image-fallback)
+    (trivial-garbage:finalize port (lambda ()
+				     (cairo:cairo-surface-destroy image-fallback))))
   (bordeaux-threads:make-thread #'gtk-main-no-traps :name "GTK Event Thread")
   (start-port-event-thread port))
 

--- a/Backends/GTK/port.lisp
+++ b/Backends/GTK/port.lisp
@@ -99,8 +99,7 @@
 (defun draw-window-content (cr mirror)
   (let ((image (bordeaux-threads:with-lock-held ((gtk-mirror/lock mirror))
                  (let ((v (gtk-mirror/image mirror)))
-                   (cairo:cairo-surface-reference v)
-                   v))))
+                   (cairo:cairo-surface-reference v)))))
     (cairo:cairo-set-source-surface cr image 0 0)
     (cairo:cairo-rectangle cr 0 0
                            (cairo:cairo-image-surface-get-width image)


### PR DESCRIPTION
With logging now all the long-living Cairo and Pango objects return to a constant reference count.