### PR TITLE
Add support for :dock frame types

### DIFF
--- a/Backends/CLX/frame-manager.lisp
+++ b/Backends/CLX/frame-manager.lisp
@@ -128,7 +128,11 @@
         (:dialog (xlib:change-property mirror
                                        :_NET_WM_WINDOW_TYPE
                                        (list (xlib:intern-atom (xlib:window-display mirror) :_NET_WM_WINDOW_TYPE_DIALOG))
-                                       :atom 32)))
+                                       :atom 32))
+        (:dock (xlib:change-property mirror
+                                     :_NET_WM_WINDOW_TYPE
+                                     (list (xlib:intern-atom (xlib:window-display mirror) :_NET_WM_WINDOW_TYPE_DOCK))
+                                     :atom 32)))
       (multiple-value-bind (w h x y) (climi::frame-geometry* frame)
         (declare (ignore w h))
         (when (and x y)


### PR DESCRIPTION
I have been wanting to write a dock application with McCLIM and found that this wasnt supported out of the box. After some digging ive found that the `:after` method for `adopt-frame` supports `:override-redirect` and `:dialog` but not `:dock`. This PR adds `:dock` to the case statement in the method and sets the appropriate property on the frames mirror. 

I am still fairly new to McCLIM, and as such I'm unsure if this is the correct way of going about this, or if one should change the window type property elsewhere. If i'm going about this the complete wrong way please let me know. 