### PR TITLE
Don't execute a disabled command

### DIFF
--- a/Core/clim-core/commands/processor.lisp
+++ b/Core/clim-core/commands/processor.lisp
@@ -346,7 +346,9 @@
 
 (define-presentation-method presentation-typep (object (type command))
   (and (consp object)
-       (command-accessible-in-command-table-p (car object) command-table)))
+       (command-accessible-in-command-table-p (car object) command-table)
+       (or (null *application-frame*)
+           (command-enabled (car object) *application-frame*))))
 
 (define-presentation-method presentation-subtypep
     ((type command) maybe-supertype)

--- a/Core/clim-core/commands/tables.lisp
+++ b/Core/clim-core/commands/tables.lisp
@@ -502,12 +502,14 @@ menu item to see if it is `:menu'."
                          (otherwise nil))))
     ;; Return a literal command, or create a partial command from a
     ;; command-name.
-    (return-from lookup-keystroke-command-item
-      (substitute-numeric-argument-marker
-       (if (symbolp command)
-           (partial-command-from-name command command-table)
-           command)
-       numeric-arg)))
+    (when (or (null *application-frame*)
+              (command-enabled (command-name command) *application-frame*))
+      (return-from lookup-keystroke-command-item
+        (substitute-numeric-argument-marker
+         (if (symbolp command)
+             (partial-command-from-name command command-table)
+             command)
+         numeric-arg))))
   gesture)
 
 (defun map-over-command-table-translators


### PR DESCRIPTION
The spec (26.6.1) say that COMMAND presentation type represent
commands  accessible in COMMAND-TABLE presentation parameter and enabled
in *APPLICATION-FRAME*. The last requirement was not checked before this commit.

The spec (27.4) say that in LOOKUP-KEYSTROKE-COMMAND-ITEM
"only keystrokes that map to an enabled application command will be
matched."

In this way  disabled commands aren't executed.

Fix #1144 issue