### PR TITLE
command-tables: fix the inherited menu items

### DIFF
--- a/Core/clim-core/commands/tables.lisp
+++ b/Core/clim-core/commands/tables.lisp
@@ -215,7 +215,7 @@ designator) inherits keystrokes."
   "Return true if `command-table' (which must be a command table
 designator) inherits menu items."
   (let ((inherit-menu (inherit-menu (find-command-table command-table))))
-    (or (inherit-keystrokes command-table)
+    (or (eq inherit-menu t)
         (eq inherit-menu :menu))))
 
 (defun %add-menu-item (command-table item after)

--- a/Core/clim-core/gadgets/menu.lisp
+++ b/Core/clim-core/gadgets/menu.lisp
@@ -21,12 +21,10 @@
 (defun make-menu-buttons (table client)
   (setf table (find-command-table table))
   (collect (items)
-    (map-over-command-table-menu
-     (lambda (item table)
-       (declare (ignore table))
-       (with-slots (menu-name keystroke type) item
-         (when (or menu-name (eq type :divider))
-           (items (make-menu-button-from-menu-item item client)))))
+    (map-over-command-table-menu-items
+     (lambda (name keystroke item)
+       (declare (ignore name keystroke))
+       (items (make-menu-button-from-menu-item item client)))
      table
      :inherited (inherit-menu table))
     (items +fill+)))


### PR DESCRIPTION
Without this fix a command table inherit the menu-item of the ancestors
also when `:inherit-menu` is `:keystrokes`