### PR TITLE
fixes the text-editor

### DIFF
--- a/Core/clim/text-editor-gadget.lisp
+++ b/Core/clim/text-editor-gadget.lisp
@@ -230,7 +230,6 @@ cause the activate callback to be called."))
                                :disarmed-callback disarmed-callback
                                :activation-gestures activation-gestures
                                :activate-callback activate-callback
-                               ;:scroll-bars scroll-bars
                                :ncolumns ncolumns
                                :nlines nlines
                                :value-changed-callback

--- a/Core/clim/text-editor-gadget.lisp
+++ b/Core/clim/text-editor-gadget.lisp
@@ -230,7 +230,7 @@ cause the activate callback to be called."))
                                :disarmed-callback disarmed-callback
                                :activation-gestures activation-gestures
                                :activate-callback activate-callback
-                               :scroll-bars scroll-bars
+                               ;:scroll-bars scroll-bars
                                :ncolumns ncolumns
                                :nlines nlines
                                :value-changed-callback


### PR DESCRIPTION
Obviously someone already removed :scroll-bars from the drei editor.
Every application that wanted to start a :text-editor pane failed
with the error about an unknown option keyword :scroll-bars.

Removing that fixes the error.