### PR TITLE
Pointer

### DIFF
--- a/Backends/CLX/basic.lisp
+++ b/Backends/CLX/basic.lisp
@@ -33,8 +33,7 @@
 	   :accessor clx-port-window)
    (font-families :initform nil :accessor font-families)
    (cursor-table :initform (make-hash-table :test #'eq)
-                 :accessor clx-port-cursor-table)
-   (pointer :reader port-pointer)))
+                 :accessor clx-port-cursor-table)))
 
 (defclass clx-basic-pointer (standard-pointer)
   ((cursor :accessor pointer-cursor :initform :upper-left)))

--- a/Backends/CLX/input.lisp
+++ b/Backends/CLX/input.lisp
@@ -149,7 +149,7 @@
              ;; release event. We ignore the latter. -- jd 2019-09-01
              (when (eq event-key :button-press)
                (make-instance 'climi::pointer-scroll-event
-                              :pointer 0
+                              :pointer (port-pointer *clx-port*)
                               :button button :x x :y y
                               :graft-x root-x
                               :graft-y root-y
@@ -167,7 +167,7 @@
              (make-instance (if (eq event-key :button-press)
                                 'pointer-button-press-event
                                 'pointer-button-release-event)
-                            :pointer 0
+                            :pointer (port-pointer *clx-port*)
                             :button button :x x :y y
                             :graft-x root-x
                             :graft-y root-y
@@ -199,7 +199,7 @@
                                            (:grab 'pointer-grab-enter-event)
                                            (:ungrab 'pointer-ungrab-enter-event)
                                            (t 'pointer-enter-event))))
-                        :pointer 0 :button code
+                        :pointer (port-pointer *clx-port*) :button code
                         :x x :y y
                         :graft-x root-x
                         :graft-y root-y
@@ -244,7 +244,7 @@
        (let ((modifier-state (clim-xcommon:x-event-state-modifiers *clx-port*
                                                                    state)))
          (make-instance 'pointer-motion-event
-                        :pointer 0 :button code
+                        :pointer (port-pointer *clx-port*) :button code
                         :x x :y y
                         :graft-x root-x
                         :graft-y root-y
@@ -389,8 +389,8 @@
 
 (defmethod synthesize-pointer-motion-event ((pointer clx-basic-pointer))
   (when-let* ((port (port pointer))
-              ;; XXX Should we rely on port-pointer-sheet being correct? -- moore
-              (sheet (port-pointer-sheet port))
+              ;; XXX Should we rely on pointer-sheet being correct? -- moore
+              (sheet (pointer-sheet pointer))
               (ancestor (sheet-mirrored-ancestor sheet))
               (mirror (sheet-direct-mirror ancestor)))
     (multiple-value-bind (x y same-screen-p child mask root-x root-y)
@@ -402,7 +402,7 @@
                 (values x y)
                 (untransform-position (sheet-native-transformation sheet) x y))
           (make-instance 'pointer-motion-event
-                         :pointer 0 :button (button-from-state mask)
+                         :pointer pointer :button (button-from-state mask)
                          :x x :y y :graft-x root-x :graft-y root-y
                          :sheet sheet
                          :modifier-state (clim-xcommon:x-event-state-modifiers

--- a/Backends/CLX/package.lisp
+++ b/Backends/CLX/package.lisp
@@ -25,7 +25,6 @@
                 ;;
                 #:clamp
                 #:get-environment-variable
-                #:port-pointer-sheet
                 #:map-repeated-sequence
                 #:do-sequence
                 #:with-transformed-position

--- a/Backends/Null/port.lisp
+++ b/Backends/Null/port.lisp
@@ -27,8 +27,8 @@
 
 (defclass null-port (basic-port)
   ((id)
-   (pointer :accessor port-pointer :initform (make-instance 'null-pointer))
-   (window :initform nil :accessor null-port-window)))
+   (window :initform nil :accessor null-port-window))
+  (:default-initargs :pointer (make-instance 'null-pointer)))
 
 (defmethod find-port-type ((type (eql :null)))
   (values 'null-port 'identity))

--- a/Core/clim-basic/decls.lisp
+++ b/Core/clim-basic/decls.lisp
@@ -1362,6 +1362,9 @@ rendered on MEDIUM with the style LINE-STYLE."))
 (defgeneric port-shrink-sheet (port sheet))
 (defgeneric port-pointer (port))
 
+;;; Defined in Franz user guide sec. 15.1
+(defgeneric port-modifier-state (port))
+
 (defgeneric pointer-update-state (pointer event)
   (:documentation "Called by port event dispatching code to update the modifier
 and button states of the pointer."))

--- a/Core/clim-basic/extended-streams/stream-input.lisp
+++ b/Core/clim-basic/extended-streams/stream-input.lisp
@@ -640,7 +640,6 @@ known gestures."
   ((port :reader port :initarg :port)
    (state-lock :reader state-lock :initform (make-lock "pointer lock"))
    (button-state :initform 0 )
-   (modifier-state :initform 0)
    (sheet :initform nil :initarg :sheet :accessor pointer-sheet)))
 
 (defgeneric pointer-sheet (pointer))
@@ -648,8 +647,6 @@ known gestures."
 (defgeneric (setf pointer-sheet) (sheet pointer))
 
 (defgeneric pointer-button-state (pointer))
-
-(defgeneric pointer-modifier-state (pointer))
 
 (defgeneric pointer-position (pointer))
 
@@ -665,15 +662,6 @@ known gestures."
 (defmethod pointer-button-state ((pointer standard-pointer))
   (with-lock-held ((state-lock pointer))
     (slot-value pointer 'button-state)))
-
-(defmethod pointer-modifier-state ((pointer standard-pointer))
-  (with-lock-held ((state-lock pointer))
-    (slot-value pointer 'modifier-state)))
-
-(defmethod pointer-update-state
-    ((pointer standard-pointer) (event keyboard-event))
-  (with-lock-held ((state-lock pointer))
-    (setf (slot-value pointer 'modifier-state) (event-modifier-state event))))
 
 (defmethod pointer-update-state
     ((pointer standard-pointer) (event pointer-button-press-event))

--- a/Core/clim-basic/extended-streams/stream-input.lisp
+++ b/Core/clim-basic/extended-streams/stream-input.lisp
@@ -640,12 +640,10 @@ known gestures."
   ((port :reader port :initarg :port)
    (state-lock :reader state-lock :initform (make-lock "pointer lock"))
    (button-state :initform 0 )
-   (modifier-state :initform 0)))
+   (modifier-state :initform 0)
+   (sheet :initform nil :initarg :sheet :accessor pointer-sheet)))
 
 (defgeneric pointer-sheet (pointer))
-
-(defmethod pointer-sheet ((pointer pointer))
-  (port-pointer-sheet (port pointer)))
 
 (defgeneric (setf pointer-sheet) (sheet pointer))
 

--- a/Core/clim-basic/windowing/ports.lisp
+++ b/Core/clim-basic/windowing/ports.lisp
@@ -110,8 +110,8 @@
    (focused-sheet :initform nil :accessor port-focused-sheet
                   :reader port-keyboard-input-focus
                   :documentation "The sheet for the keyboard events, if any")
-   (pointer-sheet :initform nil :accessor port-pointer-sheet
-		  :documentation "The sheet the pointer is over, if any")
+   (pointer :initform nil :initarg :pointer :accessor port-pointer
+		  :documentation "The pointer of the port")
    ;; The difference between grabbed-sheet and pressed-sheet is that
    ;; the former takes all pointer events while pressed-sheet receives
    ;; replicated pointer motion events. -- jd 2019-08-21
@@ -275,14 +275,15 @@ is a McCLIM extension.")
 ;;; as part of this process.
 (defun synthesize-boundary-events (port event)
   (let* ((event-sheet (event-sheet event))
-         (old-pointer-sheet (port-pointer-sheet port))
+         (pointer (pointer-event-pointer event))
+         (old-pointer-sheet (pointer-sheet pointer))
          (new-pointer-sheet old-pointer-sheet)
          (dispatch-event-p nil))
     ;; First phase: compute new pointer sheet for PORT.
     (flet ((update-pointer-sheet (new-sheet)
              (when new-sheet
                (unless (eql old-pointer-sheet new-sheet)
-                 (setf (port-pointer-sheet port) new-sheet
+                 (setf (pointer-sheet pointer) new-sheet
                        new-pointer-sheet new-sheet)))))
       (typecase event
         ;; Ignore grab-enter and ungrab-leave boundary events.

--- a/Core/clim-core/presentations/drag-and-drop.lisp
+++ b/Core/clim-core/presentations/drag-and-drop.lisp
@@ -115,8 +115,7 @@
                              (collect-translator trans)))
                          from-presentation (list context-type) frame
                          window x y
-                         :modifier-state (and (null event)
-                                              (window-modifier-state window))
+                         :modifier-state (and (null event) 0)
                          :event event)
                         (collect-translator)))
          ;; Default feedback and highlight functions are those of the

--- a/Core/clim-core/presentations/translators.lisp
+++ b/Core/clim-core/presentations/translators.lisp
@@ -457,17 +457,11 @@ and used to ensure that presentation-translators-caches are up to date.")
         (loop for context in input-context
               do (mopscp context presentation)))))
 
-(defun window-modifier-state (window)
-  "Provides default modifier state for presentation translator functions."
-  ;; There are many things which may go wrong (NULL window, sheet
-  ;; without a port etc). We clamp errors to 0 meaning "no modifiers".
-  (or (ignore-errors (pointer-modifier-state (port-pointer (port window)))) 0))
-
 (defun find-applicable-translators
     (presentation input-context frame window x y
      &key event modifier-state for-menu fastp)
   (when (and (not modifier-state) (not event))
-    (setf modifier-state (window-modifier-state window)))
+    (setf modifier-state 0))
   (let ((results nil))
     (flet ((fast-func (translator presentation context)
              (declare (ignore translator presentation context))
@@ -647,7 +641,7 @@ and used to ensure that presentation-translators-caches are up to date.")
     (input-context window x y
      &key (frame *application-frame*) modifier-state event)
   (when (and (not modifier-state) (not event))
-    (setf modifier-state (window-modifier-state window)))
+    (setf modifier-state 0))
   (values (find-innermost-presentation-match input-context
                                              (stream-output-history window)
                                              frame
@@ -662,7 +656,7 @@ and used to ensure that presentation-translators-caches are up to date.")
      &key (top-record (stream-output-history window))
        (frame *application-frame*) event modifier-state button)
   (when (and (not modifier-state) (not event))
-    (setf modifier-state (window-modifier-state window)))
+    (setf modifier-state 0))
   (find-innermost-presentation-match input-context
                                      top-record
                                      frame

--- a/Documentation/Manual/Texinfo/developer-manual.texi
+++ b/Documentation/Manual/Texinfo/developer-manual.texi
@@ -217,7 +217,6 @@ POINTER (port.lisp or pointer.lisp)
 -----------------------------------
 ;;; Originally in CLIM
 pointer-button-state
-pointer-modifier-state
 pointer-position
 @end verbatim
 

--- a/package.lisp
+++ b/package.lisp
@@ -2097,7 +2097,6 @@
    #:medium-text-style
    #:note-space-requirements-changed
    #:pointer-button-state
-   #:pointer-modifier-state
    #:pointer-position
    #:realize-mirror
    #:text-size


### PR DESCRIPTION
This PR didn't introduce new features and didn't fix any bugs. With this PR McCLIM follows better the specification:

1) The pointer events have the slot pointer bound to a pointer object and not to 0 as before
2) The pointer sheet is stored in a slot of the pointer and not of the port
3) `pointer-modifier-state` is removed because it  isn't in the specification and it is not used 