### PR TITLE
stream-write-string is supposed to return the string passed to:

### DIFF
--- a/Core/clim-basic/extended-streams/stream-output.lisp
+++ b/Core/clim-basic/extended-streams/stream-output.lisp
@@ -400,7 +400,9 @@ produces no more than one line of output i.e., doesn't wrap."))
           (seos-write-string stream string seg-start i)
           (seos-write-newline stream)
           (setq seg-start (1+ i))))
-      (seos-write-string stream string seg-start end))))
+      (seos-write-string stream string seg-start end)))
+  ;; Need to return the string
+  string)
 
 (defmethod stream-character-width ((stream standard-extended-output-stream) char
                                    &key (text-style nil))

--- a/Core/clim-basic/extended-streams/stream-output.lisp
+++ b/Core/clim-basic/extended-streams/stream-output.lisp
@@ -401,7 +401,6 @@ produces no more than one line of output i.e., doesn't wrap."))
           (seos-write-newline stream)
           (setq seg-start (1+ i))))
       (seos-write-string stream string seg-start end)))
-  ;; Need to return the string
   string)
 
 (defmethod stream-character-width ((stream standard-extended-output-stream) char


### PR DESCRIPTION
Current clasp fails with the address-book demo displaying the names of the addresses. The reason is obviously that `(write-string "Scott McKay")` returns nil, while present expects a string.

This happens since 
`(defmethod stream-write-string ((stream standard-extended-output-stream) string
                                &optional (start 0) end)...` returns nil

Looking at the documentation for stream-write-string it says:
```lisp
— Generic Function: sb-gray:stream-write-string stream string &optional start end
This is used by write-string. It writes the string to the stream, optionally delimited by start and end, which default to 0 and nil. The string argument is returned.
````