### PR TITLE
frames: graft method for application-frame

### DIFF
--- a/Core/clim-core/frames/frames.lisp
+++ b/Core/clim-core/frames/frames.lisp
@@ -217,6 +217,10 @@
     (port manager)
     nil))
 
+(defmethod graft ((frame application-frame))
+  (when-let ((tls (frame-top-level-sheet frame)))
+    (graft tls)))
+
 (defmethod (setf frame-manager)
     (new-manager (frame standard-application-frame))
   (let ((old-manager (frame-manager frame)))


### PR DESCRIPTION
The CLIM Specification says that GRAFT is defined for application
frames but before this commit the method wasn't defined.