### PR TITLE
Update ASDF dependencies and components

### DIFF
--- a/Apps/Listener/clim-listener.asd
+++ b/Apps/Listener/clim-listener.asd
@@ -15,7 +15,7 @@ experimentation. Present features include:
 - Navigation of the filesystem, including a directory stack
 - Launching of external programs sensitive to file type (determined by mailcap
   and mime.types files)"
-  :depends-on (#:mcclim #:clim-debugger #:uiop #:cl-fad #+sbcl #:sb-posix)
+  :depends-on (#:mcclim #:clim-debugger #:uiop #:cl-fad (:feature :sbcl #:sb-posix))
   :serial t
   :build-operation asdf:program-op
   :build-pathname "clim-listener"

--- a/Core/clim-core/clim-core.asd
+++ b/Core/clim-core/clim-core.asd
@@ -1,7 +1,7 @@
 (in-package #:asdf-user)
 
 (defsystem "clim-core"
-  :depends-on ("clim-basic" #+sbcl (:require "sb-introspect"))
+  :depends-on ("clim-basic" (:feature :sbcl "sb-introspect"))
   :components
   ((:file "defresource")
    (:file "theming")

--- a/Extensions/fontconfig/mcclim-fontconfig.asd
+++ b/Extensions/fontconfig/mcclim-fontconfig.asd
@@ -10,7 +10,7 @@
   :components ((:module src
                 :serial t
                 :components ((:file "package")
-                             (cffi-grovel:grovel-file "grovel")
+                             ("cffi-grovel:grovel-file" "grovel")
                              (:file "conditions")
                              (:file "functions")
                              (:file "fontconfig")))))

--- a/Extensions/harfbuzz/mcclim-harfbuzz.asd
+++ b/Extensions/harfbuzz/mcclim-harfbuzz.asd
@@ -11,6 +11,6 @@
   :components ((:module src
                 :serial t
                 :components ((:file "package")
-                             (cffi-grovel:grovel-file "grovel")
+                             ("cffi-grovel:grovel-file" "grovel")
                              (:file "functions")
                              (:file "harfbuzz")))))

--- a/Libraries/Drei/drei-mcclim.asd
+++ b/Libraries/Drei/drei-mcclim.asd
@@ -1,7 +1,7 @@
 (defsystem "drei-mcclim"
   :description "Drei Replaces EINE's Inheritor – McCLIM editor substrate"
   :depends-on ((:version "flexichain" "1.5.1")
-               "esa-mcclim" "clim-core" #-clim-without-swank "swank"
+               "esa-mcclim" "clim-core" (:feature (:not :clim-without-swank) "swank")
                "automaton" "persistent"
                "mcclim-fonts")
   :components

--- a/clim-lisp.asd
+++ b/clim-lisp.asd
@@ -8,8 +8,7 @@
   :components (;; First possible patches
                (:file "patch")
                (:module "Lisp-Dep"
-                        :components
-                        (#+(or excl clisp)
-                           (:file   #+excl      "fix-acl"
-                                    #+clisp     "fix-clisp")))
+                :components
+                ((:file "fix-acl" :if-feature :excl)
+                 (:file "fix-clisp" :if-feature :clisp)))
                (:file "package")))

--- a/mcclim.asd
+++ b/mcclim.asd
@@ -67,9 +67,9 @@ interface management system."
 ;;; A system that loads the appropriate backend for the current platform.
 (defsystem #:mcclim/looks
   :depends-on (#:clim
-               #:mcclim-clx                                #| truetype clx backend |#
-               #+mcclim-ffi-freetype #:mcclim-clx/freetype #| adds freetype        |#
-               #:mcclim-clx-fb                             #| experimental backend |#
+               #:mcclim-clx                                          #| truetype clx backend |#
+               (:feature :mcclim-ffi-freetype #:mcclim-clx/freetype) #| adds freetype        |#
+               #:mcclim-clx-fb                                       #| experimental backend |#
                ;; null backend
                #:mcclim-null))
 


### PR DESCRIPTION
Do not use reader macros to hide dependencies. Use ASDF's feature dependency
specification. This has been available since before ASDF 3.

Do not use the symbol cffi-grovel:grovel-file in component specifications. Use
the string "cffi-grovel:grovel-file" instead. This allows the reader to READ
the DEFSYSTEM before cffi-grovel has been loaded. ASDF will then load
cffi-grovel (it is in the :defsystem-depends-on list) and resolve the string to
the symbol. This has been available since ASDF 3.1.1.