### PR TITLE
accept: change a default to honor the default value

### DIFF
--- a/Core/clim-core/input-editing.lisp
+++ b/Core/clim-core/input-editing.lisp
@@ -1287,10 +1287,11 @@ protocol retrieving gestures from a provided string."))
           (apply #'stream-accept stream type :history nil :view +textual-view+ args))
       (values val ptype (+ (stream-scan-pointer stream) start)))))
 
-(defun accept-using-read (stream ptype &key ((:read-eval *read-eval*) nil))
+(defun accept-using-read (stream ptype &key ((:read-eval *read-eval*) nil)
+                                            default (default-type ptype))
   (let* ((token (read-token stream)))
     (if (string= "" token)
-        (values nil ptype)
+        (values default default-type)
         (let ((result (handler-case (read-from-string token)
                         (error (c)
                           (declare (ignore c))
@@ -1409,6 +1410,7 @@ protocol retrieving gestures from a provided string."))
 ;;; beep and warning that input must be clicked on.
 
 (define-default-presentation-method accept
-    (type stream (view textual-view) &key default default-type)
-  (declare (ignore default default-type))
-  (accept-using-read stream type :read-eval t))
+    (type stream view &key default (default-type type))
+  (accept-using-read stream type :read-eval t
+                                 :default default
+                                 :default-type default-type))

--- a/Core/clim-core/presentations/standard-presentations.lisp
+++ b/Core/clim-core/presentations/standard-presentations.lisp
@@ -99,10 +99,7 @@
 
 (define-presentation-method accept ((type symbol) stream (view textual-view)
                                     &key (default-type type) default)
-  (let ((read-result (accept-using-read stream type)))
-    (if (and (null read-result) default)
-        (values default default-type)
-        (values read-result type))))
+  (accept-using-read stream type :default default :default-type default-type))
 
 ;;; Standard presentation type `keyword'
 
@@ -337,7 +334,8 @@
 (define-presentation-method accept ((type real) stream (view textual-view)
                                     &key (default-type type) default)
   (let ((read-result (let ((*read-base* base))
-                       (accept-using-read stream type))))
+                       (accept-using-read stream type :default default
+                                                      :default-type default-type))))
     (if (and (null read-result) default)
         (values default default-type)
         (values read-result type))))


### PR DESCRIPTION
This commit changes the function accept-using-read to accept default and
default-type and return them when the token is an empty input. Fixes #839.