### PR TITLE
Use uppercase M for em conversion and allow real column values

### DIFF
--- a/Core/clim-basic/extended-streams/stream-output.lisp
+++ b/Core/clim-basic/extended-streams/stream-output.lisp
@@ -435,7 +435,7 @@ produces no more than one line of output i.e., doesn't wrap."))
                        (stream-cursor-initial-position stream))))
     (if (minusp line-width)
         nil
-        (floor line-width (stream-string-width stream "m")))))
+        (/ line-width (stream-character-width stream #\M)))))
 
 (defmethod stream-start-line-p ((stream standard-extended-output-stream))
   (multiple-value-bind (x y) (stream-cursor-position stream)


### PR DESCRIPTION
In modern typesetting an em is often just the absolute font size. This does not look good in pretty printing where using the traditional definition of the width of an uppercase "M" is better.

Also, the functions `pprint-indent` and `pprint-tab` allow Real-valued column values. The Gray stream protocol does not make any statement about the return value of `stream-line-column`. Returning a Real-valued column number will make proportional typesetting have better alignments.