### PR TITLE
frame-manager-menu-choose: presentation-type keyword

### DIFF
--- a/Core/clim-core/dialogs/menu-choose.lisp
+++ b/Core/clim-core/dialogs/menu-choose.lisp
@@ -231,8 +231,13 @@
                                (if default-item-p
                                    default-item
                                    (first items))
-                               :item-printer (or printer
-                                                 #'print-menu-item)
+                               :item-printer
+                               (cond
+                                 (presentation-type
+                                  (lambda (menu-item stream)
+                                    (present menu-item presentation-type :stream stream)))
+                                 (printer printer)
+                                 (t #'print-menu-item))
                                :max-width max-width
                                :max-height max-height
                                :n-rows n-rows


### PR DESCRIPTION
For the specification if presentation-type is supplied, the visual
representation is produced by present of the menu item with that
presentation type.

Fix #1252