### PR TITLE
Add :resynchronize-every-pass t to address book accepting-values

### DIFF
--- a/Examples/address-book.lisp
+++ b/Examples/address-book.lisp
@@ -164,7 +164,7 @@
       ;;  Address: a string
       ;;  Number: a string
       ;; is produced, where each "a string" is sensitive and can be edited.
-      (accepting-values (stream)
+      (accepting-values (stream :resynchronize-every-pass t)
         (setq name (apply #'accept 'string :stream stream :prompt
                           "Name" (and name (list :default name))))
         (terpri stream)


### PR DESCRIPTION
Context:running the Examples/address-book.lisp application.

Without this setting, with SBCL on Linux, Entering information for the
"Name" field and pressing ENTER takes you to the "Address" field, but
the "Name" field becomes blank.

With this setting the already entered values continue to be displayed.