### PR TITLE
core: read-command-using-keystrokes: sanitize the accelerator result

### DIFF
--- a/Core/clim-core/commands/processor.lisp
+++ b/Core/clim-core/commands/processor.lisp
@@ -286,7 +286,9 @@
                      ;; in ENSURE-COMPLETE-COMMAND we sanitize the returned
                      ;; value. -- jd 2022-02-18
                      (let* ((event (accelerator-gesture-event c))
-                            (command (lookup-keystroke-command-item event command-table)))
+                            (numeric-arg (accelerator-gesture-numeric-argument c))
+                            (command (lookup-keystroke-command-item
+                                      event command-table :numeric-arg numeric-arg)))
                        (when (typep command `(or symbol (cons symbol)))
                          (return-from read-command-using-keystrokes
                            (ensure-complete-command command command-table stream)))))))

--- a/Core/clim-core/commands/processor.lisp
+++ b/Core/clim-core/commands/processor.lisp
@@ -278,10 +278,19 @@
         (*partial-command-parser* partial-command-parser)
         (*accelerator-gestures* keystrokes))
     (let ((command
-            (handler-case (read-command command-table :stream stream)
-              (accelerator-gesture (c)
-                (lookup-keystroke-command-item (accelerator-gesture-event c)
-                                               command-table)))))
+            (handler-bind
+                ((accelerator-gesture
+                   (lambda (c)
+                     ;; LOOKUP-KEYSTROKE-COMMAND-ITEM is specified to return a
+                     ;; gesture if no command can be found. To avoid problems
+                     ;; in ENSURE-COMPLETE-COMMAND we sanitize the returned
+                     ;; value. -- jd 2022-02-18
+                     (let* ((event (accelerator-gesture-event c))
+                            (command (lookup-keystroke-command-item event command-table)))
+                       (when (typep command `(or symbol (cons symbol)))
+                         (return-from read-command-using-keystrokes
+                           (ensure-complete-command command command-table stream)))))))
+              (read-command command-table :stream stream))))
       (ensure-complete-command command command-table stream))))
 
 


### PR DESCRIPTION
LOOKUP-KEYSTROKE-COMMAND-ITEM may return the gesture if no command can be found
under the keystroke. We don't want to pass a gesture to ENSURE-COMPLETE-COMMAND
so just in case we check the result. This allows associating keystrokes with
arbitrary actions with add-keystroke-to-command-table :function.