### PR TITLE
window-viewport-position

### DIFF
--- a/Core/clim-core/panes/stream-panes.lisp
+++ b/Core/clim-core/panes/stream-panes.lisp
@@ -219,7 +219,9 @@
     (draw-rectangle* (sheet-medium pane) x1 y1 x2 y2 :ink +background-ink+)))
 
 (defmethod window-viewport-position ((pane clim-stream-pane))
-  (bounding-rectangle-position (stream-output-history pane)))
+  (if (pane-scroller pane)
+      (bounding-rectangle-position (window-viewport pane))
+      (values 0 0)))
 
 (defmethod* (setf window-viewport-position) (x y (pane clim-stream-pane))
   (scroll-extent pane x y)


### PR DESCRIPTION
The implementation was wrong. From the specification window-erase-viewport:

> Returns two values, the x and y position of the top-left corner of the CLIM
> stream pane window's viewport. If the window is not scrollable, this will return
> the two values 0 and 0.