### PR TITLE
command-accessible-in-command-table-p: specification conformance

### DIFF
--- a/Core/clim-core/commands/tables.lisp
+++ b/Core/clim-core/commands/tables.lisp
@@ -164,8 +164,10 @@
           (map-func command-table)))))
 
 (defun command-present-in-command-table-p (command-name command-table)
-  (let ((ht (slot-value (find-command-table command-table) 'commands)))
-    (nth-value 1 (gethash command-name ht))))
+  (let ((table (find-command-table command-table)))
+    (let ((ht (slot-value table 'commands)))
+      (when (nth-value 1 (gethash command-name ht))
+        table))))
 
 (defun command-accessible-in-command-table-p (command-name command-table)
   (or (command-present-in-command-table-p command-name command-table)


### PR DESCRIPTION
For the specification COMMAND-ACCESSIBLE-IN-COMMAND-TABLE-P must
return the command table in which the command was found or NIL if the
command was not found.

Before this commit it return T or NIL.

With this commit also COMMAND-PRESENT-IN-COMMAND-TABLE-P return the
command table or NIL. I think this adhere to the specification where
is written that COMMAND-PRESENT-IN-COMMAND-TABLE-P returns true if the
command is present in the command table but the specification doesn't
say that it must return T.