### PR TITLE
Define indirect-ink-ink as a generic function

### DIFF
--- a/Core/clim-basic/drawing/design.lisp
+++ b/Core/clim-basic/drawing/design.lisp
@@ -272,8 +272,9 @@
 (defun indirect-ink-p (design)
   (typep design 'indirect-ink))
 
-(defun indirect-ink-ink (design)
-  (check-type design indirect-ink)
+(defgeneric indirect-ink-ink (design))
+
+(defmethod indirect-ink-ink ((design indirect-ink))
   (with-slots (dynamic-variable-symbol default-ink) design
     (if (boundp dynamic-variable-symbol)
         (symbol-value dynamic-variable-symbol)

--- a/Core/clim-basic/drawing/design.lisp
+++ b/Core/clim-basic/drawing/design.lisp
@@ -84,7 +84,7 @@
 ;;;
 ;;;   INDIRECT-INK                                                    [class]
 ;;;   INDIRECT-INK-P ink                                              [predicate]
-;;;   INDIRECT-INK-INK ink                                            [function]
+;;;   INDIRECT-INK-INK ink                                            [generic function]
 ;;;
 ;;;      Indirect inks are underspecified in the standard. Class is exported for
 ;;;      specialization. Predicate INDIRECT-INK-P is defined. Initargs:


### PR DESCRIPTION
This will allow subclassing `indirect-ink` to provide different implementations of `indirect-ink-ink`, which would be desirable for the indirect-ink-based theme library I'm working on, with (hopefully) no impact on McCLIM.