### PR TITLE
frame-managers: use make-pane-1 instead of make-instance

### DIFF
--- a/Core/clim-core/frames/frame-managers.lisp
+++ b/Core/clim-core/frames/frame-managers.lisp
@@ -214,7 +214,7 @@
                  (setf pdoc pane
                        (frame-pointer-documentation-output frame) stream)))
              (if (or menu pdoc)
-                 (make-instance 'vrack-pane
+                 (make-pane-1 fm frame 'vrack-pane
                                 :contents (remove nil (list menu root pdoc))
                                 :port (port frame))
                  root))))


### PR DESCRIPTION
When there is menu or pointer-documentation-pane in a frame the top
level vrack layout pane was created using MAKE-INSTANCE instead of
MAKE-PANE-1, in this way it was created an instance of the abstract
class and not an instance of the concrete class choosed by the frame
manager.