### PR TITLE
format-items: fix default printer

### DIFF
--- a/Core/clim-core/presentations/typed-output.lisp
+++ b/Core/clim-core/presentations/typed-output.lisp
@@ -82,7 +82,7 @@
 
 (defun format-items (items &rest args
                      &key (stream *standard-output*)
-                       (printer #'prin1) presentation-type
+                       printer presentation-type
                        cell-align-x cell-align-y
                      &allow-other-keys)
   (let ((printer (if printer


### PR DESCRIPTION
In format-items the default for printer cannot be provided in the lambda list
otherwise when the actual printer function is constructed in the let
form the case when presentation-type is supplied and printer isn't
supplied is never selected.