### PR TITLE
define :complete gesture as #\tab not :TAB

### DIFF
--- a/Core/extended-input/standard-gestures.lisp
+++ b/Core/extended-input/standard-gestures.lisp
@@ -17,7 +17,7 @@
 
 (define-gesture-name :abort         :keyboard             (#\c :control))
 (define-gesture-name :clear-input   :keyboard             (#\u :control))
-(define-gesture-name :complete      :keyboard             (:tab))
+(define-gesture-name :complete      :keyboard             (#\tab))
 (define-gesture-name :help          :keyboard             (#\/ :control))
 (define-gesture-name :possibilities :keyboard             (#\? :control))
 


### PR DESCRIPTION
otherwise the TAB completion doesn't work.