### PR TITLE
map-over-frames: always return nil

### DIFF
--- a/Core/clim-core/frames/frame-managers.lisp
+++ b/Core/clim-core/frames/frame-managers.lisp
@@ -40,7 +40,7 @@
 
 (defun map-over-frames (function &key port frame-manager)
   (cond (frame-manager
-         (mapc function (frame-manager-frames frame-manager)))
+         (map nil function (frame-manager-frames frame-manager)))
         (port
          (loop for manager in (frame-managers port)
                do (map-over-frames function :frame-manager manager)))


### PR DESCRIPTION
MAP-OVER-FRAMES must always return NIL also when FRAME-MANAGER keyword argument is provided.

Otherwise, for example, FIND-APPLICATION-FRAME doesn't work with FRAME-MANAGER keyword argument provided.